### PR TITLE
Add interpolation variables to --format flag

### DIFF
--- a/Sources/AppBundle/command/format.swift
+++ b/Sources/AppBundle/command/format.swift
@@ -67,6 +67,8 @@ private enum FormatVar: Equatable {
         case appBundleId = "app-bundle-id"
         case appName = "app-name"
         case appPid = "app-pid"
+        case appExecPath = "app-exec-path"
+        case appBundlePath = "app-bundle-path"
     }
 
     enum MonitorFormatVar: String, Equatable {
@@ -150,6 +152,8 @@ extension String {
                     case .appBundleId: .success(.string(a.id ?? "NULL-APP-BUNDLE-ID"))
                     case .appName: .success(.string(a.name ?? "NULL-APP-NAME"))
                     case .appPid: .success(.int32(a.pid))
+                    case .appExecPath: .success(.string(a.execPath ?? "NULL-APP-EXEC-PATH"))
+                    case .appBundlePath: .success(.string(a.bundlePath ?? "NULL-APP-BUNDLE-PATH"))
                 }
             default: break
         }

--- a/Sources/AppBundle/tree/AbstractApp.swift
+++ b/Sources/AppBundle/tree/AbstractApp.swift
@@ -25,6 +25,8 @@ class AbstractApp: Hashable {
 
     func getFocusedWindow(startup: Bool) -> Window? { error("Not implemented") }
     var name: String? { nil }
+    var execPath: String? { nil }
+    var bundlePath: String? { nil }
     func detectNewWindowsAndGetAll(startup: Bool) -> [Window] { error("Not implemented") }
 }
 

--- a/Sources/AppBundle/tree/MacApp.swift
+++ b/Sources/AppBundle/tree/MacApp.swift
@@ -52,6 +52,10 @@ final class MacApp: AbstractApp {
 
     override var name: String? { nsApp.localizedName }
 
+    override var execPath: String? { nsApp.executableURL?.path }
+
+    override var bundlePath: String? { nsApp.bundleURL?.path }
+
     private func observe(_ handler: AXObserverCallback, _ notifKey: String) -> Bool {
         guard let observer = AXObserver.observe(nsApp.processIdentifier, notifKey, axApp, handler, data: nil) else { return false }
         axObservers.append(AxObserverWrapper(obs: observer, ax: axApp, notif: notifKey as CFString))

--- a/docs/aerospace-list-apps.adoc
+++ b/docs/aerospace-list-apps.adoc
@@ -54,6 +54,8 @@ The following variables can be used inside `<output-format>`:
 %{app-bundle-id}:: String. Application unique identifier. https://developer.apple.com/documentation/appstoreconnectapi/bundle_ids[Bundle ID]
 %{app-name}:: String. Application name
 %{app-pid}:: Number. https://en.wikipedia.org/wiki/Process_identifier[UNIX process identifier]
+%{app-exec-path}:: String. Application executable path
+%{app-bundle-path}:: String. Application bundle path
 
 %{right-padding}:: A special variable which expands with a minimum number of spaces required to form a right padding in the appropriate column
 %{newline}:: Unicode U+000A newline symbol `\n`

--- a/docs/aerospace-list-windows.adoc
+++ b/docs/aerospace-list-windows.adoc
@@ -82,6 +82,8 @@ The following variables can be used inside `<output-format>`:
 %{app-bundle-id}:: String. Application unique identifier. https://developer.apple.com/documentation/appstoreconnectapi/bundle_ids[Bundle ID]
 %{app-name}:: String. Application name
 %{app-pid}:: Number. https://en.wikipedia.org/wiki/Process_identifier[UNIX process identifier]
+%{app-exec-path}:: String. Application executable path
+%{app-bundle-path}:: String. Application bundle path
 
 %{workspace}:: String. Name of the belonging workspace
 


### PR DESCRIPTION
Add %{app-exec-path} and %{app-bundle-path} interpolation variable to --format flag in query commands list-apps and list-windows
#592 