### PR TITLE
Fixes #586, #678: Traymenu workspace statuses are not updating

### DIFF
--- a/Sources/AppBundle/MenuBar.swift
+++ b/Sources/AppBundle/MenuBar.swift
@@ -12,19 +12,7 @@ public func menuBar(viewModel: TrayMenuModel) -> some Scene {
         Divider()
         if viewModel.isEnabled {
             Text("Workspaces:")
-            ForEach(Workspace.all) { (workspace: Workspace) in
-                Button {
-                    refreshSession { _ = workspace.focusWorkspace() }
-                } label: {
-                    Toggle(isOn: workspace == focus.workspace
-                        ? Binding(get: { true }, set: { _, _ in })
-                        : Binding(get: { false }, set: { _, _ in }))
-                    {
-                        let monitor = workspace.isVisible || !workspace.isEffectivelyEmpty ? " - \(workspace.workspaceMonitor.name)" : ""
-                        Text(workspace.name + monitor).font(.system(.body, design: .monospaced))
-                    }
-                }
-            }
+            ForEach(viewModel.workspaceStatus) { $0.button }
             Divider()
         }
         Button(viewModel.isEnabled ? "Disable" : "Enable") {

--- a/Sources/AppBundle/TrayMenuModel.swift
+++ b/Sources/AppBundle/TrayMenuModel.swift
@@ -1,5 +1,11 @@
 import AppKit
 import Common
+import SwiftUI
+
+struct WorkspaceButton: Identifiable {
+    let id = UUID()
+    let button: Button<Toggle<Text>>
+}
 
 public class TrayMenuModel: ObservableObject {
     public static let shared = TrayMenuModel()
@@ -9,6 +15,7 @@ public class TrayMenuModel: ObservableObject {
     @Published var trayText: String = ""
     /// Is "layouting" enabled
     @Published var isEnabled: Bool = true
+    @Published var workspaceStatus: [WorkspaceButton] = []
 }
 
 func updateTrayText() {
@@ -19,4 +26,17 @@ func updateTrayText() {
             ($0.activeWorkspace == focus.workspace && sortedMonitors.count > 1 ? "*" : "") + $0.activeWorkspace.name
         }
         .joined(separator: " │ ")
+    TrayMenuModel.shared.workspaceStatus = Workspace.all.map { (workspace: Workspace) in
+        WorkspaceButton(button: Button {
+            refreshSession { _ = workspace.focusWorkspace() }
+        } label: {
+            Toggle(isOn: workspace == focus.workspace
+                ? Binding(get: { true }, set: { _, _ in })
+                : Binding(get: { false }, set: { _, _ in }))
+            {
+                let monitor = workspace.isVisible || !workspace.isEffectivelyEmpty ? " - \(workspace.workspaceMonitor.name)" : ""
+                Text(workspace.name + monitor).font(.system(.body, design: .monospaced))
+            }
+        })
+    }
 }


### PR DESCRIPTION
Hi there,

I moved the workspace Toggles in the menu inside a @Published property of the ObservableObject to allow information flow. Then, the Toggles are updated along with the tray text inside updateTrayText().

Thanks!!