### PR TITLE
Implement list-modes command

### DIFF
--- a/Sources/AppBundle/command/cmdManifest.swift
+++ b/Sources/AppBundle/command/cmdManifest.swift
@@ -36,6 +36,8 @@ extension CmdArgs {
                 command = ListAppsCommand(args: self as! ListAppsCmdArgs)
             case .listExecEnvVars:
                 command = ListExecEnvVarsCommand(args: self as! ListExecEnvVarsCmdArgs)
+            case .listModes:
+                command = ListModesCommand(args: self as! ListModesCmdArgs)
             case .listMonitors:
                 command = ListMonitorsCommand(args: self as! ListMonitorsCmdArgs)
             case .listWindows:

--- a/Sources/AppBundle/command/impl/ListModesCommand.swift
+++ b/Sources/AppBundle/command/impl/ListModesCommand.swift
@@ -1,0 +1,17 @@
+import AppKit
+import Common
+
+struct ListModesCommand: Command {
+    let args: ListModesCmdArgs
+
+    func run(_ env: CmdEnv, _ io: CmdIo) -> Bool {
+        check(Thread.current.isMainThread)
+
+        if args.current {
+            return io.out(activeMode ?? mainModeId)
+        } else {
+            let modeNames: [String] = config.modes.map { $0.key }
+            return io.out(modeNames)
+        }
+    }
+}

--- a/Sources/AppBundleTests/command/ListModesTest.swift
+++ b/Sources/AppBundleTests/command/ListModesTest.swift
@@ -1,0 +1,12 @@
+@testable import AppBundle
+import Common
+import XCTest
+
+final class ListModesTest: XCTestCase {
+    override func setUpWithError() throws { setUpWorkspacesForTests() }
+
+    func testParseListModesCommand() {
+        testParseCommandSucc("list-modes", ListModesCmdArgs(rawArgs: []))
+        testParseCommandSucc("list-modes --current", ListModesCmdArgs(rawArgs: []).copy(\.current, true))
+    }
+}

--- a/Sources/Cli/subcommandDescriptionsGenerated.swift
+++ b/Sources/Cli/subcommandDescriptionsGenerated.swift
@@ -17,6 +17,7 @@ let subcommandDescriptions = [
     ["  layout", "Change layout of the focused window to the given layout"],
     ["  list-apps", "Print the list of running applications that appears in the Dock and may have a user interface"],
     ["  list-exec-env-vars", "List environment variables that exec-* commands and callbacks are run with"],
+    ["  list-modes", "Print a list of modes currently specified in the configuration"],
     ["  list-monitors", "Print monitors that satisfy conditions"],
     ["  list-windows", "Print windows that satisfy conditions"],
     ["  list-workspaces", "Print workspaces that satisfy conditions"],

--- a/Sources/Common/cmdArgs/cmdArgsManifest.swift
+++ b/Sources/Common/cmdArgs/cmdArgsManifest.swift
@@ -17,6 +17,7 @@ public enum CmdKind: String, CaseIterable, Equatable {
     case layout
     case listApps = "list-apps"
     case listExecEnvVars = "list-exec-env-vars"
+    case listModes = "list-modes"
     case listMonitors = "list-monitors"
     case listWindows = "list-windows"
     case listWorkspaces = "list-workspaces"
@@ -76,6 +77,8 @@ func initSubcommands() -> [String: any SubCommandParserProtocol] {
                 result[kind.rawValue] = SubCommandParser(parseListAppsCmdArgs)
             case .listExecEnvVars:
                 result[kind.rawValue] = SubCommandParser(ListExecEnvVarsCmdArgs.init)
+            case .listModes:
+                result[kind.rawValue] = SubCommandParser(parseListModesCmdArgs)
             case .listMonitors:
                 result[kind.rawValue] = SubCommandParser(parseListMonitorsCmdArgs)
             case .listWindows:

--- a/Sources/Common/cmdArgs/impl/ListModesCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/ListModesCmdArgs.swift
@@ -1,0 +1,23 @@
+public struct ListModesCmdArgs: CmdArgs {
+    public let rawArgs: EquatableNoop<[String]>
+    public init(rawArgs: [String]) {
+        self.rawArgs = .init(rawArgs)
+    }
+    public static var parser: CmdParser<Self> = cmdParser(
+        kind: .listModes,
+        allowInConfig: false,
+        help: list_modes_help_generated,
+        options: [
+            "--current": trueBoolFlag(\.current),
+        ],
+        arguments: []
+    )
+
+    public var windowId: UInt32?               // unused
+    public var workspaceName: WorkspaceName?   // unused
+    public var current: Bool = false
+}
+
+public func parseListModesCmdArgs(_ args: [String]) -> ParsedCmd<ListModesCmdArgs> {
+    parseSpecificCmdArgs(ListModesCmdArgs(rawArgs: args), args)
+}

--- a/Sources/Common/cmdHelpGenerated.swift
+++ b/Sources/Common/cmdHelpGenerated.swift
@@ -63,6 +63,9 @@ let list_apps_help_generated = """
 let list_exec_env_vars_help_generated = """
     USAGE: list-exec-env-vars [-h|--help]
     """
+let list_modes_help_generated = """
+    USAGE: list-modes [-h|--help] [--current]
+    """
 let list_monitors_help_generated = """
     USAGE: list-monitors [-h|--help] [--focused [no]] [--mouse [no]] [--format <output-format>] [--count] [--json]
     """

--- a/docs/aerospace-list-modes.adoc
+++ b/docs/aerospace-list-modes.adoc
@@ -1,0 +1,34 @@
+= aerospace-list-modes(1)
+include::util/man-attributes.adoc[]
+// tag::purpose[]
+:manpurpose: Print a list of modes currently specified in the configuration
+// end::purpose[]
+:manname: aerospace-list-modes
+
+// =========================================================== Synopsis
+== Synopsis
+[verse]
+// tag::synopsis[]
+aerospace list-modes [-h|--help] [--current]
+
+// end::synopsis[]
+
+// =========================================================== Description
+== Description
+
+// tag::body[]
+{manpurpose}
+
+See xref:guide.adoc#binding-modes[the guide] for documentation about binding modes
+// end::body[]
+
+// =========================================================== Options
+include::util/conditional-options-header.adoc[]
+
+-h, --help:: Print help
+
+--current::
+Only print the currently active mode
+
+// =========================================================== Footer
+include::util/man-footer.adoc[]

--- a/docs/commands.adoc
+++ b/docs/commands.adoc
@@ -239,6 +239,13 @@ include::aerospace-list-exec-env-vars.adoc[tags=synopsis]
 include::aerospace-list-exec-env-vars.adoc[tags=purpose]
 include::aerospace-list-exec-env-vars.adoc[tags=body]
 
+=== list-modes
+----
+include::aerospace-list-modes.adoc[tags=synopsis]
+----
+include::aerospace-list-modes.adoc[tags=purpose]
+include::aerospace-list-modes.adoc[tags=body]
+
 === list-monitors
 ----
 include::aerospace-list-monitors.adoc[tags=synopsis]

--- a/grammar/commands-bnf-grammar.txt
+++ b/grammar/commands-bnf-grammar.txt
@@ -86,6 +86,8 @@ aerospace -h;
 
     | list-exec-env-vars
 
+    | list-modes [--current]
+
     | list-monitors [--focused [no] | --mouse [no] | --format <output_format> | --count | --json]...
 
     | list-windows [<list_windows_filter_flag> | --format <output_format> | --count | --json]...


### PR DESCRIPTION
Adds a new command `list-modes` which lists modes currently known to AeroSpace. This is to solve issue https://github.com/nikitabobko/AeroSpace/issues/377. I have not added support for formats, JSON, or anything like that.

I am not sure if I have found every file to update with a new command (like docs, and so on), so just tell me if I need to add it somewhere else.