### PR TITLE
Add features that are requested in issue #766

### DIFF
--- a/Sources/Cli/subcommandDescriptionsGenerated.swift
+++ b/Sources/Cli/subcommandDescriptionsGenerated.swift
@@ -26,7 +26,7 @@ let subcommandDescriptions = [
     ["  move-mouse", "Move mouse to the requested position"],
     ["  move-node-to-monitor", "Move window to monitor targeted by relative direction, by order, or by pattern"],
     ["  move-node-to-workspace", "Move the focused window to the specified workspace"],
-    ["  move-workspace-to-monitor", "Move the focused workspace to the next or previous monitor."],
+    ["  move-workspace-to-monitor", "Move workspace to monitor targeted by relative direction, by order, or by pattern."],
     ["  move", "Move the focused window in the given direction"],
     ["  reload-config", "Reload currently active config"],
     ["  resize", "Resize the focused window"],

--- a/Sources/Common/cmdArgs/cmdArgsManifest.swift
+++ b/Sources/Common/cmdArgs/cmdArgsManifest.swift
@@ -99,7 +99,7 @@ func initSubcommands() -> [String: any SubCommandParserProtocol] {
             case .moveNodeToWorkspace:
                 result[kind.rawValue] = SubCommandParser(parseMoveNodeToWorkspaceCmdArgs)
             case .moveWorkspaceToMonitor:
-                result[kind.rawValue] = SubCommandParser(MoveWorkspaceToMonitorCmdArgs.init)
+                result[kind.rawValue] = SubCommandParser(parseWorkspaceToMonitorCmdArgs)
                 // deprecated
                 result["move-workspace-to-display"] = SubCommandParser(MoveWorkspaceToMonitorCmdArgs.init)
             case .reloadConfig:

--- a/Sources/Common/cmdArgs/impl/MoveWorkpsaceToMonitorCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/MoveWorkpsaceToMonitorCmdArgs.swift
@@ -9,18 +9,23 @@ public struct MoveWorkspaceToMonitorCmdArgs: CmdArgs {
             "--wrap-around": trueBoolFlag(\.wrapAround),
             "--workspace": optionalWorkspaceFlag(),
         ],
-        arguments: [newArgParser(\.target, parseMonitorTarget, mandatoryArgPlaceholder: "(next|prev)")]
+        arguments: [
+            newArgParser(
+                \.target, parseTarget,
+                mandatoryArgPlaceholder: "(left|down|up|right|next|prev|<monitor-pattern>)"),
+        ]
     )
 
     public var windowId: UInt32?
     public var workspaceName: WorkspaceName?
     public var wrapAround: Bool = false
-    public var target: Lateinit<MoveWorkspaceToMonitorCmdArgs.MonitorTarget> = .uninitialized
-    public enum MonitorTarget: String, CaseIterable {
-        case next, prev
-    }
+    public var target: Lateinit<MonitorTarget> = .uninitialized
 }
-
-private func parseMonitorTarget(arg: String, nextArgs: inout [String]) -> Parsed<MoveWorkspaceToMonitorCmdArgs.MonitorTarget> {
-    parseEnum(arg, MoveWorkspaceToMonitorCmdArgs.MonitorTarget.self)
+public func parseWorkspaceToMonitorCmdArgs(_ args: [String]) -> ParsedCmd<
+    MoveWorkspaceToMonitorCmdArgs
+> {
+    parseSpecificCmdArgs(MoveWorkspaceToMonitorCmdArgs(rawArgs: args), args)
+        .filter("--wrap-around is incompatible with <monitor-pattern> argument") {
+            $0.wrapAround.implies(!$0.target.val.isPatterns)
+        }
 }

--- a/Sources/Common/cmdHelpGenerated.swift
+++ b/Sources/Common/cmdHelpGenerated.swift
@@ -106,7 +106,8 @@ let move_node_to_workspace_help_generated = """
                                   [--window-id <window-id>] <workspace-name>
     """
 let move_workspace_to_monitor_help_generated = """
-    USAGE: move-workspace-to-monitor [-h|--help] [--workspace <workspace>] [--wrap-around] (next|prev)
+    USAGE: move-workspace-to-monitor [-h|--help] [--workspace <workspace>] [--wrap-around] (left|down|up|right|next|prev)
+       OR: move-workspace-to-monitor [-h|--help] [--workspace <workspace>] <monitor-pattern>...
     """
 let move_help_generated = """
     USAGE: move [-h|--help] [--window-id <window-id>] (left|down|up|right)

--- a/docs/aerospace-move-workspace-to-monitor.adoc
+++ b/docs/aerospace-move-workspace-to-monitor.adoc
@@ -2,14 +2,15 @@
 include::util/man-attributes.adoc[]
 :manname: aerospace-move-workspace-to-monitor
 // tag::purpose[]
-:manpurpose: Move the focused workspace to the next or previous monitor.
+:manpurpose: Move workspace to monitor targeted by relative direction, by order, or by pattern.
 // end::purpose[]
 
 // =========================================================== Synopsis
 == Synopsis
 [verse]
 // tag::synopsis[]
-aerospace move-workspace-to-monitor [-h|--help] [--workspace <workspace>] [--wrap-around] (next|prev)
+aerospace move-workspace-to-monitor [-h|--help] [--workspace <workspace>] [--wrap-around] (left|down|up|right|next|prev)
+aerospace move-workspace-to-monitor [-h|--help] [--workspace <workspace>] <monitor-pattern>...
 
 // end::synopsis[]
 
@@ -34,9 +35,16 @@ include::./util/workspace-flag-desc.adoc[]
 // =========================================================== Arguments
 include::./util/conditional-arguments-header.adoc[]
 
+(left|down|up|right)::
+Move workspace to monitor in direction relative to the focused monitor
+
 (next|prev)::
 Move the workspace to next or prev monitor.
 'next' or 'prev' monitor is calculated relative to the monitor `<workspace>` currently belongs to.
+
+<monitor-pattern>::
+Find the first monitor pattern in the list that doesn't describe the current monitor and move the workspace to the appropriate monitor.
+Monitor pattern is the same as in `workspace-to-monitor-force-assignment` config option
 
 // end::body[]
 


### PR DESCRIPTION
I added the capability to use a `<monitor-pattern>` in the `move-workspace-to-monitor` command. A workspace is only moved if the source and target monitors are different. If the `--wrap-around` flag is used in combination with a monitor pattern, an error is shown in the CLI. Additionally, I added the option to use `left|down|up|right`, similar to the `focus-monitor` command, to move a workspace relative to the current monitor.