### PR TITLE
[draft][summon-workspace] summon workspace works on non-focused monitors

### DIFF
--- a/Sources/AppBundle/command/impl/SummonWorkspaceCommand.swift
+++ b/Sources/AppBundle/command/impl/SummonWorkspaceCommand.swift
@@ -7,15 +7,23 @@ struct SummonWorkspaceCommand: Command {
     func run(_ env: CmdEnv, _ io: CmdIo) -> Bool {
         check(Thread.current.isMainThread)
         let workspace = Workspace.get(byName: args.target.val.raw)
-        let monitor = focus.workspace.workspaceMonitor
+        let onMonitor = monitors.first { $0.activeWorkspace == workspace }
+        if onMonitor != nil {
+            io.err("Workspace '\(workspace.name)' is already visible on a monitor, returning")
+            return !args.failIfNoop
+        }
+
+        let monitor = focus.workspace.forceAssignedMonitor ?? focus.workspace.workspaceMonitor
         if monitor.activeWorkspace == workspace {
             io.err("Workspace '\(workspace.name)' is already visible on the focused monitor. Tip: use --fail-if-noop to exit with non-zero code")
             return !args.failIfNoop
         }
-        if monitor.setActiveWorkspace(workspace) {
-            return workspace.focusWorkspace()
+
+        if isValidAssignment(workspace: workspace, monitor: monitor) {
+            _ = monitor.setActiveWorkspace(workspace)
+            return monitor.activeWorkspace.focusWorkspace()
         } else {
-            return io.err("Can't move workspace '\(workspace.name)' to monitor '\(monitor.name)'. workspace-to-monitor-force-assignment doesn't allow it")
+            return workspace.forceAssignedMonitor?.setActiveWorkspace(workspace) != nil
         }
     }
 }

--- a/Sources/AppBundle/command/impl/SummonWorkspaceCommand.swift
+++ b/Sources/AppBundle/command/impl/SummonWorkspaceCommand.swift
@@ -7,16 +7,27 @@ struct SummonWorkspaceCommand: Command {
     func run(_ env: CmdEnv, _ io: CmdIo) -> Bool {
         check(Thread.current.isMainThread)
         let workspace = Workspace.get(byName: args.target.val.raw)
-        let onMonitor = monitors.first { $0.activeWorkspace == workspace }
-        if onMonitor != nil {
-            io.err("Workspace '\(workspace.name)' is already visible on a monitor, returning")
-            return !args.failIfNoop
-        }
 
-        let monitor = focus.workspace.forceAssignedMonitor ?? focus.workspace.workspaceMonitor
+        let curMonitor = focus.workspace.workspaceMonitor
+
+        let monitor = focus.workspace.forceAssignedMonitor ?? curMonitor
         if monitor.activeWorkspace == workspace {
             io.err("Workspace '\(workspace.name)' is already visible on the focused monitor. Tip: use --fail-if-noop to exit with non-zero code")
             return !args.failIfNoop
+        }
+
+        let onMonitor = monitors.first { $0.activeWorkspace == workspace }
+        if let onMonitor = onMonitor {
+            if workspace.forceAssignedMonitor?.monitorId == onMonitor.monitorId {
+                io.err("Workspace '\(workspace.name)' is already visible on a monitor, returning")
+                return !args.failIfNoop
+            }
+            if curMonitor.activeWorkspace.forceAssignedMonitor != nil {
+                io.err("Current Monitor has a pinned workspace, can't swap - returning")
+                return !args.failIfNoop
+            }
+
+            _ = onMonitor.setActiveWorkspace(curMonitor.activeWorkspace)
         }
 
         if isValidAssignment(workspace: workspace, monitor: monitor) {

--- a/Sources/AppBundle/tree/Workspace.swift
+++ b/Sources/AppBundle/tree/Workspace.swift
@@ -191,3 +191,7 @@ private func isValidAssignment(workspace: Workspace, screen: CGPoint) -> Bool {
         return true
     }
 }
+
+func isValidAssignment(workspace: Workspace, monitor: Monitor) -> Bool {
+    isValidAssignment(workspace: workspace, screen: monitor.rect.topLeftCorner)
+}


### PR DESCRIPTION
#### Description

If the workspace has an assignedMonitor, it pulls that workspace onto its assigned monitor but the focus is retained on the current monitor. If the workspace is visible, nothing happens and focus stays on the current monitor

**use case**

You may keep a terminal on one monitor and want to cycle what is visible on the other monitor while staying in the terminal. This fixes the issue of rapidly cycling workspaces causing the monitor focus to shift. When wanting to focus a monitor, `focus-monitor` is used instead. 

#### Test Plan

[1,2,3] are main, [8,9,0] are secondary, [U,Z] have no assigned monitor

* [1, 0*] - summon 2 -> [2, 0*] (summons 2 to pinned monitor)
* [1, 0*] - summon U -> [1, U*] (summons U to current monitor)
* [U, 0*] - summon U -> [U, 0*] (nothing happens because 0 is pinned)
* [U, Z*] - summon U -> [Z, U*] (swap workspaces)

#### Notes

* feel free to edit the commit
* feel free to ignore this commit, this is just how i configured the behavior for myself


