### PR TITLE
Add 'fail' action to boundaries handling.

### DIFF
--- a/Sources/AppBundle/command/impl/FocusCommand.swift
+++ b/Sources/AppBundle/command/impl/FocusCommand.swift
@@ -51,6 +51,7 @@ private func hitWorkspaceBoundaries(
         case .workspace:
             return switch args.boundariesAction {
                 case .stop: true
+                case .fail: false
                 case .wrapAroundTheWorkspace: wrapAroundTheWorkspace(target, io, direction)
                 case .wrapAroundAllMonitors: errorT("Must be discarded by args parser")
             }
@@ -79,6 +80,8 @@ private func hitAllMonitorsOuterFrameBoundaries(
     switch args.boundariesAction {
         case .stop:
             return true
+        case .fail:
+            return false
         case .wrapAroundTheWorkspace:
             return wrapAroundTheWorkspace(target, io, direction)
         case .wrapAroundAllMonitors:

--- a/Sources/Common/cmdArgs/impl/FocusCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/FocusCmdArgs.swift
@@ -47,6 +47,7 @@ public struct FocusCmdArgs: CmdArgs {
     }
     public enum WhenBoundariesCrossed: String, CaseIterable, Equatable {
         case stop = "stop"
+        case fail = "fail"
         case wrapAroundTheWorkspace = "wrap-around-the-workspace"
         case wrapAroundAllMonitors = "wrap-around-all-monitors"
     }

--- a/docs/aerospace-focus.adoc
+++ b/docs/aerospace-focus.adoc
@@ -44,7 +44,7 @@ The default is: `workspace`
 
 --boundaries-action <action>::
 Defines the behavior when requested to cross the `<boundary>`. +
-`<action>` possible values: `(stop|wrap-around-the-workspace|wrap-around-all-monitors)` +
+`<action>` possible values: `(stop|fail|wrap-around-the-workspace|wrap-around-all-monitors)` +
 The default is: `stop`
 
 --window-id <window-id>::

--- a/grammar/commands-bnf-grammar.txt
+++ b/grammar/commands-bnf-grammar.txt
@@ -112,7 +112,7 @@ aerospace -h;
 <move_node_to_monitor2_flag> ::= --window-id <window_id>|--focus-follows-window|--fail-if-noop;
 
 <focus_flag> ::= --boundaries <boundary>|--boundaries-action <boundaries_action>|--ignore-floating;
-<boundaries_action> ::= stop|wrap-around-the-workspace|wrap-around-all-monitors;
+<boundaries_action> ::= stop|fail|wrap-around-the-workspace|wrap-around-all-monitors;
 <boundary> ::= workspace|all-monitors-outer-frame;
 
 <list_windows_filter_flag> ::= --workspace (visible | focused | <workspace>)...


### PR DESCRIPTION
Fix #1073 

Output:
```bash
bash-3.2$ .debug/aerospace focus right --boundaries-action stop && echo succeed
succeed
bash-3.2$ .debug/aerospace focus right --boundaries-action fail || echo fail
fail
```