### PR TITLE
Fixed issue #1041

### DIFF
--- a/Sources/AppBundle/config/Config.swift
+++ b/Sources/AppBundle/config/Config.swift
@@ -25,7 +25,12 @@ let defaultConfig: Config = {
     if !parsedConfig.errors.isEmpty {
         error("Can't parse default config: \(parsedConfig.errors)")
     }
-    return parsedConfig.config
+    // Assign to a local variable so you can validate it
+    let config = parsedConfig.config
+    if !config.automaticallyUnhideMacosHiddenApps && !config.automaticallyUnhideMacosHiddenAppsExceptions.isEmpty {
+        error("Config error: automatically-unhide-macos-hidden-apps is false but exceptions array is non-empty.")
+    }
+    return config
 }()
 var config: Config = defaultConfig
 var configUrl: URL = defaultConfigUrl
@@ -49,6 +54,7 @@ struct Config: Copyable {
     var onFocusChanged: [any Command] = []
     // var onFocusedWorkspaceChanged: [any Command] = []
     var onFocusedMonitorChanged: [any Command] = []
+    var automaticallyUnhideMacosHiddenAppsExceptions: [String] = []
 
     var gaps: Gaps = .zero
     var workspaceToMonitorForceAssignment: [String: [MonitorDescription]] = [:]

--- a/Sources/AppBundle/config/parseConfig.swift
+++ b/Sources/AppBundle/config/parseConfig.swift
@@ -102,6 +102,7 @@ private let configParser: [String: any ParserProtocol<Config>] = [
 
     "start-at-login": Parser(\.startAtLogin, parseBool),
     "automatically-unhide-macos-hidden-apps": Parser(\.automaticallyUnhideMacosHiddenApps, parseBool),
+    "automatically-unhide-macos-hidden-apps-exceptions": Parser(\.automaticallyUnhideMacosHiddenAppsExceptions, parseStringArray),
     "accordion-padding": Parser(\.accordionPadding, parseInt),
     "exec-on-workspace-change": Parser(\.execOnWorkspaceChange, parseExecOnWorkspaceChange),
     "exec": Parser(\.execConfig, parseExecConfig),
@@ -280,6 +281,13 @@ private func skipParsing<T>(_ value: T) -> (_ raw: TOMLValueConvertible, _ backt
 }
 
 private func parseExecOnWorkspaceChange(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace) -> ParsedToml<[String]> {
+    parseTomlArray(raw, backtrace)
+        .flatMap { arr in
+            arr.mapAllOrFailure { elem in parseString(elem, backtrace) }
+        }
+}
+
+private func parseStringArray(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace) -> ParsedToml<[String]> {
     parseTomlArray(raw, backtrace)
         .flatMap { arr in
             arr.mapAllOrFailure { elem in parseString(elem, backtrace) }

--- a/docs/config-examples/default-config.toml
+++ b/docs/config-examples/default-config.toml
@@ -41,7 +41,10 @@ on-focused-monitor-changed = ['move-mouse monitor-lazy-center']
 # You can effectively turn off macOS "Hide application" (cmd-h) feature by toggling this flag
 # Useful if you don't use this macOS feature, but accidentally hit cmd-h or cmd-alt-h key
 # Also see: https://nikitabobko.github.io/AeroSpace/goodies#disable-hide-app
-automatically-unhide-macos-hidden-apps = false
+
+# automatically automatically-unhide-macos-hidden-apps must be true if exceptions array is non-empty
+automatically-unhide-macos-hidden-apps = true
+automatically-unhide-macos-hidden-apps-exceptions = []
 
 # Possible values: (qwerty|dvorak)
 # See https://nikitabobko.github.io/AeroSpace/guide#key-mapping


### PR DESCRIPTION
Fix to #1041

-Added automatically-unhide-macos-hidden-apps-exceptions = [] to default-config
- Changed automatically-unhide-macos-hidden-apps to True
- Config.swift error if hidden apps is false while hidden apps exceptions is empty
- Added these configs to parseConfig Dictionary