### PR TITLE
Add basic support for azerty

### DIFF
--- a/Sources/AppBundle/config/keysMap.swift
+++ b/Sources/AppBundle/config/keysMap.swift
@@ -46,6 +46,7 @@ func getKeysPreset(_ layout: KeyMapping.Preset) -> [String: Key] {
     return switch layout {
         case .qwerty: keyNotationToKeyCode
         case .dvorak: dvorakMap
+        case .azerty: azertyMap
     }
 }
 
@@ -194,6 +195,16 @@ private let dvorakMap: [String: Key] = keyNotationToKeyCode + [
     w: .comma,
     v: .period,
     z: .slash,
+]
+
+private let azertyMap: [String: Key] = keyNotationToKeyCode + [
+    a: .q,
+    q: .a,
+    z: .w,
+    w: .z,
+    m: .semicolon,
+    comma: .m,
+    semicolon: .comma
 ]
 
 let modifiersMap: [String: NSEvent.ModifierFlags] = [

--- a/Sources/AppBundle/config/parseKeyMapping.swift
+++ b/Sources/AppBundle/config/parseKeyMapping.swift
@@ -9,7 +9,7 @@ private let keyMappingParser: [String: any ParserProtocol<KeyMapping>] = [
 
 struct KeyMapping: Copyable, Equatable {
     enum Preset: String, CaseIterable {
-        case qwerty, dvorak
+        case qwerty, dvorak, azerty
     }
 
     public init(

--- a/docs/config-examples/default-config.toml
+++ b/docs/config-examples/default-config.toml
@@ -43,7 +43,7 @@ on-focused-monitor-changed = ['move-mouse monitor-lazy-center']
 # Also see: https://nikitabobko.github.io/AeroSpace/goodies#disable-hide-app
 automatically-unhide-macos-hidden-apps = false
 
-# Possible values: (qwerty|dvorak)
+# Possible values: (qwerty|dvorak|azerty)
 # See https://nikitabobko.github.io/AeroSpace/guide#key-mapping
 [key-mapping]
     preset = 'qwerty'


### PR DESCRIPTION
Might resolve #195

Add support for azerty keyboards. I intentionally left the number-rows as-is since I didn't run into any issues using the qwerty layout. When I press the button with the number 5 on it, I go to workspace number 5, so this seems to work as intended (although technically I pressed the "("-key).