### PR TITLE
Allow specifying relative DFS index for focus command

### DIFF
--- a/Sources/AppBundle/command/impl/FocusCommand.swift
+++ b/Sources/AppBundle/command/impl/FocusCommand.swift
@@ -32,10 +32,23 @@ struct FocusCommand: Command {
                     return io.err("Can't find window with ID \(windowId)")
                 }
             case .dfsIndex(let dfsIndex):
-                if let windowToFocus = target.workspace.rootTilingContainer.allLeafWindowsRecursive.getOrNil(atIndex: Int(dfsIndex)) {
+                guard let window = target.windowOrNil else {
+                    return io.err("Can't focus window by DFS index without a window")
+                }
+
+                let allWindows = target.workspace.rootTilingContainer.allLeafWindowsRecursive
+
+                guard let dfsAbsoluteIndex = switch dfsIndex {
+                    case .absolute(let index): index
+                    case .relative(let index): allWindows.firstIndex(of: window).map { $0 + index }
+                } else {
+                    return io.err("Can't find window in allLeafWindowsRecursive")
+                }
+
+                if let windowToFocus = allWindows.get(wrappingIndex: dfsAbsoluteIndex) {
                     return windowToFocus.focusWindow()
                 } else {
-                    return io.err("Can't find window with DFS index \(dfsIndex)")
+                    return io.err("Can't find window with DFS index \(dfsAbsoluteIndex)")
                 }
         }
     }

--- a/Sources/Common/cmdArgs/cmdArgsStringArrayEx.swift
+++ b/Sources/Common/cmdArgs/cmdArgsStringArrayEx.swift
@@ -7,6 +7,10 @@ extension [String] {
         first?.starts(with: "-") == true ? nil : nextOrNil()
     }
 
+    mutating func nextNonFullFlagOrNil() -> String? {
+        first?.starts(with: "--") == true ? nil : nextOrNil()
+    }
+
     mutating func allNextNonFlagArgs() -> [String] {
         var args: [String] = []
         while let nextArg = nextNonFlagOrNil() {

--- a/Sources/Common/model/dfsIndex.swift
+++ b/Sources/Common/model/dfsIndex.swift
@@ -1,0 +1,4 @@
+public enum DfsIndex: Equatable {
+    case absolute(Int)
+    case relative(Int)
+}


### PR DESCRIPTION
I also wanted dfs next/prev as discussed in https://github.com/nikitabobko/AeroSpace/issues/248.

I figured I could implement without adding additional flags or breaking backwards compatibility by having the parser look for an optional +/- suffix on the existing dfs-index argument. The next/previous behavior can be had via:

focus --dfs-index +1
focus --dfs-index -1

respectively.

As with my other PR, I haven't implemented any automated tests around this but would be happy to look into doing so if desired.