### PR TITLE
Add Ghostty to Application Id List

### DIFF
--- a/docs/goodies.adoc
+++ b/docs/goodies.adoc
@@ -258,6 +258,7 @@ The list is useful to compose custom xref:guide.adoc#on-window-detected-callback
 |Finder|`com.apple.finder`
 |Firefox|`org.mozilla.firefox`
 |Freeform|`com.apple.freeform`
+|Ghostty|`com.mitchellh.ghostty`
 |GIMP|`org.gimp.gimp-2.10`
 |Google Chrome|`com.google.Chrome`
 |Grapher|`com.apple.grapher`


### PR DESCRIPTION
This is a very small tweak that adds the Application ID for [Ghostty](https://ghostty.org/) to the Goodies page. With Kitty, WezTerm, and Alacritty on the list already I figured this would be a good addition. 