### PR TITLE
Add flag to skip empty workspaces in workspace next/prev

### DIFF
--- a/LocalPackage/Sources/Common/cmdArgs/MoveNodeToWorkspaceCmdArgs.swift
+++ b/LocalPackage/Sources/Common/cmdArgs/MoveNodeToWorkspaceCmdArgs.swift
@@ -35,6 +35,6 @@ public struct MoveNodeToWorkspaceCmdArgs: CmdArgs, Equatable {
 
 public func parseMoveNodeToWorkspaceCmdArgs(_ args: [String]) -> ParsedCmd<MoveNodeToWorkspaceCmdArgs> {
     parseRawCmdArgs(RawMoveNodeToWorkspaceCmdArgs(), args)
-        .flatMap { raw in raw.target.val.parse(wrapAround: raw.wrapAroundNextPrev, autoBackAndForth: nil) }
+        .flatMap { raw in raw.target.val.parse(wrapAround: raw.wrapAroundNextPrev, autoBackAndForth: nil, nonEmpty: false) }
         .flatMap { target in .cmd(MoveNodeToWorkspaceCmdArgs(target)) }
 }

--- a/src/command/WorkspaceCommand.swift
+++ b/src/command/WorkspaceCommand.swift
@@ -45,6 +45,7 @@ func getNextPrevWorkspace(current: Workspace, relative: WTarget.Relative, stdin:
     let currentMonitor = current.monitor
     let workspaces: [Workspace] = stdinWorkspaces.isEmpty
         ? Workspace.all.filter { $0.monitor.rect.topLeftCorner == currentMonitor.rect.topLeftCorner }
+            .filter{ !relative.nonEmpty || $0.isEffectivelyEmpty == false}
             .toSet()
             .union([current])
             .sortedBy { $0.name }


### PR DESCRIPTION
This patch adds a flag to jump to a non-empty workspace when using workspace next or workspace prev.