### PR TITLE
New menu bar option for i3-like functionality #844

### DIFF
--- a/Sources/AeroSpaceApp/AeroSpaceApp.swift
+++ b/Sources/AeroSpaceApp/AeroSpaceApp.swift
@@ -8,6 +8,7 @@ import SwiftUI
 struct AeroSpaceApp: App {
     @MainActor // macOS 13
     @StateObject var viewModel = TrayMenuModel.shared
+    @StateObject var appearance = Appearance.shared
 
     init() {
         initAppBundle()
@@ -15,6 +16,6 @@ struct AeroSpaceApp: App {
 
     @MainActor // macOS 13
     var body: some Scene {
-        menuBar(viewModel: viewModel)
+        menuBar(viewModel: viewModel, appearance: appearance)
     }
 }

--- a/Sources/AppBundle/ExperimentalUISettings.swift
+++ b/Sources/AppBundle/ExperimentalUISettings.swift
@@ -1,0 +1,68 @@
+import AppKit
+import SwiftUI
+
+struct ExperimentalUISettings {
+    var displayStyle: MenuBarStyle {
+        get {
+            if let value = UserDefaults.standard.string(forKey: ExperimentalUISettingsItems.displayStyle.rawValue) {
+                return MenuBarStyle(rawValue: value) ?? .monospacedText
+            } else {
+                return .monospacedText
+            }
+        }
+        set {
+            UserDefaults.standard.setValue(newValue.rawValue, forKey: ExperimentalUISettingsItems.displayStyle.rawValue)
+            UserDefaults.standard.synchronize()
+        }
+    }
+}
+
+enum ExperimentalUISettingsItems: String {
+    case displayStyle
+}
+
+@MainActor
+func getExperimentalUISettingsMenu(viewModel: TrayMenuModel) -> some View {
+    let appearence = NSApplication.shared.effectiveAppearance.name
+    let color = (appearence == .vibrantDark || appearence == .darkAqua) ? Color.white : Color.black
+    return Menu {
+        Text("These settings are EXPERIMENTAL.")
+        Text("No stability guarantees are provided.")
+        Divider()
+        Text("Menu bar style (macOS 14 or later):")
+        Text(MenuBarStyle.systemText.title)
+        Button {
+            viewModel.experimentalUISettings.displayStyle = .systemText
+        } label: {
+            Toggle(isOn: .constant(viewModel.experimentalUISettings.displayStyle == .systemText)) {
+                MenuBarLabel(viewModel.trayText, textStyle: .system, color: color)
+            }
+        }
+        Text(MenuBarStyle.monospacedText.title)
+        Button {
+            viewModel.experimentalUISettings.displayStyle = .monospacedText
+        } label: {
+            Toggle(isOn: .constant(viewModel.experimentalUISettings.displayStyle == .monospacedText)) {
+                MenuBarLabel(viewModel.trayText, color: color)
+            }
+        }
+        Text(MenuBarStyle.squares.title)
+        Button {
+            viewModel.experimentalUISettings.displayStyle = .squares
+        } label: {
+            Toggle(isOn: .constant(viewModel.experimentalUISettings.displayStyle == .squares)) {
+                MenuBarLabel(viewModel.trayText, color: color, trayItems: viewModel.trayItems)
+            }
+        }
+        Text(MenuBarStyle.i3.title)
+        Button {
+            viewModel.experimentalUISettings.displayStyle = .i3
+        } label: {
+            Toggle(isOn: .constant(viewModel.experimentalUISettings.displayStyle == .i3)) {
+                MenuBarLabel(viewModel.trayText, color: color, trayItems: viewModel.trayItems, workspaces: viewModel.workspaces)
+            }
+        }
+    } label: {
+        Text("Experimental UI Settings")
+    }
+}

--- a/Sources/AppBundle/MenuBar.swift
+++ b/Sources/AppBundle/MenuBar.swift
@@ -26,6 +26,8 @@ public func menuBar(viewModel: TrayMenuModel) -> some Scene { // todo should it 
             }
             Divider()
         }
+        getExperimentalUISettingsMenu(viewModel: viewModel)
+        Divider()
         Button(viewModel.isEnabled ? "Disable" : "Enable") {
             Task {
                 try await runSession(.menuBarButton, .forceRun) { () throws in
@@ -62,25 +64,51 @@ public func menuBar(viewModel: TrayMenuModel) -> some Scene { // todo should it 
         }.keyboardShortcut("Q", modifiers: .command)
     } label: {
         if viewModel.isEnabled {
-            MonospacedText(viewModel.trayText)
+            switch viewModel.experimentalUISettings.displayStyle {
+                case .systemText:
+                    MenuBarLabel(viewModel.trayText, textStyle: .system)
+                case .monospacedText:
+                    MenuBarLabel(viewModel.trayText)
+                case .squares:
+                    MenuBarLabel(viewModel.trayText, trayItems: viewModel.trayItems)
+                case .i3:
+                    MenuBarLabel(viewModel.trayText, trayItems: viewModel.trayItems, workspaces: viewModel.workspaces)
+            }
         } else {
-            MonospacedText("⏸️")
+            MenuBarLabel("⏸️")
         }
     }
 }
 
-struct MonospacedText: View {
+@MainActor
+struct MenuBarLabel: View {
     @Environment(\.colorScheme) var colorScheme: ColorScheme
     var text: String
-    init(_ text: String) { self.text = text }
+    var textStyle: MenuBarTextStyle
+    var color: Color?
+    var trayItems: [TrayItem]?
+    var workspaces: [WorkspaceViewModel]?
+
+    let hStackSpacing = CGFloat(4)
+    let itemHeight = CGFloat(40)
+    let itemBorderSize = CGFloat(4)
+    let itemCornerRadius = CGFloat(6)
+
+    var finalColor: Color {
+        return color ?? (colorScheme == .dark ? Color.white : Color.black)
+    }
+
+    init(_ text: String, textStyle: MenuBarTextStyle = .monospaced, color: Color? = nil, trayItems: [TrayItem]? = nil, workspaces: [WorkspaceViewModel]? = nil) {
+        self.text = text
+        self.textStyle = textStyle
+        self.color = color
+        self.trayItems = trayItems
+        self.workspaces = workspaces
+    }
 
     var body: some View {
         if #available(macOS 14, *) { // https://github.com/nikitabobko/AeroSpace/issues/1122
-            let renderer = ImageRenderer(
-                content: Text(text)
-                    .font(.system(.largeTitle, design: .monospaced))
-                    .foregroundStyle(colorScheme == .light ? Color.black : Color.white)
-            )
+            let renderer = ImageRenderer(content: menuBarContent)
             if let cgImage = renderer.cgImage {
                 // Using scale: 1 results in a blurry image for unknown reasons
                 Image(cgImage, scale: 2, label: Text(text))
@@ -91,6 +119,129 @@ struct MonospacedText: View {
         } else { // macOS 13 and lower
             Text(text)
         }
+    }
+
+    var menuBarContent: some View {
+        return ZStack {
+            if let trayItems {
+                HStack(spacing: hStackSpacing) {
+                    ForEach(trayItems, id: \.id) { item in
+                        itemView(for: item)
+                        if item.type == .mode {
+                            Text(":")
+                                .font(.system(.largeTitle, design: textStyle.design))
+                                .foregroundStyle(finalColor)
+                                .bold()
+                        }
+                    }
+                    if workspaces != nil {
+                        let otherWorkspaces = Workspace.all.filter { workspace in
+                            !workspace.isEffectivelyEmpty && !trayItems.contains(where: { item in item.type == .monitor && item.name == workspace.name })
+                        }
+                        if !otherWorkspaces.isEmpty {
+                            Group {
+                                Text("|")
+                                    .font(.system(.largeTitle, design: textStyle.design))
+                                    .foregroundStyle(finalColor)
+                                    .bold()
+                                    .padding(.bottom, 2)
+                                ForEach(otherWorkspaces, id: \.name) { item in
+                                    itemView(for: TrayItem(type: .monitor, name: item.name, isActive: false))
+                                }
+                            }
+                            .opacity(0.6)
+                        }
+                    }
+                }
+                .frame(height: itemHeight)
+            } else {
+                HStack(spacing: hStackSpacing) {
+                    Text(text)
+                        .font(.system(.largeTitle, design: textStyle.design))
+                        .foregroundStyle(finalColor)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    fileprivate func itemView(for item: TrayItem) -> some View {
+        if item.name.containsEmoji() {
+            // If workspace name contains emojis we use the plain emoji in text to avoid visibility issues scaling the emoji to fit the squares
+            Text(item.name)
+                .font(.system(.largeTitle, design: textStyle.design))
+                .foregroundStyle(finalColor)
+        } else {
+            if let imageName = item.systemImageName {
+                Image(systemName: imageName)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .symbolRenderingMode(.monochrome)
+                    .foregroundStyle(finalColor)
+            } else {
+                let text = Text(item.name)
+                    .font(.system(.largeTitle, design: textStyle.design))
+                    .bold()
+                    .padding(.horizontal, item.isActive ? itemBorderSize * 2 : itemBorderSize * 1.5)
+                    .frame(height: itemHeight)
+                if item.isActive {
+                    ZStack {
+                        text.foregroundStyle(.clear)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: itemCornerRadius, style: .circular)
+                            )
+                        text.blendMode(.destinationOut)
+                    }
+                    .compositingGroup()
+                    .foregroundStyle(finalColor)
+                } else {
+                    text
+                        .padding(.horizontal, itemBorderSize)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: itemCornerRadius, style: .circular)
+                                .strokeBorder(lineWidth: itemBorderSize)
+                        )
+                        .foregroundStyle(finalColor)
+                }
+            }
+        }
+    }
+}
+
+enum MenuBarTextStyle: String {
+    case monospaced
+    case system
+    var design: Font.Design {
+        switch self {
+            case .monospaced:
+                return .monospaced
+            case .system:
+                return .default
+        }
+    }
+}
+
+enum MenuBarStyle: String, CaseIterable, Identifiable, Equatable, Hashable {
+    case monospacedText
+    case systemText
+    case squares
+    case i3
+    var id: Int {
+        return self.hashValue
+    }
+    var title: String {
+        switch self {
+            case .monospacedText: "Monospaced font"
+            case .systemText: "System font"
+            case .squares: "Square images"
+            case .i3: "i3 style"
+        }
+    }
+}
+
+private extension String {
+    func containsEmoji() -> Bool {
+        unicodeScalars.contains { $0.properties.isEmoji && $0.properties.isEmojiPresentation }
     }
 }
 

--- a/Sources/AppBundle/TrayMenuModel.swift
+++ b/Sources/AppBundle/TrayMenuModel.swift
@@ -7,9 +7,11 @@ public class TrayMenuModel: ObservableObject {
     private init() {}
 
     @Published var trayText: String = ""
+    @Published var trayItems: [TrayItem] = []
     /// Is "layouting" enabled
     @Published var isEnabled: Bool = true
     @Published var workspaces: [WorkspaceViewModel] = []
+    @Published var experimentalUISettings: ExperimentalUISettings = ExperimentalUISettings()
 }
 
 @MainActor func updateTrayText() {
@@ -25,10 +27,51 @@ public class TrayMenuModel: ObservableObject {
         let monitor = $0.isVisible || !$0.isEffectivelyEmpty ? " - \($0.workspaceMonitor.name)" : ""
         return WorkspaceViewModel(name: $0.name, suffix: monitor, isFocused: focus.workspace == $0)
     }
+    var items = sortedMonitors.map {
+        TrayItem(type: .monitor, name: $0.activeWorkspace.name, isActive: $0.activeWorkspace == focus.workspace && sortedMonitors.count > 1)
+    }
+    let mode = activeMode?.takeIf { $0 != mainModeId }?.first?.lets { TrayItem(type: .mode, name: $0.uppercased(), isActive: true) }
+    if let mode {
+        items.insert(mode, at: 0)
+    }
+    TrayMenuModel.shared.trayItems = items
 }
 
-struct WorkspaceViewModel {
+struct WorkspaceViewModel: Hashable {
     let name: String
     let suffix: String
     let isFocused: Bool
+}
+
+enum TrayItemType: String, Hashable {
+    case mode
+    case monitor
+}
+
+private let validNumbers = "0" ... "9"
+private let validLetters = "A" ... "Z"
+
+struct TrayItem: Hashable, Identifiable {
+    let type: TrayItemType
+    let name: String
+    let isActive: Bool
+    var systemImageName: String? {
+        // System image type is only valid for single number and single capital char workspace name
+        guard name.count == 1 else { return nil }
+        guard validNumbers.contains(name) || validLetters.contains(name) else { return nil }
+        let lowercasedName = name.lowercased()
+        switch type {
+            case .mode:
+                return "\(lowercasedName).circle"
+            case .monitor:
+                if isActive {
+                    return "\(lowercasedName).square.fill"
+                } else {
+                    return "\(lowercasedName).square"
+                }
+        }
+    }
+    var id: String {
+        return type.rawValue + name
+    }
 }

--- a/Sources/AppBundle/ui/Appearance.swift
+++ b/Sources/AppBundle/ui/Appearance.swift
@@ -1,0 +1,28 @@
+//import AppKit
+import SwiftUI
+
+enum AppearanceType {
+    case light
+    case dark
+}
+
+@MainActor
+public class Appearance: ObservableObject {
+    public static let shared = Appearance()
+
+    private var appearanceObserver: NSKeyValueObservation?
+
+    private init() {
+        appearanceObserver = NSApp.observe(\.effectiveAppearance) { [weak self] app, _ in
+            Task { @MainActor in
+                let name = app.effectiveAppearance.name
+                let isDarkAppearance = name == .vibrantDark || name == .darkAqua || name == .accessibilityHighContrastDarkAqua || name == .accessibilityHighContrastVibrantDark
+                self?.appAppearance = isDarkAppearance ? .dark : .light
+            }
+        }
+    }
+
+    /// System Settings -> Appearance -> Light/Dark
+    /// This is the theme representing how the UI should look inside the app (this might be different than the menu bar color)
+    @Published var appAppearance: AppearanceType = .dark
+}

--- a/Sources/AppBundle/ui/Appearance.swift
+++ b/Sources/AppBundle/ui/Appearance.swift
@@ -1,4 +1,3 @@
-//import AppKit
 import SwiftUI
 
 enum AppearanceType {

--- a/Sources/AppBundle/ui/ExperimentalUISettings.swift
+++ b/Sources/AppBundle/ui/ExperimentalUISettings.swift
@@ -1,4 +1,3 @@
-import AppKit
 import SwiftUI
 
 struct ExperimentalUISettings {

--- a/Sources/AppBundle/ui/ExperimentalUISettings.swift
+++ b/Sources/AppBundle/ui/ExperimentalUISettings.swift
@@ -22,9 +22,8 @@ enum ExperimentalUISettingsItems: String {
 }
 
 @MainActor
-func getExperimentalUISettingsMenu(viewModel: TrayMenuModel) -> some View {
-    let appearence = NSApplication.shared.effectiveAppearance.name
-    let color = (appearence == .vibrantDark || appearence == .darkAqua) ? Color.white : Color.black
+func getExperimentalUISettingsMenu(viewModel: TrayMenuModel, appearance: Appearance) -> some View {
+    let color = appearance.appAppearance == .dark ? Color.white : Color.black
     return Menu {
         Text("Menu bar style (macOS 14 or later):")
         Button {

--- a/Sources/AppBundle/ui/ExperimentalUISettings.swift
+++ b/Sources/AppBundle/ui/ExperimentalUISettings.swift
@@ -26,43 +26,40 @@ func getExperimentalUISettingsMenu(viewModel: TrayMenuModel) -> some View {
     let appearence = NSApplication.shared.effectiveAppearance.name
     let color = (appearence == .vibrantDark || appearence == .darkAqua) ? Color.white : Color.black
     return Menu {
-        Text("These settings are EXPERIMENTAL.")
-        Text("No stability guarantees are provided.")
-        Divider()
         Text("Menu bar style (macOS 14 or later):")
-        Text(MenuBarStyle.systemText.title)
-        Button {
-            viewModel.experimentalUISettings.displayStyle = .systemText
-        } label: {
-            Toggle(isOn: .constant(viewModel.experimentalUISettings.displayStyle == .systemText)) {
-                MenuBarLabel(viewModel.trayText, textStyle: .system, color: color)
-            }
-        }
-        Text(MenuBarStyle.monospacedText.title)
         Button {
             viewModel.experimentalUISettings.displayStyle = .monospacedText
         } label: {
             Toggle(isOn: .constant(viewModel.experimentalUISettings.displayStyle == .monospacedText)) {
                 MenuBarLabel(viewModel.trayText, color: color)
+                Text(" -  " + MenuBarStyle.monospacedText.title)
             }
         }
-        Text(MenuBarStyle.squares.title)
+        Button {
+            viewModel.experimentalUISettings.displayStyle = .systemText
+        } label: {
+            Toggle(isOn: .constant(viewModel.experimentalUISettings.displayStyle == .systemText)) {
+                MenuBarLabel(viewModel.trayText, textStyle: .system, color: color)
+                Text(" -  " + MenuBarStyle.systemText.title)
+            }
+        }
         Button {
             viewModel.experimentalUISettings.displayStyle = .squares
         } label: {
             Toggle(isOn: .constant(viewModel.experimentalUISettings.displayStyle == .squares)) {
                 MenuBarLabel(viewModel.trayText, color: color, trayItems: viewModel.trayItems)
+                Text(" -  " + MenuBarStyle.squares.title)
             }
         }
-        Text(MenuBarStyle.i3.title)
         Button {
             viewModel.experimentalUISettings.displayStyle = .i3
         } label: {
             Toggle(isOn: .constant(viewModel.experimentalUISettings.displayStyle == .i3)) {
                 MenuBarLabel(viewModel.trayText, color: color, trayItems: viewModel.trayItems, workspaces: viewModel.workspaces)
+                Text(" -  " + MenuBarStyle.i3.title)
             }
         }
     } label: {
-        Text("Experimental UI Settings")
+        Text("Experimental UI Settings (No stability guarantees)")
     }
 }

--- a/Sources/AppBundle/ui/MenuBar.swift
+++ b/Sources/AppBundle/ui/MenuBar.swift
@@ -65,10 +65,10 @@ public func menuBar(viewModel: TrayMenuModel) -> some Scene { // todo should it 
     } label: {
         if viewModel.isEnabled {
             switch viewModel.experimentalUISettings.displayStyle {
-                case .systemText:
-                    MenuBarLabel(viewModel.trayText, textStyle: .system)
                 case .monospacedText:
                     MenuBarLabel(viewModel.trayText)
+                case .systemText:
+                    MenuBarLabel(viewModel.trayText, textStyle: .system)
                 case .squares:
                     MenuBarLabel(viewModel.trayText, trayItems: viewModel.trayItems)
                 case .i3:
@@ -134,9 +134,9 @@ struct MenuBarLabel: View {
                                 .bold()
                         }
                     }
-                    if workspaces != nil {
-                        let otherWorkspaces = Workspace.all.filter { workspace in
-                            !workspace.isEffectivelyEmpty && !trayItems.contains(where: { item in item.type == .monitor && item.name == workspace.name })
+                    if let workspaces {
+                        let otherWorkspaces = workspaces.filter { workspace in
+                            !workspace.isEffectivelyEmpty && !trayItems.contains(where: { item in item.type == .workspace && item.name == workspace.name })
                         }
                         if !otherWorkspaces.isEmpty {
                             Group {
@@ -146,7 +146,7 @@ struct MenuBarLabel: View {
                                     .bold()
                                     .padding(.bottom, 2)
                                 ForEach(otherWorkspaces, id: \.name) { item in
-                                    itemView(for: TrayItem(type: .monitor, name: item.name, isActive: false))
+                                    itemView(for: TrayItem(type: .workspace, name: item.name, isActive: false))
                                 }
                             }
                             .opacity(0.6)

--- a/Sources/AppBundle/ui/MenuBar.swift
+++ b/Sources/AppBundle/ui/MenuBar.swift
@@ -136,9 +136,7 @@ struct MenuBarLabel: View {
                         }
                     }
                     if let workspaces {
-                        let otherWorkspaces = workspaces.filter { workspace in
-                            !workspace.isEffectivelyEmpty && !trayItems.contains(where: { item in item.type == .workspace && item.name == workspace.name })
-                        }
+                        let otherWorkspaces = workspaces.filter { !$0.isEffectivelyEmpty && !$0.isVisible }
                         if !otherWorkspaces.isEmpty {
                             Group {
                                 Text("|")

--- a/Sources/AppBundle/ui/MenuBar.swift
+++ b/Sources/AppBundle/ui/MenuBar.swift
@@ -3,7 +3,7 @@ import Foundation
 import SwiftUI
 
 @MainActor
-public func menuBar(viewModel: TrayMenuModel) -> some Scene { // todo should it be converted to "SwiftUI struct"?
+public func menuBar(viewModel: TrayMenuModel, appearance: Appearance) -> some Scene { // todo should it be converted to "SwiftUI struct"?
     MenuBarExtra {
         let shortIdentification = "\(aeroSpaceAppName) v\(aeroSpaceAppVersion) \(gitShortHash)"
         let identification      = "\(aeroSpaceAppName) v\(aeroSpaceAppVersion) \(gitHash)"
@@ -26,7 +26,7 @@ public func menuBar(viewModel: TrayMenuModel) -> some Scene { // todo should it 
             }
             Divider()
         }
-        getExperimentalUISettingsMenu(viewModel: viewModel)
+        getExperimentalUISettingsMenu(viewModel: viewModel, appearance: appearance)
         Divider()
         Button(viewModel.isEnabled ? "Disable" : "Enable") {
             Task {
@@ -82,7 +82,7 @@ public func menuBar(viewModel: TrayMenuModel) -> some Scene { // todo should it 
 
 @MainActor
 struct MenuBarLabel: View {
-    @Environment(\.colorScheme) var colorScheme: ColorScheme
+    @Environment(\.colorScheme) var menuColorScheme: ColorScheme
     var text: String
     var textStyle: MenuBarTextStyle
     var color: Color?
@@ -94,8 +94,8 @@ struct MenuBarLabel: View {
     let itemBorderSize = CGFloat(4)
     let itemCornerRadius = CGFloat(6)
 
-    var finalColor: Color {
-        return color ?? (colorScheme == .dark ? Color.white : Color.black)
+    private var finalColor: Color {
+        return color ?? (menuColorScheme == .dark ? Color.white : Color.black)
     }
 
     init(_ text: String, textStyle: MenuBarTextStyle = .monospaced, color: Color? = nil, trayItems: [TrayItem]? = nil, workspaces: [WorkspaceViewModel]? = nil) {

--- a/Sources/AppBundle/ui/MenuBar.swift
+++ b/Sources/AppBundle/ui/MenuBar.swift
@@ -89,9 +89,10 @@ struct MenuBarLabel: View {
     var trayItems: [TrayItem]?
     var workspaces: [WorkspaceViewModel]?
 
-    let hStackSpacing = CGFloat(4)
-    let itemHeight = CGFloat(40)
+    let hStackSpacing = CGFloat(6)
+    let itemSize = CGFloat(40)
     let itemBorderSize = CGFloat(4)
+    let itemPadding = CGFloat(8)
     let itemCornerRadius = CGFloat(6)
 
     private var finalColor: Color {
@@ -141,10 +142,10 @@ struct MenuBarLabel: View {
                         if !otherWorkspaces.isEmpty {
                             Group {
                                 Text("|")
-                                    .font(.system(.largeTitle, design: textStyle.design))
+                                    .font(.system(.largeTitle))
                                     .foregroundStyle(finalColor)
                                     .bold()
-                                    .padding(.bottom, 2)
+                                    .padding(.bottom, 6)
                                 ForEach(otherWorkspaces, id: \.name) { item in
                                     itemView(for: TrayItem(type: .workspace, name: item.name, isActive: false))
                                 }
@@ -153,7 +154,7 @@ struct MenuBarLabel: View {
                         }
                     }
                 }
-                .frame(height: itemHeight)
+                .frame(height: itemSize)
             } else {
                 HStack(spacing: hStackSpacing) {
                     Text(text)
@@ -169,8 +170,9 @@ struct MenuBarLabel: View {
         if item.name.containsEmoji() {
             // If workspace name contains emojis we use the plain emoji in text to avoid visibility issues scaling the emoji to fit the squares
             Text(item.name)
-                .font(.system(.largeTitle, design: textStyle.design))
+                .font(.system(.largeTitle))
                 .foregroundStyle(finalColor)
+                .frame(height: itemSize)
         } else {
             if let imageName = item.systemImageName {
                 Image(systemName: imageName)
@@ -178,30 +180,30 @@ struct MenuBarLabel: View {
                     .aspectRatio(contentMode: .fit)
                     .symbolRenderingMode(.monochrome)
                     .foregroundStyle(finalColor)
+                    .frame(width: itemSize, height: itemSize)
             } else {
                 let text = Text(item.name)
-                    .font(.system(.largeTitle, design: textStyle.design))
+                    .font(.system(.largeTitle))
                     .bold()
-                    .padding(.horizontal, item.isActive ? itemBorderSize * 2 : itemBorderSize * 1.5)
-                    .frame(height: itemHeight)
+                    .padding(.horizontal, itemBorderSize * 2)
+                    .frame(height: itemSize)
                 if item.isActive {
                     ZStack {
-                        text.foregroundStyle(.clear)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: itemCornerRadius, style: .circular)
-                            )
+                        text.background {
+                            RoundedRectangle(cornerRadius: itemCornerRadius, style: .circular)
+                        }
                         text.blendMode(.destinationOut)
                     }
                     .compositingGroup()
                     .foregroundStyle(finalColor)
+                    .frame(height: itemSize)
                 } else {
-                    text
-                        .padding(.horizontal, itemBorderSize)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: itemCornerRadius, style: .circular)
-                                .strokeBorder(lineWidth: itemBorderSize)
-                        )
-                        .foregroundStyle(finalColor)
+                    text.background {
+                        RoundedRectangle(cornerRadius: itemCornerRadius, style: .circular)
+                            .strokeBorder(lineWidth: itemBorderSize)
+                    }
+                    .foregroundStyle(finalColor)
+                    .frame(height: itemSize)
                 }
             }
         }

--- a/Sources/AppBundle/ui/TrayMenuModel.swift
+++ b/Sources/AppBundle/ui/TrayMenuModel.swift
@@ -28,7 +28,7 @@ public class TrayMenuModel: ObservableObject {
         return WorkspaceViewModel(name: $0.name, suffix: monitor, isFocused: focus.workspace == $0, isEffectivelyEmpty: $0.isEffectivelyEmpty)
     }
     var items = sortedMonitors.map {
-        TrayItem(type: .workspace, name: $0.activeWorkspace.name, isActive: $0.activeWorkspace == focus.workspace && sortedMonitors.count > 1)
+        TrayItem(type: .workspace, name: $0.activeWorkspace.name, isActive: $0.activeWorkspace == focus.workspace)
     }
     let mode = activeMode?.takeIf { $0 != mainModeId }?.first?.lets { TrayItem(type: .mode, name: $0.uppercased(), isActive: true) }
     if let mode {
@@ -49,7 +49,6 @@ enum TrayItemType: String, Hashable {
     case workspace
 }
 
-private let validNumbers = (0 ... 50).map { String($0) }
 private let validLetters = "A" ... "Z"
 
 struct TrayItem: Hashable, Identifiable {
@@ -58,8 +57,13 @@ struct TrayItem: Hashable, Identifiable {
     let isActive: Bool
     var systemImageName: String? {
         // System image type is only valid for numbers 0 to 50 and single capital char workspace name
-        guard name.count <= 2 else { return nil }
-        guard validNumbers.contains(name) || validLetters.contains(name) else { return nil }
+        if let number = Int(name) {
+            guard number >= 0 && number <= 50 else { return nil }
+        } else if name.count == 1 {
+            guard validLetters.contains(name) else { return nil }
+        } else {
+            return nil
+        }
         let lowercasedName = name.lowercased()
         switch type {
             case .mode:

--- a/Sources/AppBundle/ui/TrayMenuModel.swift
+++ b/Sources/AppBundle/ui/TrayMenuModel.swift
@@ -25,7 +25,13 @@ public class TrayMenuModel: ObservableObject {
         .joined(separator: " │ ")
     TrayMenuModel.shared.workspaces = Workspace.all.map {
         let monitor = $0.isVisible || !$0.isEffectivelyEmpty ? " - \($0.workspaceMonitor.name)" : ""
-        return WorkspaceViewModel(name: $0.name, suffix: monitor, isFocused: focus.workspace == $0, isEffectivelyEmpty: $0.isEffectivelyEmpty)
+        return WorkspaceViewModel(
+            name: $0.name,
+            suffix: monitor,
+            isFocused: focus.workspace == $0,
+            isEffectivelyEmpty: $0.isEffectivelyEmpty,
+            isVisible: $0.isVisible
+        )
     }
     var items = sortedMonitors.map {
         TrayItem(type: .workspace, name: $0.activeWorkspace.name, isActive: $0.activeWorkspace == focus.workspace)
@@ -42,6 +48,7 @@ struct WorkspaceViewModel: Hashable {
     let suffix: String
     let isFocused: Bool
     let isEffectivelyEmpty: Bool
+    let isVisible: Bool
 }
 
 enum TrayItemType: String, Hashable {


### PR DESCRIPTION
New menu-bar-style configuration to add extra menu functionality ('text' monospaced default, 'squares' images indicator and 'i3' squares + not active workspaces with windows in them)

Feel free to suggest better naming for the options. I will update all needed suggestions/recomendations

Full details of this implementation in #844 