### PR TITLE
Implement focus --dfs-index <dfs-index>

### DIFF
--- a/Sources/AppBundle/command/FocusCommand.swift
+++ b/Sources/AppBundle/command/FocusCommand.swift
@@ -32,6 +32,12 @@ struct FocusCommand: Command {
                 } else {
                     return state.failCmd(msg: "Can't find window with ID \(windowId)")
                 }
+            case .dfsIndex(let dfsIndex):
+                if let windowToFocus = workspace.rootTilingContainer.allLeafWindowsRecursive.getOrNil(atIndex: dfsIndex.int ?? -1) {
+                    result = windowToFocus.focusWindow() && result
+                } else {
+                    return state.failCmd(msg: "Can't find window with DFS index \(dfsIndex)")
+                }
         }
         state.subject = .focused
         return result

--- a/docs/aerospace-focus.adoc
+++ b/docs/aerospace-focus.adoc
@@ -12,6 +12,7 @@ include::util/man-attributes.adoc[]
 aerospace focus [-h|--help] [--boundaries <boundary>]
                 [--boundaries-action <action>] [--ignore-floating] (left|down|up|right)
 aerospace focus [-h|--help] --window-id <window-id>
+aerospace focus [-h|--help] --dfs-index <dfs-index>
 
 // end::synopsis[]
 
@@ -47,6 +48,9 @@ The default is: `wrap-around-the-workspace`
 
 --window-id <window-id>::
 Focus the window with specified `<window-id>`
+
+--dfs-index <dfs-index>::
+focus a window by its index, based on a depth-first search (DFS) of the window tree within the current workspace
 
 --ignore-floating::
 Don't perceive floating windows as part of the tree.


### PR DESCRIPTION
Issue #427 

Added a new argument `--dfs-index` to the `focus` command. This allows users to focus on a specific window by its index, based on a depth-first search (DFS) of the window tree within the current workspace.

Example of indexes:

h_tiles
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;window1 (index: 0)
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;v_tiles
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;window2 (index: 1)
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;window3 (index: 2)
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;window4 (index: 3)

I have previously used similar feature and i really like to bind it to.
cmd - 1 = "focus --dfs-index 0"
cmd - 2 = "focus --dfs-index 1"
....
cmd - 9 = "focus --dfs-index 8"

As this allows for quick and consistent changing to a window.