### PR TITLE
[focus] add `prev` and `next` as directions to focusCommand

### DIFF
--- a/Sources/Common/model/CardinalDirection.swift
+++ b/Sources/Common/model/CardinalDirection.swift
@@ -1,16 +1,18 @@
 public enum CardinalDirection: String, CaseIterable, Equatable {
-    case left, down, up, right
+    case left, down, up, right, next, prev
 }
 
 public extension CardinalDirection {
     var orientation: Orientation { self == .up || self == .down ? .v : .h }
-    var isPositive: Bool { self == .down || self == .right }
+    var isPositive: Bool { self == .down || self == .right || self == .next}
     var opposite: CardinalDirection {
         return switch self {
             case .left: .right
             case .down: .up
             case .up: .down
             case .right: .left
+            case .next: .next
+            case .prev: .prev
         }
     }
     var focusOffset: Int { isPositive ? 1 : -1 }

--- a/docs/aerospace-focus.adoc
+++ b/docs/aerospace-focus.adoc
@@ -11,7 +11,7 @@ include::util/man-attributes.adoc[]
 // tag::synopsis[]
 aerospace focus [-h|--help] [--ignore-floating]
                 [--boundaries <boundary>] [--boundaries-action <action>]
-                (left|down|up|right)
+                (left|down|up|right|prev|next)
 aerospace focus [-h|--help] --window-id <window-id>
 aerospace focus [-h|--help] --dfs-index <dfs-index>
 


### PR DESCRIPTION
#### Description

Adds `prev` and `next` as directions to `focus` command. The specific benefit here is that they don't rely on cardinal directions and that they wrap around when they get to the first or last window. 

This is similar to how xmonad's [window cycling feature behaves](https://hackage.haskell.org/package/xmonad-contrib-0.18.1/docs/XMonad-Actions-CycleWindows.html)

#### Test Plan

* Load a workspace with multiple windows, verify `next` and `prev` cycle between them and don't stop at the end.
  * Verify in accordion and tiles
* Load a workspace with no windows, verify program doesn't crash

#### Notes

* Please edit the commit / commit message as desired
* I did not regen docs, wasn't able to get it to work properly