### PR TITLE
Add soft default assigned monitor

### DIFF
--- a/Sources/AppBundle/command/impl/MoveWorkspaceToMonitorCommand.swift
+++ b/Sources/AppBundle/command/impl/MoveWorkspaceToMonitorCommand.swift
@@ -11,10 +11,16 @@ struct MoveWorkspaceToMonitorCommand: Command {
         let prevMonitor = focusedWorkspace.workspaceMonitor
         let sortedMonitors = sortedMonitors
         guard let index = sortedMonitors.firstIndex(where: { $0.rect.topLeftCorner == prevMonitor.rect.topLeftCorner }) else { return false }
-        let targetMonitor = args.wrapAround
-            ? sortedMonitors.get(wrappingIndex: args.target.val == .next ? index + 1 : index - 1)
-            : sortedMonitors.getOrNil(atIndex: args.target.val == .next ? index + 1 : index - 1)
+        let targetMonitor = args.target.val == .reset
+            ? focusedWorkspace.forceAssignedMonitor ?? focusedWorkspace.defaultAssignedMonitor ?? mainMonitor
+            : args.wrapAround
+                ? sortedMonitors.get(wrappingIndex: args.target.val == .next ? index + 1 : index - 1)
+                : sortedMonitors.getOrNil(atIndex: args.target.val == .next ? index + 1 : index - 1)
         guard let targetMonitor else { return false }
+
+        if targetMonitor.monitorAppKitNsScreenScreensId == prevMonitor.monitorAppKitNsScreenScreensId {
+            return false
+        }
 
         if targetMonitor.setActiveWorkspace(focusedWorkspace) {
             let stubWorkspace = getStubWorkspace(for: prevMonitor)

--- a/Sources/AppBundle/config/Config.swift
+++ b/Sources/AppBundle/config/Config.swift
@@ -52,6 +52,7 @@ struct Config: Copyable {
 
     var gaps: Gaps = .zero
     var workspaceToMonitorForceAssignment: [String: [MonitorDescription]] = [:]
+    var workspaceToMonitorDefaultAssignment: [String: [MonitorDescription]] = [:]
     var modes: [String: Mode] = [:]
     var onWindowDetected: [WindowDetectedCallback] = []
 

--- a/Sources/AppBundle/config/parseConfig.swift
+++ b/Sources/AppBundle/config/parseConfig.swift
@@ -111,6 +111,7 @@ private let configParser: [String: any ParserProtocol<Config>] = [
 
     "gaps": Parser(\.gaps, parseGaps),
     "workspace-to-monitor-force-assignment": Parser(\.workspaceToMonitorForceAssignment, parseWorkspaceToMonitorAssignment),
+    "workspace-to-monitor-default-assignment": Parser(\.workspaceToMonitorDefaultAssignment, parseWorkspaceToMonitorAssignment),
     "on-window-detected": Parser(\.onWindowDetected, parseOnWindowDetectedArray),
 
     // Deprecated

--- a/Sources/AppBundle/tree/Workspace.swift
+++ b/Sources/AppBundle/tree/Workspace.swift
@@ -106,6 +106,7 @@ extension Workspace {
         forceAssignedMonitor
             ?? visibleWorkspaceToScreenPoint[self]?.monitorApproximation
             ?? assignedMonitorPoint?.monitorApproximation
+            ?? defaultAssignedMonitor
             ?? mainMonitor
     }
 }

--- a/Sources/AppBundle/tree/WorkspaceEx.swift
+++ b/Sources/AppBundle/tree/WorkspaceEx.swift
@@ -47,4 +47,12 @@ extension Workspace {
             .compactMap { $0.resolveMonitor(sortedMonitors: sortedMonitors) }
             .first
     }
+
+    var defaultAssignedMonitor: Monitor? {
+        guard let monitorDescriptions = config.workspaceToMonitorDefaultAssignment[name] else { return nil }
+        let sortedMonitors = sortedMonitors
+        return monitorDescriptions.lazy
+            .compactMap { $0.resolveMonitor(sortedMonitors: sortedMonitors) }
+            .first
+    }
 }

--- a/Sources/Cli/subcommandDescriptionsGenerated.swift
+++ b/Sources/Cli/subcommandDescriptionsGenerated.swift
@@ -26,7 +26,7 @@ let subcommandDescriptions = [
     ["  move-mouse", "Move mouse to the requested position"],
     ["  move-node-to-monitor", "Move window to monitor targeted by relative direction, by order, or by pattern"],
     ["  move-node-to-workspace", "Move the focused window to the specified workspace"],
-    ["  move-workspace-to-monitor", "Move the focused workspace to the next or previous monitor."],
+    ["  move-workspace-to-monitor", "Move the focused workspace monitor by order, or resets to the default monitor."],
     ["  move", "Move the focused window in the given direction"],
     ["  reload-config", "Reload currently active config"],
     ["  resize", "Resize the focused window"],

--- a/Sources/Common/cmdArgs/impl/MoveWorkpsaceToMonitorCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/MoveWorkpsaceToMonitorCmdArgs.swift
@@ -9,7 +9,7 @@ public struct MoveWorkspaceToMonitorCmdArgs: CmdArgs {
             "--wrap-around": trueBoolFlag(\.wrapAround),
             "--workspace": optionalWorkspaceFlag(),
         ],
-        arguments: [newArgParser(\.target, parseMonitorTarget, mandatoryArgPlaceholder: "(next|prev)")]
+        arguments: [newArgParser(\.target, parseMonitorTarget, mandatoryArgPlaceholder: "(next|prev|reset)")]
     )
 
     public var windowId: UInt32?
@@ -17,7 +17,7 @@ public struct MoveWorkspaceToMonitorCmdArgs: CmdArgs {
     public var wrapAround: Bool = false
     public var target: Lateinit<MoveWorkspaceToMonitorCmdArgs.MonitorTarget> = .uninitialized
     public enum MonitorTarget: String, CaseIterable {
-        case next, prev
+        case next, prev, reset
     }
 }
 

--- a/Sources/Common/cmdHelpGenerated.swift
+++ b/Sources/Common/cmdHelpGenerated.swift
@@ -107,6 +107,7 @@ let move_node_to_workspace_help_generated = """
     """
 let move_workspace_to_monitor_help_generated = """
     USAGE: move-workspace-to-monitor [-h|--help] [--workspace <workspace>] [--wrap-around] (next|prev)
+       OR: move-workspace-to-monitor [-h|--help] [--workspace <workspace>] (reset)
     """
 let move_help_generated = """
     USAGE: move [-h|--help] [--window-id <window-id>] (left|down|up|right)

--- a/docs/aerospace-move-workspace-to-monitor.adoc
+++ b/docs/aerospace-move-workspace-to-monitor.adoc
@@ -2,7 +2,7 @@
 include::util/man-attributes.adoc[]
 :manname: aerospace-move-workspace-to-monitor
 // tag::purpose[]
-:manpurpose: Move the focused workspace to the next or previous monitor.
+:manpurpose: Move the focused workspace monitor by order, or resets to the default monitor.
 // end::purpose[]
 
 // =========================================================== Synopsis
@@ -10,6 +10,7 @@ include::util/man-attributes.adoc[]
 [verse]
 // tag::synopsis[]
 aerospace move-workspace-to-monitor [-h|--help] [--workspace <workspace>] [--wrap-around] (next|prev)
+aerospace move-workspace-to-monitor [-h|--help] [--workspace <workspace>] (reset)
 
 // end::synopsis[]
 
@@ -37,6 +38,10 @@ include::./util/conditional-arguments-header.adoc[]
 (next|prev)::
 Move the workspace to next or prev monitor.
 'next' or 'prev' monitor is calculated relative to the monitor `<workspace>` currently belongs to.
+
+(reset)::
+Move the workspace to the xref:guide.adoc#assign-workspaces-to-monitors[default monitor].
+Will default to the 'main' monitor if no default monitor is defined.
 
 // end::body[]
 

--- a/docs/guide.adoc
+++ b/docs/guide.adoc
@@ -643,12 +643,26 @@ When you switch to an empty workspace, AeroSpace puts the workspace on an assign
 [#assign-workspaces-to-monitors]
 === Assign workspaces to monitors
 
-You can use `workspace-to-monitor-force-assignment` syntax to assign
-workspaces to always appear on particular monitors
+You can use `workspace-to-monitor-force-assignment` and `workspace-to-monitor-default-assignment` syntax to assign
+workspaces to particular monitors.
+
+The default is a soft assignment, which means workspaces can still be moved to different monitors.
+The workspace can always be reset to the default assigned monitor using the xref:commands.adoc#move-workspace-to-monitor[move-workspace-to-monitor] reset command.
+The xref:commands.adoc#move-workspace-to-monitor[move-workspace-to-monitor] command has no effect for workspaces that have forced monitor assignment
+
+`workspace-to-monitor-force-assignment` will always have preference over `workspace-to-monitor-default-assignment`.
 
 [source,toml]
 ----
 [workspace-to-monitor-force-assignment]
+1 = 1                            # Monitor sequence number from left to right. 1-based indexing
+2 = 'main'                       # Main monitor
+3 = 'secondary'                  # Non-main monitor in case when there are only two monitors
+4 = 'built-in'                   # Case insensitive regex substring
+5 = '^built-in retina display$'  # Case insensitive regex match
+6 = ['secondary', 'dell']        # You can specify multiple patterns. The first matching pattern will be used
+
+[workspace-to-monitor-default-assignment]
 1 = 1                            # Monitor sequence number from left to right. 1-based indexing
 2 = 'main'                       # Main monitor
 3 = 'secondary'                  # Non-main monitor in case when there are only two monitors
@@ -669,8 +683,6 @@ Supported monitor patterns:
 
 You can specify multiple patterns as an array.
 The first matching pattern will be used
-
-xref:commands.adoc#move-workspace-to-monitor[move-workspace-to-monitor] command has no effect for workspaces that have monitor assignment
 
 == Dialog heuristics
 


### PR DESCRIPTION
Added the possibility to add a default assigned monitor to a workspace, as suggested in https://github.com/nikitabobko/AeroSpace/issues/752#issue-2687386754.
Default assigned monitor works similarly to force assigned monitor, though the move-workspace-to-monitor command will work in this case. The move-workspace-to-monitor reset command can be used to reset to the default monitor (defaults to main). Force assigned monitor will always have priority over default assigned monitor.