### PR TITLE
Add "Open config" Menu Item

### DIFF
--- a/Sources/AppBundle/MenuBar.swift
+++ b/Sources/AppBundle/MenuBar.swift
@@ -36,24 +36,17 @@ public func menuBar(viewModel: TrayMenuModel) -> some Scene {
                let fileManager = FileManager.default
                let homeDirectory = NSHomeDirectory()
                let destinationPath = homeDirectory.appending("/.aerospace.toml")
-               
-               // Check if the config file already exists
                if !fileManager.fileExists(atPath: destinationPath) {
-                   // Construct the source path of the default config file within the app bundle
                    if let sourcePath = Bundle.main.path(forResource: "default-config", ofType: "toml") {
                        do {
-                           // Copy the default config file to the user's home directory
                            try fileManager.copyItem(atPath: sourcePath, toPath: destinationPath)
                            print("Default config copied to \(destinationPath).")
                        } catch {
                            print("Error copying default config: \(error.localizedDescription)")
-                           // Handle the error, possibly with an alert to the user
                        }
                    }
                }
-               
-               // Open the config file with the default application
-               NSWorkspace.shared.openFile(destinationPath)
+            NSWorkspace.shared.open(URL(filePath: destinationPath))
            }
            .keyboardShortcut("O", modifiers: .command)
         if viewModel.isEnabled {

--- a/Sources/AppBundle/MenuBar.swift
+++ b/Sources/AppBundle/MenuBar.swift
@@ -32,7 +32,7 @@ public func menuBar(viewModel: TrayMenuModel) -> some Scene {
             }
         }
             .keyboardShortcut("E", modifiers: .command)
-        Button("Open Config") {
+        Button("Open config") {
                let fileManager = FileManager.default
                let homeDirectory = NSHomeDirectory()
                let destinationPath = homeDirectory.appending("/.aerospace.toml")

--- a/Sources/AppBundle/MenuBar.swift
+++ b/Sources/AppBundle/MenuBar.swift
@@ -32,6 +32,30 @@ public func menuBar(viewModel: TrayMenuModel) -> some Scene {
             }
         }
             .keyboardShortcut("E", modifiers: .command)
+        Button("Open Config") {
+               let fileManager = FileManager.default
+               let homeDirectory = NSHomeDirectory()
+               let destinationPath = homeDirectory.appending("/.aerospace.toml")
+               
+               // Check if the config file already exists
+               if !fileManager.fileExists(atPath: destinationPath) {
+                   // Construct the source path of the default config file within the app bundle
+                   if let sourcePath = Bundle.main.path(forResource: "default-config", ofType: "toml") {
+                       do {
+                           // Copy the default config file to the user's home directory
+                           try fileManager.copyItem(atPath: sourcePath, toPath: destinationPath)
+                           print("Default config copied to \(destinationPath).")
+                       } catch {
+                           print("Error copying default config: \(error.localizedDescription)")
+                           // Handle the error, possibly with an alert to the user
+                       }
+                   }
+               }
+               
+               // Open the config file with the default application
+               NSWorkspace.shared.openFile(destinationPath)
+           }
+           .keyboardShortcut("O", modifiers: .command)
         if viewModel.isEnabled {
             Button("Reload config") {
                 refreshSession { _ = ReloadConfigCommand().run(.focused) }


### PR DESCRIPTION
Hi, 

I found myself to be experimenting a lot with the config. It is super handy to have a "Reload config" menu item at hand but I found myself to always jump to the terminal and open the config file. Before having the config at hand I had to copy it from the app into my home folder using as recommended in the Readme.

This PR adds a menu item to open the config file directly. It also copies it initially from the App to the home folder when no config is present.

It's a quality of life improvement for me. Would be happy to have this in AeroSpace :)

Cheers Bijan