### PR TITLE
default-config: Do not use -n for terminal

### DIFF
--- a/docs/config-examples/default-config.toml
+++ b/docs/config-examples/default-config.toml
@@ -81,7 +81,7 @@ outer.right =      0
 
 # You can uncomment this line to open up terminal with alt + enter shortcut
 # See: https://nikitabobko.github.io/AeroSpace/commands#exec-and-forget
-# alt-enter = 'exec-and-forget open -n /System/Applications/Utilities/Terminal.app'
+# alt-enter = 'exec-and-forget open -a /System/Applications/Utilities/Terminal.app ~'
 
 # See: https://nikitabobko.github.io/AeroSpace/commands#layout
 alt-slash = 'layout tiles horizontal vertical'


### PR DESCRIPTION
With -n, the terminal apps just keeps accumulating in the dock.

So use -a combined with argument of ~ to open new window of default terminal.