### PR TITLE
Fixed issue #74 - support for custom menu bars

### DIFF
--- a/src/model/Monitor.swift
+++ b/src/model/Monitor.swift
@@ -4,6 +4,7 @@ private struct MonitorImpl {
     let name: String
     let rect: Rect
     let visibleRect: Rect
+    let safeAreaInsets: NSEdgeInsets
 }
 
 extension MonitorImpl: Monitor {
@@ -18,6 +19,7 @@ protocol Monitor: AeroAny {
     var visibleRect: Rect { get }
     var width: CGFloat { get }
     var height: CGFloat { get }
+    var safeAreaInsets: NSEdgeInsets { get }
 }
 
 class LazyMonitor: Monitor {
@@ -25,6 +27,7 @@ class LazyMonitor: Monitor {
     let name: String
     let width: CGFloat
     let height: CGFloat
+    let safeAreaInsets: NSEdgeInsets
     private var _rect: Rect? = nil
     private var _visibleRect: Rect? = nil
 
@@ -32,6 +35,7 @@ class LazyMonitor: Monitor {
         self.name = screen.localizedName
         self.width = screen.frame.width // Don't call rect because it would cause recursion during mainMonitor init
         self.height = screen.frame.height // Don't call rect because it would cause recursion during mainMonitor init
+        self.safeAreaInsets = screen.safeAreaInsets
         self.screen = screen
     }
 
@@ -45,7 +49,9 @@ class LazyMonitor: Monitor {
 }
 
 private extension NSScreen {
-    var monitor: Monitor { MonitorImpl(name: localizedName, rect: rect, visibleRect: visibleRect) }
+    var monitor: Monitor {
+        MonitorImpl(name: localizedName, rect: rect, visibleRect: visibleRect, safeAreaInsets: safeAreaInsets)
+    }
 
     var isMainScreen: Bool {
         frame.minX == 0 && frame.minY == 0
@@ -64,7 +70,12 @@ private extension NSScreen {
 }
 
 private let testMonitorRect = Rect(topLeftX: 0, topLeftY: 0, width: 1920, height: 1080)
-private let testMonitor = MonitorImpl(name: "Test Monitor", rect: testMonitorRect, visibleRect: testMonitorRect)
+private let testMonitor = MonitorImpl(
+    name: "Test Monitor",
+    rect: testMonitorRect,
+    visibleRect: testMonitorRect,
+    safeAreaInsets: .init()
+)
 
 /// It's inaccurate because NSScreen.main doesn't work correctly from NSWorkspace.didActivateApplicationNotification &
 /// kAXFocusedWindowChangedNotification callbacks.

--- a/src/model/MonitorEx.swift
+++ b/src/model/MonitorEx.swift
@@ -1,11 +1,18 @@
+import AppKit
+
 extension Monitor {
     var visibleRectPaddedByOuterGaps: Rect {
-        let topLeft = visibleRect.topLeftCorner
+        // When the system menu bar is visible, add gap to the visible area, otherwise add it to the top of the screen.
+        let visibleAreaTopOffset = visibleRect.topLeftY - rect.topLeftY
+        let adjustedTopOffset = (NSMenu.menuBarVisible() ? visibleAreaTopOffset : 0.0) + config.gaps.outer.top.toDouble()
+        let visibleAreaBottomOffset = rect.bottomLeftCorner.y - visibleRect.bottomLeftCorner.y
+        let height = rect.height - visibleAreaBottomOffset - adjustedTopOffset - config.gaps.outer.bottom.toDouble()
+
         return Rect(
-            topLeftX: topLeft.x + config.gaps.outer.left.toDouble(),
-            topLeftY: topLeft.y + config.gaps.outer.top.toDouble(),
+            topLeftX: visibleRect.topLeftX + config.gaps.outer.left.toDouble(),
+            topLeftY: rect.topLeftY + adjustedTopOffset,
             width: visibleRect.width - config.gaps.outer.left.toDouble() - config.gaps.outer.right.toDouble(),
-            height: visibleRect.height - config.gaps.outer.top.toDouble() - config.gaps.outer.bottom.toDouble()
+            height: height
         )
     }
 }


### PR DESCRIPTION
It resolves issue #74. 

The main assumptions of this solution:
- if the system menu bar is visible, we want to calculate the top gap from it.
- if the system menu bar is hidden, we want to calculate the top gap from the screen top.

Detailed description of possible cases:
1. System menu bar is used and is visible. In this case, we want to calculate padding from the menu bar, because the menu bar height could differ per screen (the status bar for screens with a notch is bigger). For this purpose, I'm using the top offset provided by `visibleRect` calculating it this way: `visibleRect.topLeftY - rect.topLeftY`.
2. Custom menu bar is used. In this case, we would like to calculate the padding always from the screen top (ignoring notch) to allow users to have a consistent top padding across all screens to avoid issues like #74 where custom menu bars have the same height on all screens.
3. System menu bar is used and is hidden. This is the only case that is not perfect because for screens with a notch and the config with `0` top gap windows will be placed slightly under the notch. After setting top gap to for example `40` now we will have the same padding on all screens, causing an unwanted gap on external screens if we adjusted it to our screen with notch.

I think the third case is quite rare and I don't see any way to solve it without having a padding option per screen, so for now I think this approach is still better than the current one. It allows us to use AeroSpace both with the system menu bar and custom menu bar having expected top gap.