### PR TITLE
Make menu font monospaced using ImageRenderer

### DIFF
--- a/Sources/AppBundle/MenuBar.swift
+++ b/Sources/AppBundle/MenuBar.swift
@@ -51,8 +51,35 @@ public func menuBar(viewModel: TrayMenuModel) -> some Scene {
             terminateApp()
         }.keyboardShortcut("Q", modifiers: .command)
     } label: {
-        // .font(.system(.body, design: .monospaced)) doesn't work unfortunately :(
-        Text(viewModel.isEnabled ? viewModel.trayText : "⏸️")
+        if viewModel.isEnabled {
+            menuLabel(viewModel: viewModel)
+                .id(viewModel.trayText.hashValue)
+        } else {
+            Text("⏸️")
+        }
+    }
+}
+
+struct menuLabel: View {
+    var viewModel: TrayMenuModel
+
+    var body: some View {
+        let renderer = ImageRenderer(content: imageContent)
+        if let cgImage = renderer.cgImage {
+            Image(cgImage, scale: 2, label: Text(viewModel.trayText))
+                .renderingMode(.template)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+        } else {
+            // In case image can't be rendered fallback to plain text
+            Text(viewModel.trayText)
+        }
+    }
+
+    // I used a largeTitle font and then use a scale of 2 to make the image look smoother
+    private var imageContent: some View {
+        Text(viewModel.trayText)
+            .font(.system(.largeTitle, design: .monospaced))
     }
 }
 

--- a/Sources/AppBundle/MenuBar.swift
+++ b/Sources/AppBundle/MenuBar.swift
@@ -61,13 +61,14 @@ public func menuBar(viewModel: TrayMenuModel) -> some Scene {
 }
 
 struct menuLabel: View {
+    @Environment(\.colorScheme) var colorScheme
+
     var viewModel: TrayMenuModel
 
     var body: some View {
         let renderer = ImageRenderer(content: imageContent)
         if let cgImage = renderer.cgImage {
             Image(cgImage, scale: 2, label: Text(viewModel.trayText))
-                .renderingMode(.template)
                 .resizable()
                 .aspectRatio(contentMode: .fit)
         } else {
@@ -80,6 +81,7 @@ struct menuLabel: View {
     private var imageContent: some View {
         Text(viewModel.trayText)
             .font(.system(.largeTitle, design: .monospaced))
+            .foregroundStyle(colorScheme == .light ? Color.black : Color.white)
     }
 }
 


### PR DESCRIPTION
Here is quite a small change to enable the menu to display the monospaced font. The trick is achieved using `ImageRenderer` that will create an image from a content view.