### PR TITLE
Fix typo + links to on-window-detected on default-config.toml

### DIFF
--- a/docs/config-examples/default-config.toml
+++ b/docs/config-examples/default-config.toml
@@ -190,3 +190,14 @@ alt-shift-h = ['join-with left', 'mode main']
 alt-shift-j = ['join-with down', 'mode main']
 alt-shift-k = ['join-with up', 'mode main']
 alt-shift-l = ['join-with right', 'mode main']
+
+# You can use on-window-detected callback to run commands every time a new window is detected.
+# See: https://nikitabobko.github.io/AeroSpace/guide#on-window-detected-callback
+#
+# List of popular and built-in applications IDs
+# See: https://nikitabobko.github.io/AeroSpace/goodness#popular-apps-ids
+#
+# For example make ActivityMonitor float
+# [[on-window-detected]]
+# if.app-id = 'com.apple.ActivityMonitor'
+# run = 'layout floating'

--- a/docs/config-examples/default-config.toml
+++ b/docs/config-examples/default-config.toml
@@ -1,7 +1,7 @@
 # Place a copy of this config to ~/.aerospace.toml
 # After that, you can edit ~/.aerospace.toml to your liking
 
-# It's not neceesary to copy all keys to your config.
+# It's not necessary to copy all keys to your config.
 # If the key is missing in your config, "default-config.toml" will serve as a fallback
 
 # You can use it to add commands that run after login to macOS user session.


### PR DESCRIPTION
Hello there,

Giving this app a try and I saw the typo in the docs and also I needed to make 1password and iterm2 (using in "quake" mode) float by default, so I added some docs to the default configuration as well.

Hope this is useful for future users.

Thank you for putting this app together. 💜 