### PR TITLE
Reduce workspace switching flicker

### DIFF
--- a/Sources/AppBundle/refresh.swift
+++ b/Sources/AppBundle/refresh.swift
@@ -68,14 +68,15 @@ private func refreshFocusedWorkspaceBasedOnFocusedWindow() { // todo drop. It sh
 }
 
 private func layoutWorkspaces() {
-    for workspace in Workspace.all {
-        if workspace.isVisible {
-            // todo no need to unhide tiling windows (except for keeping hide/unhide state variables invariants)
-            workspace.allLeafWindowsRecursive.forEach { ($0 as! MacWindow).unhideViaEmulation() } // todo as!
-        } else {
-            workspace.allLeafWindowsRecursive.forEach { ($0 as! MacWindow).hideViaEmulation() } // todo as!
-        }
-    }
+    // to reduce flicker, first unhide visible workspaces, then hide invisible ones
+    Workspace.all.filter({ $0.isVisible }).forEach({
+        // todo no need to unhide tiling windows (except for keeping hide/unhide state variables invariants)
+        $0.allLeafWindowsRecursive.forEach { ($0 as! MacWindow).unhideViaEmulation() } // todo as!
+    })
+    Workspace.all.filter({ !$0.isVisible }).forEach({
+        $0.allLeafWindowsRecursive.forEach { ($0 as! MacWindow).hideViaEmulation() } // todo as!
+    })
+
     for monitor in monitors {
         monitor.activeWorkspace.layoutWorkspace()
     }


### PR DESCRIPTION
Previously, workspace switch might flicker a bit upon changing to a higher number. This could be observed by switching repeatedly between first and second workspace, for example. 2->1 does not flicker, but 1->2 sometimes shows desktop. This fixes the issue: visible workspaces are first unhidden, and then invisible ones are hidden.