### PR TITLE
Add `--when-visible (focus|swap)` option to the summon-workspace command

### DIFF
--- a/Sources/Common/cmdArgs/impl/SummonWorkspaceCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/SummonWorkspaceCmdArgs.swift
@@ -1,3 +1,5 @@
+private let actio = "<action>"
+
 public struct SummonWorkspaceCmdArgs: CmdArgs {
     public let rawArgs: EquatableNoop<[String]>
     public init(rawArgs: [String]) { self.rawArgs = .init(rawArgs) }
@@ -7,6 +9,7 @@ public struct SummonWorkspaceCmdArgs: CmdArgs {
         help: summon_workspace_help_generated,
         options: [
             "--fail-if-noop": trueBoolFlag(\.failIfNoop),
+            "--when-visible": ArgParser(\.rawWhenVisibleAction, upcastArgParserFun(parseWhenVisibleAction)),
         ],
         arguments: [newArgParser(\.target, parseWorkspaceName, mandatoryArgPlaceholder: "<workspace>")]
     )
@@ -16,8 +19,26 @@ public struct SummonWorkspaceCmdArgs: CmdArgs {
 
     public var target: Lateinit<WorkspaceName> = .uninitialized
     public var failIfNoop: Bool = false
+    public var rawWhenVisibleAction: WhenVisible? = nil
+
+    public enum WhenVisible: String, CaseIterable, Equatable {
+        case focus = "focus"
+        case swap = "swap"
+    }
+}
+
+public extension SummonWorkspaceCmdArgs {
+    var whenVisible: WhenVisible { rawWhenVisibleAction ?? .focus }
 }
 
 private func parseWorkspaceName(arg: String, nextArgs: inout [String]) -> Parsed<WorkspaceName> {
     WorkspaceName.parse(arg)
+}
+
+private func parseWhenVisibleAction(arg: String, nextArgs: inout [String]) -> Parsed<SummonWorkspaceCmdArgs.WhenVisible> {
+    if let arg = nextArgs.nextNonFlagOrNil() {
+        return parseEnum(arg, SummonWorkspaceCmdArgs.WhenVisible.self)
+    } else {
+        return .failure("\(actio) is mandatory")
+    }
 }

--- a/Sources/Common/cmdHelpGenerated.swift
+++ b/Sources/Common/cmdHelpGenerated.swift
@@ -121,7 +121,7 @@ let split_help_generated = """
     USAGE: split [-h|--help] [--window-id <window-id>] (horizontal|vertical|opposite)
     """
 let summon_workspace_help_generated = """
-    USAGE: summon-workspace [-h|--help] [--fail-if-noop] <workspace>
+    USAGE: summon-workspace [-h|--help] [--fail-if-noop] [--when-visible (focus|swap)] <workspace>
     """
 let trigger_binding_help_generated = """
     USAGE: trigger-binding [-h|--help] <binding> --mode <mode-id>

--- a/docs/aerospace-summon-workspace.adoc
+++ b/docs/aerospace-summon-workspace.adoc
@@ -9,7 +9,7 @@ include::util/man-attributes.adoc[]
 == Synopsis
 [verse]
 // tag::synopsis[]
-aerospace summon-workspace [-h|--help] [--fail-if-noop] <workspace>
+aerospace summon-workspace [-h|--help] [--fail-if-noop] [--when-visible (focus|swap)] <workspace>
 
 // end::synopsis[]
 
@@ -29,6 +29,11 @@ include::./util/conditional-options-header.adoc[]
 
 -h, --help:: Print help
 --fail-if-noop:: Exit with non-zero exit code if the workspace already visible on the focused monitor.
+
+--when-visible <action>::
+Defines the behavior if the workspace is already visible on another monitor.
+`<action>` possible values: `(focus|swap)`. +
+The default is: `focus`
 
 // =========================================================== Arguments
 include::./util/conditional-arguments-header.adoc[]


### PR DESCRIPTION
First, let me say AeroSpace is really cool! I've been trying to relive my XMonad memories on Mac [for years](https://kevinlynagh.com/organizing-windows/) and am excited about the possibilities with AeroSpace.

This PR implements the swapping behavior discussed in https://github.com/nikitabobko/AeroSpace/issues/603.

I could be misunderstanding the AeroSpace internals, but it doesn't seem like this feature is blocking on workspace renaming. I've tested it locally with multiple monitors and tiling / accordion layouts and it seemed to work as intended. (Note: I have not attempted to wire up any automated tests, though would be happy to do so if you'd like me to.)

Even though in that issue you said you wanted `swap` to be the default behavior, in the PR I have `focus` as the default for backwards compatibility.

Finally, I live and work in Oud-West, so if you would prefer to discuss in person --- beverages are on me =D