### PR TITLE
Support resizing floating windows.

### DIFF
--- a/Sources/AppBundle/command/impl/ResizeCommand.swift
+++ b/Sources/AppBundle/command/impl/ResizeCommand.swift
@@ -8,6 +8,79 @@ struct ResizeCommand: Command { // todo cover with tests
         check(Thread.current.isMainThread)
         guard let target = args.resolveTargetOrReportError(env, io) else { return false }
 
+        if let window = target.windowOrNil, window.isFloating {
+            guard let size = window.getSize(), let topLeftCorner = window.getTopLeftCorner() else { return false }
+
+            let computeTopLeftCorner = { (newSize: CGSize) -> CGPoint in
+                let newX = if topLeftCorner.x + newSize.width > target.workspace.workspaceMonitor.width {
+                    max(0, topLeftCorner.x - (topLeftCorner.x + newSize.width - target.workspace.workspaceMonitor.width))
+                } else {
+                    topLeftCorner.x
+                }
+
+                let newY = if topLeftCorner.y + newSize.height > target.workspace.workspaceMonitor.height {
+                    max(0, topLeftCorner.y - (topLeftCorner.y + newSize.height - target.workspace.workspaceMonitor.height))
+                } else {
+                    topLeftCorner.y
+                }
+
+                return CGPoint(x: newX, y: newY)
+            }
+
+            let newTopLeftCorner: CGPoint
+            let newSize: CGSize
+            let isWidthDominant = size.width >= size.height
+
+            switch args.dimension.val {
+                case .width:
+                    let diff: CGFloat = switch args.units.val {
+                        case .set(let unit): CGFloat(unit) - size.width
+                        case .add(let unit): CGFloat(unit)
+                        case .subtract(let unit): -CGFloat(unit)
+                    }
+                    let width = size.width + diff
+                    newSize = CGSize(width: width, height: size.height)
+                    newTopLeftCorner = computeTopLeftCorner(newSize)
+
+                case .height:
+                    let diff: CGFloat = switch args.units.val {
+                        case .set(let unit): CGFloat(unit) - size.height
+                        case .add(let unit): CGFloat(unit)
+                        case .subtract(let unit): -CGFloat(unit)
+                    }
+                    let height = size.height + diff
+                    newSize = CGSize(width: size.width, height: height)
+                    newTopLeftCorner = computeTopLeftCorner(newSize)
+
+                case .smart:
+                    let diff: CGFloat = switch args.units.val {
+                        case .set(let unit): CGFloat(unit) - (isWidthDominant ? size.width : size.height)
+                        case .add(let unit): CGFloat(unit)
+                        case .subtract(let unit): -CGFloat(unit)
+                    }
+                    newSize = if isWidthDominant {
+                        CGSize(width: size.width + diff, height: size.height + diff * (size.height / size.width))
+                    } else {
+                        CGSize(width: size.width + diff * (size.width / size.height), height: size.height + diff)
+                    }
+                    newTopLeftCorner = computeTopLeftCorner(newSize)
+
+                case .smartOpposite:
+                    let diff: CGFloat = switch args.units.val {
+                        case .set(let unit): CGFloat(unit) - (isWidthDominant ? size.height : size.width)
+                        case .add(let unit): CGFloat(unit)
+                        case .subtract(let unit): -CGFloat(unit)
+                    }
+                    newSize = if isWidthDominant {
+                        CGSize(width: size.width + diff * (size.width / size.height), height: size.height + diff)
+                    } else {
+                        CGSize(width: size.width + diff, height: size.height + diff * (size.height / size.width))
+                    }
+                    newTopLeftCorner = computeTopLeftCorner(newSize)
+            }
+            return window.setFrame(newTopLeftCorner, newSize)
+        }
+
         let candidates = target.windowOrNil?.parentsWithSelf
             .filter { ($0.parent as? TilingContainer)?.layout == .tiles }
             ?? []


### PR DESCRIPTION
May close #9 

I’ve noticed that resizing floating windows can be done independently of other cases, so I’ve written some separate code to handle it. 

I’m introducing a new concept called the ‘leading axis’ to handle resizing options like ‘smart | smart-opposite’. The leading axis is the longer axis of the floating window, like the X-axis if the width is greater than the height.

With ‘resize smart’, the leading axis will be adjusted while keeping the aspect ratio of the window the same.

And with ‘resize smart-opposite’, the non-leading axis will be adjusted.