### PR TITLE
Add automatically-unhide-macos-hidden-apps-exceptions config option.

### DIFF
--- a/Sources/AppBundle/GlobalObserver.swift
+++ b/Sources/AppBundle/GlobalObserver.swift
@@ -19,11 +19,22 @@ class GlobalObserver {
                    // "Hide app" (cmd-h) -> force focus
                    MacApp.allAppsMap.values.filter({ $0.nsApp.isHidden }).count == 1
                 {
-                    // Force focus
-                    _ = w.focusWindow()
-                    _ = w.nativeFocus()
+                    if let identifier = w.macAppUnsafe.nsApp.bundleIdentifier,
+                       config.automaticallyUnhideMacosHiddenAppsExceptions.contains(identifier)
+                    {
+                    }
+                    else {
+                        // Force focus
+                        _ = w.focusWindow()
+                        _ = w.nativeFocus()
+                    }
                 }
                 for app in MacApp.allAppsMap.values {
+                    if let identifier = app.nsApp.bundleIdentifier,
+                       config.automaticallyUnhideMacosHiddenAppsExceptions.contains(identifier)
+                    {
+                        continue
+                    }
                     app.nsApp.unhide()
                 }
             }

--- a/Sources/AppBundle/GlobalObserver.swift
+++ b/Sources/AppBundle/GlobalObserver.swift
@@ -21,8 +21,7 @@ class GlobalObserver {
                 {
                     if let identifier = w.macAppUnsafe.nsApp.bundleIdentifier,
                        config.automaticallyUnhideMacosHiddenAppsExceptions.contains(identifier)
-                    {
-                    }
+                    {}
                     else {
                         // Force focus
                         _ = w.focusWindow()

--- a/Sources/AppBundle/config/Config.swift
+++ b/Sources/AppBundle/config/Config.swift
@@ -40,6 +40,7 @@ struct Config: Copyable {
     var defaultRootContainerOrientation: DefaultContainerOrientation = .auto
     var startAtLogin: Bool = false
     var automaticallyUnhideMacosHiddenApps: Bool = false
+    var automaticallyUnhideMacosHiddenAppsExceptions: [String] = []
     var accordionPadding: Int = 30
     var enableNormalizationOppositeOrientationForNestedContainers: Bool = true
     var execOnWorkspaceChange: [String] = [] // todo deprecate

--- a/Sources/AppBundle/normalizeLayoutReason.swift
+++ b/Sources/AppBundle/normalizeLayoutReason.swift
@@ -22,7 +22,7 @@ private func _normalizeLayoutReason(workspace: Workspace, windows: [Window]) {
         let isMacosFullscreen = window.isMacosFullscreen
         let isMacosMinimized = !isMacosFullscreen && window.isMacosMinimized
         let isMacosWindowOfHiddenApp = !isMacosFullscreen && !isMacosMinimized &&
-            (!config.automaticallyUnhideMacosHiddenApps || config.automaticallyUnhideMacosHiddenAppsExceptions.contains(window.app.id ?? "")) && 
+            (!config.automaticallyUnhideMacosHiddenApps || config.automaticallyUnhideMacosHiddenAppsExceptions.contains(window.app.id ?? "")) &&
             window.macAppUnsafe.nsApp.isHidden
         switch window.layoutReason {
             case .standard:

--- a/Sources/AppBundle/normalizeLayoutReason.swift
+++ b/Sources/AppBundle/normalizeLayoutReason.swift
@@ -22,7 +22,8 @@ private func _normalizeLayoutReason(workspace: Workspace, windows: [Window]) {
         let isMacosFullscreen = window.isMacosFullscreen
         let isMacosMinimized = !isMacosFullscreen && window.isMacosMinimized
         let isMacosWindowOfHiddenApp = !isMacosFullscreen && !isMacosMinimized &&
-            !config.automaticallyUnhideMacosHiddenApps && window.macAppUnsafe.nsApp.isHidden
+            (!config.automaticallyUnhideMacosHiddenApps || config.automaticallyUnhideMacosHiddenAppsExceptions.contains(window.app.id ?? "")) && 
+            window.macAppUnsafe.nsApp.isHidden
         switch window.layoutReason {
             case .standard:
                 if isMacosFullscreen {

--- a/Sources/AppBundle/tree/TreeNodeEx.swift
+++ b/Sources/AppBundle/tree/TreeNodeEx.swift
@@ -44,7 +44,14 @@ extension TreeNode {
     }
 
     var mostRecentWindowRecursive: Window? {
-        self as? Window ?? mostRecentChild?.mostRecentWindowRecursive
+        if let window = self as? Window,
+           config.automaticallyUnhideMacosHiddenAppsExceptions.contains(window.app.id ?? "")
+           && window.app.asMacApp().nsApp.isHidden
+        {
+            // Skip hidden apps in automaticallyUnhideMacosHiddenAppsExceptions
+            return mostRecentChild?.mostRecentWindowRecursive
+        }
+        return self as? Window ?? mostRecentChild?.mostRecentWindowRecursive
     }
 
     var anyLeafWindowRecursive: Window? {

--- a/docs/config-examples/default-config.toml
+++ b/docs/config-examples/default-config.toml
@@ -42,6 +42,7 @@ on-focused-monitor-changed = ['move-mouse monitor-lazy-center']
 # Useful if you don't use this macOS feature, but accidentally hit cmd-h or cmd-alt-h key
 # Also see: https://nikitabobko.github.io/AeroSpace/goodies#disable-hide-app
 automatically-unhide-macos-hidden-apps = false
+automatically-unhide-macos-hidden-apps-exceptions = []
 
 # Possible values: (qwerty|dvorak)
 # See https://nikitabobko.github.io/AeroSpace/guide#key-mapping


### PR DESCRIPTION
Fix #1041 

I tested both Raycast shortcuts and Discord, and they will not be unhidden automatically with `automatically-unhide-macos-hidden-apps-exceptions=['com.github.wez.wezterm', 'com.hnc.Discord']`


Currently, apps in exceptions will remember the workspace where they launched. When you reopen the app, it always appears on that workspace and focuses on that workspace.
