### PR TITLE
feat: add `--boundaries` options to move command

### DIFF
--- a/Sources/AppBundle/command/impl/MoveCommand.swift
+++ b/Sources/AppBundle/command/impl/MoveCommand.swift
@@ -26,13 +26,13 @@ struct MoveCommand: Command {
                     return true
                 } else {
                     if moveOut(io, window: currentWindow, direction: direction) {
-                        return true;
+                        return true
                     } else if args.boundaries == .allMonitorsUnionFrame {
                         let moveNodeToMonitor = args.moveNodeToMonitor.copy(\.target, .initialized(.directional(direction)))
                         return MoveNodeToMonitorCommand(args: moveNodeToMonitor).run(env, io)
                     } else {
                         io.err("Window is not moved. Tip: use --fail-if-noop to exit with non-zero exit code")
-                        return !args.failIfNoop;
+                        return !args.failIfNoop
                     }
                 }
             case .workspace: // floating window
@@ -65,7 +65,7 @@ private func moveOut(_ io: CmdIo, window: Window, direction: CardinalDirection) 
             bindToIndex = innerMostChild.ownIndex + direction.insertionOffset
         case .workspace(let parent): // create implicit container
             if !canMoveOutInDirection(window: window, direction: direction) {
-                return false;
+                return false
             }
 
             let prevRoot = parent.rootTilingContainer
@@ -90,7 +90,7 @@ private func moveOut(_ io: CmdIo, window: Window, direction: CardinalDirection) 
         adaptiveWeight: WEIGHT_AUTO,
         index: bindToIndex
     )
-    return true;
+    return true
 }
 
 private func canMoveOutInDirection(window: Window, direction: CardinalDirection) -> Bool {

--- a/Sources/AppBundle/command/impl/MoveCommand.swift
+++ b/Sources/AppBundle/command/impl/MoveCommand.swift
@@ -25,7 +25,12 @@ struct MoveCommand: Command {
                     }
                     return true
                 } else {
-                    return moveOut(io, window: currentWindow, direction: direction)
+                    if moveOut(io, window: currentWindow, direction: direction) {
+                        return true;
+                    } else {
+                        io.err("Window is not moved. Tip: use --fail-if-noop to exit with non-zero exit code")
+                        return !args.failIfNoop;
+                    }
                 }
             case .workspace: // floating window
                 return io.err("moving floating windows isn't yet supported") // todo

--- a/Sources/AppBundle/command/impl/MoveCommand.swift
+++ b/Sources/AppBundle/command/impl/MoveCommand.swift
@@ -48,6 +48,7 @@ private func moveOut(_ io: CmdIo, window: Window, direction: CardinalDirection) 
                  .macosHiddenAppsWindowsContainer, .macosPopupWindowsContainer: true
         }
     }) as! TilingContainer
+    let lastAppliedLayoutVirtualRect: Rect? = window.lastAppliedLayoutVirtualRect
     let bindTo: TilingContainer
     let bindToIndex: Int
     switch innerMostChild.parent.nodeCases {
@@ -78,7 +79,7 @@ private func moveOut(_ io: CmdIo, window: Window, direction: CardinalDirection) 
         adaptiveWeight: WEIGHT_AUTO,
         index: bindToIndex
     )
-    return true
+    return window.lastAppliedLayoutVirtualRect != lastAppliedLayoutVirtualRect;
 }
 
 private func deepMoveIn(window: Window, into container: TilingContainer, moveDirection: CardinalDirection) {

--- a/Sources/AppBundle/command/impl/MoveCommand.swift
+++ b/Sources/AppBundle/command/impl/MoveCommand.swift
@@ -27,6 +27,9 @@ struct MoveCommand: Command {
                 } else {
                     if moveOut(io, window: currentWindow, direction: direction) {
                         return true;
+                    } else if args.boundaries == .allMonitorsUnionFrame {
+                        let moveNodeToMonitor = args.moveNodeToMonitor.copy(\.target, .initialized(.directional(direction)))
+                        return MoveNodeToMonitorCommand(args: moveNodeToMonitor).run(env, io)
                     } else {
                         io.err("Window is not moved. Tip: use --fail-if-noop to exit with non-zero exit code")
                         return !args.failIfNoop;

--- a/Sources/AppBundle/command/impl/MoveNodeToMonitorCommand.swift
+++ b/Sources/AppBundle/command/impl/MoveNodeToMonitorCommand.swift
@@ -14,9 +14,12 @@ struct MoveNodeToMonitorCommand: Command {
             return io.err(windowIsntPartOfTree(window))
         }
         switch args.target.val.resolve(currentMonitor, wrapAround: args.wrapAround) {
-            case .success(let targetMonitor):
+            case .success(let (targetMonitor, targetIndex)):
                 if let wName = WorkspaceName.parse(targetMonitor.activeWorkspace.name).getOrNil(appendErrorTo: &io.stderr) {
-                    let moveNodeToWorkspace = args.moveNodeToWorkspace.copy(\.target, .initialized(.direct(wName)))
+                    let moveNodeToWorkspace = (args.moveNodeToWorkspace
+                        .copy(\.target, .initialized(.direct(wName)))
+                        .copy(\.targetIndex, targetIndex)
+                    )
                     return MoveNodeToWorkspaceCommand(args: moveNodeToWorkspace).run(env, io)
                 } else {
                     return false

--- a/Sources/AppBundle/command/impl/MoveNodeToWorkspaceCommand.swift
+++ b/Sources/AppBundle/command/impl/MoveNodeToWorkspaceCommand.swift
@@ -29,7 +29,7 @@ struct MoveNodeToWorkspaceCommand: Command {
         }
         let targetContainer: NonLeafTreeNodeObject = window.isFloating ? targetWorkspace : targetWorkspace.rootTilingContainer
 
-        window.bind(to: targetContainer, adaptiveWeight: WEIGHT_AUTO, index: INDEX_BIND_LAST)
+        window.bind(to: targetContainer, adaptiveWeight: WEIGHT_AUTO, index: args.targetIndex)
         return args.focusFollowsWindow ? window.focusWindow() : true
     }
 }

--- a/Sources/AppBundle/model/Rect.swift
+++ b/Sources/AppBundle/model/Rect.swift
@@ -1,7 +1,7 @@
 import AppKit
 import Common
 
-struct Rect: Copyable, Equatable {
+struct Rect: Copyable {
     var topLeftX: CGFloat
     var topLeftY: CGFloat
     var width: CGFloat

--- a/Sources/AppBundle/model/Rect.swift
+++ b/Sources/AppBundle/model/Rect.swift
@@ -1,7 +1,7 @@
 import AppKit
 import Common
 
-struct Rect: Copyable {
+struct Rect: Copyable, Equatable {
     var topLeftX: CGFloat
     var topLeftY: CGFloat
     var width: CGFloat

--- a/Sources/Common/cmdArgs/impl/MoveCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/MoveCmdArgs.swift
@@ -1,3 +1,5 @@
+private let boundar = "<boundary>"
+
 public struct MoveCmdArgs: CmdArgs {
     public let rawArgs: EquatableNoop<[String]>
     fileprivate init(rawArgs: [String]) { self.rawArgs = .init(rawArgs) }
@@ -6,23 +8,51 @@ public struct MoveCmdArgs: CmdArgs {
         allowInConfig: true,
         help: move_help_generated,
         options: [
+            // "Own" option
+            "--boundaries": ArgParser(\.rawBoundaries, upcastArgParserFun(parseBoundaries)),
             "--fail-if-noop": trueBoolFlag(\.failIfNoop),
+
+            // Forward to moveNodeToMonitor
             "--window-id": optionalWindowIdFlag(),
+            "--wrap-around": trueBoolFlag(\.moveNodeToMonitor.wrapAround),
+            "--focus-follows-window": trueBoolFlag(\.moveNodeToMonitor.moveNodeToWorkspace.focusFollowsWindow),
         ],
         arguments: [newArgParser(\.direction, parseCardinalDirectionArg, mandatoryArgPlaceholder: CardinalDirection.unionLiteral)]
     )
 
     public var direction: Lateinit<CardinalDirection> = .uninitialized
-    public var windowId: UInt32?
+    public var windowId: UInt32? { // Forward to moveNodeToMonitor
+        get { moveNodeToMonitor.windowId }
+        set(newValue) { moveNodeToMonitor.windowId = newValue }
+    }
     public var workspaceName: WorkspaceName?
     public var failIfNoop: Bool = false
+    public var rawBoundaries: Boundaries? = nil
+    public var moveNodeToMonitor = MoveNodeToMonitorCmdArgs(rawArgs: [])
 
     public init(rawArgs: [String], _ direction: CardinalDirection) {
         self.rawArgs = .init(rawArgs)
         self.direction = .initialized(direction)
     }
+
+    public enum Boundaries: String, CaseIterable, Equatable {
+        case workspace
+        case allMonitorsUnionFrame = "all-monitors-outer-frame"
+    }
+}
+
+public extension MoveCmdArgs {
+    var boundaries: Boundaries { rawBoundaries ?? .workspace }
 }
 
 public func parseMoveCmdArgs(_ args: [String]) -> ParsedCmd<MoveCmdArgs> {
     parseSpecificCmdArgs(MoveCmdArgs(rawArgs: args), args)
+}
+
+private func parseBoundaries(arg: String, nextArgs: inout [String]) -> Parsed<MoveCmdArgs.Boundaries> {
+    if let arg = nextArgs.nextNonFlagOrNil() {
+        return parseEnum(arg, MoveCmdArgs.Boundaries.self)
+    } else {
+        return .failure("\(boundar) is mandatory")
+    }
 }

--- a/Sources/Common/cmdArgs/impl/MoveCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/MoveCmdArgs.swift
@@ -6,6 +6,7 @@ public struct MoveCmdArgs: CmdArgs {
         allowInConfig: true,
         help: move_help_generated,
         options: [
+            "--fail-if-noop": trueBoolFlag(\.failIfNoop),
             "--window-id": optionalWindowIdFlag(),
         ],
         arguments: [newArgParser(\.direction, parseCardinalDirectionArg, mandatoryArgPlaceholder: CardinalDirection.unionLiteral)]
@@ -14,6 +15,7 @@ public struct MoveCmdArgs: CmdArgs {
     public var direction: Lateinit<CardinalDirection> = .uninitialized
     public var windowId: UInt32?
     public var workspaceName: WorkspaceName?
+    public var failIfNoop: Bool = false
 
     public init(rawArgs: [String], _ direction: CardinalDirection) {
         self.rawArgs = .init(rawArgs)

--- a/Sources/Common/cmdArgs/impl/MoveNodeToMonitorCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/MoveNodeToMonitorCmdArgs.swift
@@ -1,6 +1,6 @@
 public struct MoveNodeToMonitorCmdArgs: CmdArgs {
     public let rawArgs: EquatableNoop<[String]>
-    fileprivate init(rawArgs: [String]) { self.rawArgs = .init(rawArgs) }
+    public init(rawArgs: [String]) { self.rawArgs = .init(rawArgs) }
     public static let parser: CmdParser<Self> = cmdParser(
         kind: .moveNodeToMonitor,
         allowInConfig: true,

--- a/Sources/Common/cmdArgs/impl/MoveNodeToWorkspaceCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/MoveNodeToWorkspaceCmdArgs.swift
@@ -19,6 +19,7 @@ public struct MoveNodeToWorkspaceCmdArgs: CmdArgs {
     public var windowId: UInt32?
     public var workspaceName: WorkspaceName?
     public var target: Lateinit<WorkspaceTarget> = .uninitialized
+    public var targetIndex: Int = -1 // = INDEX_BIND_LAST
 
     public init(rawArgs: [String]) {
         self.rawArgs = .init(rawArgs)

--- a/Sources/Common/cmdHelpGenerated.swift
+++ b/Sources/Common/cmdHelpGenerated.swift
@@ -109,7 +109,8 @@ let move_workspace_to_monitor_help_generated = """
     USAGE: move-workspace-to-monitor [-h|--help] [--workspace <workspace>] [--wrap-around] (next|prev)
     """
 let move_help_generated = """
-    USAGE: move [-h|--help] [--window-id <window-id>] (left|down|up|right)
+    USAGE: move [-h|--help] [--window-id <window-id>] [--focus-follows-window]
+                [--fail-if-noop] [--boundaries <boundary>] [--wrap-around] (left|down|up|right)
     """
 let reload_config_help_generated = """
     USAGE: reload-config [-h|--help] [--no-gui] [--dry-run]

--- a/Sources/Common/model/CardinalDirection.swift
+++ b/Sources/Common/model/CardinalDirection.swift
@@ -14,5 +14,6 @@ public extension CardinalDirection {
         }
     }
     var focusOffset: Int { isPositive ? 1 : -1 }
+    var focusMonitorOffset: Int { isPositive ? 0 : -1 }
     var insertionOffset: Int { isPositive ? 1 : 0 }
 }

--- a/docs/aerospace-move.adoc
+++ b/docs/aerospace-move.adoc
@@ -9,7 +9,8 @@ include::util/man-attributes.adoc[]
 == Synopsis
 [verse]
 // tag::synopsis[]
-aerospace move [-h|--help] [--window-id <window-id>] (left|down|up|right)
+aerospace move [-h|--help] [--window-id <window-id>] [--focus-follows-window]
+               [--fail-if-noop] [--boundaries <boundary>] [--wrap-around] (left|down|up|right)
 
 // end::synopsis[]
 
@@ -25,6 +26,17 @@ Deprecated name: `move-through`
 include::./util/conditional-options-header.adoc[]
 
 -h, --help:: Print help
+--fail-if-noop:: Exit with a non-zero status if the window cannot move because it’s at the boundary
+--wrap-around:: Make it possible to wrap around the movement
+
+--boundaries <boundary>::
+Defines move boundaries. +
+`<boundary>` possible values: `(workspace|all-monitors-outer-frame)`. +
+The default is: `workspace`
+
+--focus-follows-window::
+Make sure that the window in question receives focus after moving.
+This flag is a shortcut for manually running `aerospace-workspace`/`aerospace-focus` after `move` successful execution.
 
 --window-id <window-id>::
 include::./util/window-id-flag-desc.adoc[]

--- a/grammar/commands-bnf-grammar.txt
+++ b/grammar/commands-bnf-grammar.txt
@@ -43,7 +43,7 @@ aerospace -h;
 
     | mode <mode_id>
 
-    | move [--window-id <window_id>] (left|down|up|right) [--window-id <window_id>]
+    | move [<move_flag>]... (left|down|up|right) [<move_flag>]...
 
     | move-mouse [--fail-if-noop] (monitor-lazy-center|monitor-force-center|window-lazy-center|window-force-center) [--fail-if-noop]
 
@@ -103,6 +103,8 @@ aerospace -h;
 <monitor_pattern> ::= {{{ true }}};
 
 <list_workspaces1_flag> ::= --visible [no] | --empty [no] | --format <output_format> | --format <output_format> | --count | --json;
+
+<move_flag> ::= --boundaries <boundary>|--window-id <window-id>|--focus-follows-window|--fail-if-noop|--wrap-around;
 
 <move_node_to_monitor1_flag> ::= --window-id <window_id>|--focus-follows-window|--fail-if-noop|--wrap-around;
 <move_node_to_monitor2_flag> ::= --window-id <window_id>|--focus-follows-window|--fail-if-noop;


### PR DESCRIPTION
## Summary
- Resolves #183

This PR introduces a new `--boundaries` option to the move command, allowing windows to move beyond their current workspace.

By default, window movements remain within a single workspace. With `--boundaries all-monitors-outer-frame`, windows can now be moved across multiple monitors for increased flexibility.

## Key Changes

`move` Command Updates:

```diff
- aerospace move [-h|--help] [--window-id <window-id>] (left|down|up|right)
+ aerospace move [-h|--help] [--window-id <window-id>] [--focus-follows-window]
+                [--fail-if-noop] [--boundaries <boundary>] [--wrap-around] (left|down|up|right)
```

- `--boundaries <boundary>`: Choose between staying within the `workspace` or `all-monitors-outer-frame`.
- `--wrap-around`: Cycle through monitors when reaching an edge.
- `--focus-follows-window:` Automatically focus the moved window.
- `--fail-if-noop`: Exit with a non-zero status if the window cannot move (e.g., hitting the boundary without `--boundaries all-monitors-outer-frame`).

## Why?

These enhancements provide more control over window movement in multi-monitor setups and improve scripting scenarios by offering fail-fast behavior, wrap-around cycling, and automatic refocusing.

## Example

```toml
# aerospace.toml
ctrl-alt-left = "move left --boundaries all-monitors-outer-frame --focus-follows-window"
ctrl-alt-down = "move down --boundaries all-monitors-outer-frame --focus-follows-window"
ctrl-alt-up = "move up --boundaries all-monitors-outer-frame --focus-follows-window"
ctrl-alt-right = "move right --boundaries all-monitors-outer-frame --focus-follows-window"
```