### PR TITLE
docs: Add Monitor resolution impacts into the guide

### DIFF
--- a/docs/guide.adoc
+++ b/docs/guide.adoc
@@ -365,9 +365,13 @@ Overview of '`Displays have separate Spaces`'
 |😡 No
 |👍 Yes
 
-|macOS status bar ...
-|... is displayed on both monitors
-|... is displayed only on main monitor
+|macOS status bar
+|Displayed on both monitors
+|Displayed only on main monitor
+
+|Monitors have different resolution
+|😡 Might experience performance impact due to windows moving between spaces
+|👍 No performance impact
 |===
 
 == Callbacks


### PR DESCRIPTION
I've been using Aerospace for the last couple months, while it worked great in office, it didn't at home where I have 2 different monitors with different screen resolutions.
As a result I've been having performance impacts, where it took long for my windows to switch between workspaces.
After stalking the the issues tab I noticed #333 and in that conversation #159 and wished this was somewhere included into the guide/docs, either as a warning or in the comparison. 

+ cleanup