### PR TITLE
Add more query data types

### DIFF
--- a/Sources/AppBundle/command/format.swift
+++ b/Sources/AppBundle/command/format.swift
@@ -1,5 +1,4 @@
 import Common
-import Foundation
 
 enum AeroObj {
     case window(Window)

--- a/Sources/AppBundle/command/format.swift
+++ b/Sources/AppBundle/command/format.swift
@@ -116,7 +116,7 @@ enum Primitive: Encodable {
             case .int32(let x): x.description
             case .uint32(let x): x.description
             case .string(let x): x
-            case .array(let x): x.map{$0.toString()}.joined(separator: ",")
+            case .array(let x): x.map { $0.toString() }.joined(separator: ",")
         }
     }
 
@@ -175,7 +175,7 @@ extension String {
             case (.workspace(let ws), .monitor):
                 return expandFormatVar(obj: AeroObj.monitor(ws.workspaceMonitor))
             case (.workspace(let ws), .app):
-                return .success(.array(ws.allLeafWindowsRecursive.compactMap{
+                return .success(.array(ws.allLeafWindowsRecursive.compactMap {
                     do {
                         return try expandFormatVar(obj: AeroObj.app($0.app)).get()
                     } catch {
@@ -183,7 +183,7 @@ extension String {
                     }
                 }))
             case (.workspace(let ws), .window):
-                return .success(.array(ws.allLeafWindowsRecursive.compactMap{
+                return .success(.array(ws.allLeafWindowsRecursive.compactMap {
                     do {
                         return try expandFormatVar(obj: AeroObj.window($0)).get()
                     } catch {

--- a/Sources/AppBundle/command/format.swift
+++ b/Sources/AppBundle/command/format.swift
@@ -82,8 +82,8 @@ enum FormatVar: Equatable {
 
     enum WorkspaceFormatVar: String, Equatable, CaseIterable {
         case workspaceName = "workspace"
-        case workspaceFocused = "workspace-focused"
-        case workspaceVisible = "workspace-visible"
+        case workspaceFocused = "workspace-is-focused"
+        case workspaceVisible = "workspace-is-visible"
     }
 
     enum AppFormatVar: String, Equatable, CaseIterable {

--- a/Sources/AppBundle/command/format.swift
+++ b/Sources/AppBundle/command/format.swift
@@ -107,7 +107,6 @@ enum Primitive: Encodable {
     case int32(Int32)
     case uint32(UInt32)
     case string(String)
-    indirect case array([Primitive])
 
     func toString() -> String {
         switch self {
@@ -116,7 +115,6 @@ enum Primitive: Encodable {
             case .int32(let x): x.description
             case .uint32(let x): x.description
             case .string(let x): x
-            case .array(let x): x.map { $0.toString() }.joined(separator: ",")
         }
     }
 
@@ -127,7 +125,6 @@ enum Primitive: Encodable {
             case .int32(let x): x
             case .uint32(let x): x
             case .string(let x): x
-            case .array(let x): x
         }
         var container = encoder.singleValueContainer()
         try container.encode(value)
@@ -174,22 +171,6 @@ extension String {
 
             case (.workspace(let ws), .monitor):
                 return expandFormatVar(obj: AeroObj.monitor(ws.workspaceMonitor))
-            case (.workspace(let ws), .app):
-                return .success(.array(ws.allLeafWindowsRecursive.compactMap {
-                    do {
-                        return try expandFormatVar(obj: AeroObj.app($0.app)).get()
-                    } catch {
-                        return .string("Error: \(error)")
-                    }
-                }))
-            case (.workspace(let ws), .window):
-                return .success(.array(ws.allLeafWindowsRecursive.compactMap {
-                    do {
-                        return try expandFormatVar(obj: AeroObj.window($0)).get()
-                    } catch {
-                        return .string("Error: \(error)")
-                    }
-                }))
             case (.workspace, _): break
 
             case (.app(_), _): break

--- a/docs/aerospace-list-windows.adoc
+++ b/docs/aerospace-list-windows.adoc
@@ -87,6 +87,8 @@ The following variables can be used inside `<output-format>`:
 %{app-bundle-path}:: String. Application bundle path
 
 %{workspace}:: String. Name of the belonging workspace
+%{workspace-is-focused}:: Boolean. True if the workspace has focus
+%{workspace-is-visible}:: Boolean. True if the workspace is visible. A workspace can be visible but not focused in a multi-monitor setup
 
 %{monitor-id}:: 1-based Number. Sequential number of the belonging monitor.
 %{monitor-appkit-nsscreen-screens-id}:: 1-based index of the belonging monitor in `NSScreen.screens` array. Useful for integration with other tools that might be using `NSScreen.screens` ordering (like sketchybar).

--- a/docs/aerospace-list-workspaces.adoc
+++ b/docs/aerospace-list-workspaces.adoc
@@ -66,6 +66,8 @@ If not specified, the default `<output-format>` is: +
 The following variables can be used inside `<output-format>`:
 
 %{workspace}:: String. Name of the belonging workspace
+%{workspace-is-focused}:: Boolean. True if the workspace has focus
+%{workspace-is-visible}:: Boolean. True if the workspace is visible. A workspace can be visible but not focused in a multi-monitor setup
 
 %{monitor-id}:: 1-based Number. Sequential number of the belonging monitor
 %{monitor-appkit-nsscreen-screens-id}:: 1-based Number. Sequential number of the belonging monitor in `NSScreen.screens`. Useful for integration with other tools that might be using `NSScreen.screens` ordering (like sketchybar).


### PR DESCRIPTION
Currently querying aerospace is rather slow (approx 50ms per call on my machine). I believe this is mostly caused by the usage of unix domain sockets for IPC, which seems to be much slower than mach ports, which is used by sketchybar (approx 1ms per call).

A common use-case, where this is noticeable is for updating bars and there has been some complex workarounds. Most of these can be removed by just creating a single call that contains all necessary information.

This modification allows us to get a list of workspaces including visibility and focus information, as well as names of apps. This is composable, so now e.g. window and app variables can also be used for workspace queries.

This can e.g. be used in the following command: `./.debug/aerospace list-workspaces --all --format '%{workspace-focused}%{workspace-visible}%{app-name}' --json`

Which will return e.g. the following json response now:

```
...
  {
    "app-name" : [
      "Mail",
      "iTerm2"
    ],
    "workspace-visible" : true,
    "workspace-focused" : true
  },
...
```

This allows for statusbar updates without noticeable latency without any additional caching or variables.

@nikitabobko Please let me know if you are interested in potentially merging this. I can make this a bit more complete and add some testing and documentation.

Related issues:
https://github.com/nikitabobko/AeroSpace/issues/104

These changes are used in the following sketchybar plugin: https://github.com/xiamaz/sketchybar-aerospace-plugin