### PR TITLE
Closes 479 - Remove launchctl calls in startAtLogin routine

### DIFF
--- a/Sources/AppBundle/config/startAtLogin.swift
+++ b/Sources/AppBundle/config/startAtLogin.swift
@@ -26,9 +26,7 @@ func syncStartAtLogin() {
             """
         Result { try plist.write(to: url, atomically: false, encoding: .utf8) }
             .getOrThrow("Can't write to \(url) ")
-        Result { try Process.run(URL(filePath: "/bin/launchctl"), arguments: ["load", url.absoluteString]) }.getOrThrow()
     } else {
-        Result { try Process.run(URL(filePath: "/bin/launchctl"), arguments: ["unload", url.absoluteString]) }.getOrThrow()
         try? FileManager.default.removeItem(at: url)
     }
 }


### PR DESCRIPTION
closes #479 

As described in #479, the calls to launchctl are broken due to invalid file paths, but *fixing* them introduces a worse bug.

As macos/launchd will automatically load a plist if it's present in the launch agents directory on load, it's enough that we simply write/delete the file as needed. For now at least, as there is no regression in functionality.

In future, if we wanted tighter control over the app as a launch agent we could explore enforcing a single instance of the app or introducing a startup helper to manage the lifecycle of AeroSpaceApp.

No hard feelings if you don't like this solution, I know we've not discussed it prior.

Update:
I'd not thought of this sooner, so it's not mentioned in the issue, but if you did want to fix the launchctl calls and keep them - a simple option to prevent the duplicate app bug would be to update the launch agent plist to run:
```sh
open -W /Applications/AeroSpace.app --args --started-at-login
``` 
instead of 
```sh
/Applications/Aerospace.app/Contents/MacOS/AeroSpace --started-at-login
```

As by default, Mac OS app bundles only allow one instance to run at a time.

However with this option, without some kind of guard, you'd still see errors on the unload when the plist file doesn't exist and start-at-login is false. And you'd see the load errors when the agent is already loaded and `start-at-login` is true.