### PR TITLE
Added support for hyper and meh modifiers

### DIFF
--- a/Sources/AppBundle/config/keysMap.swift
+++ b/Sources/AppBundle/config/keysMap.swift
@@ -201,6 +201,8 @@ let modifiersMap: [String: NSEvent.ModifierFlags] = [
     "alt": .option,
     "ctrl": .control,
     "cmd": .command,
+    "meh": [.shift, .control, .option],
+    "hyper": [.command, .shift, .control, .option],
 ]
 
 extension NSEvent.ModifierFlags {


### PR DESCRIPTION
There's two popular custom modifier keys called `hyper` and `meh` which are `cmd+alt+shift+ctrl` and `alt+shift+ctrl` respectively.

I've added two new modifier types to the `modifiersMap` global variable. This allows for shorthand syntax in the config file: `hyper-h` instead of having to write `cmd-ctrl-alt-shift-h`.