### PR TITLE
Add is-dialog function to on-window-detected callback

### DIFF
--- a/Sources/AppBundle/config/parseOnWindowDetected.swift
+++ b/Sources/AppBundle/config/parseOnWindowDetected.swift
@@ -22,6 +22,7 @@ struct WindowDetectedCallbackMatcher: Copyable, Equatable {
     var windowTitleRegexSubstring: Regex<AnyRegexOutput>?
     var workspace: String?
     var duringAeroSpaceStartup: Bool?
+    var isDialog: Bool?
 
     static func == (lhs: WindowDetectedCallbackMatcher, rhs: WindowDetectedCallbackMatcher) -> Bool {
         check(
@@ -46,6 +47,7 @@ private let matcherParsers: [String: any ParserProtocol<WindowDetectedCallbackMa
     "app-name-regex-substring": Parser(\.appNameRegexSubstring, upcast(parseCasInsensitiveRegex)),
     "window-title-regex-substring": Parser(\.windowTitleRegexSubstring, upcast(parseCasInsensitiveRegex)),
     "during-aerospace-startup": Parser(\.duringAeroSpaceStartup, upcast(parseBool)),
+    "is-dialog": Parser(\.isDialog, upcast(parseBool))
 ]
 
 private func upcast<T>(_ fun: @escaping (TOMLValueConvertible, TomlBacktrace) -> ParsedToml<T>) -> (TOMLValueConvertible, TomlBacktrace) -> ParsedToml<T?> {

--- a/Sources/AppBundle/tree/MacWindow.swift
+++ b/Sources/AppBundle/tree/MacWindow.swift
@@ -361,6 +361,14 @@ extension WindowDetectedCallback {
         if let workspace = matcher.workspace, workspace != window.workspace?.name {
             return false
         }
+        let macWindow = window.asMacWindow()
+        let axWindow = macWindow.axWindow
+        let app = macWindow.macApp
+        let isDialogStatus = shouldFloat(axWindow, app) || !isWindow(axWindow, app)
+        // Don't run callback if isDialog conf and isDialogStatus mismatch
+        if let isDialog = matcher.isDialog, isDialog != isDialogStatus{
+            return false
+        }
         return true
     }
 }


### PR DESCRIPTION
Add handling for is-dialog to parseOnWindowDetected.swift 
Add shouldFloat and !isWindow handling to WindowDetectedCallbackMatcher in MacWindow.swift

In response to Issue #103 