### PR TITLE
Add Colemak keyboard layout preset (#730)

### DIFF
--- a/Sources/AppBundle/config/keysMap.swift
+++ b/Sources/AppBundle/config/keysMap.swift
@@ -46,6 +46,7 @@ func getKeysPreset(_ layout: KeyMapping.Preset) -> [String: Key] {
     return switch layout {
         case .qwerty: keyNotationToKeyCode
         case .dvorak: dvorakMap
+        case .colemak: colemakMap
     }
 }
 
@@ -202,6 +203,46 @@ private let dvorakMap: [String: Key] = keyNotationToKeyCode + [
     w: .comma,
     v: .period,
     z: .slash,
+]
+
+private let colemakMap: [String: Key] = keyNotationToKeyCode + [
+    q: .q,
+    w: .w,
+    f: .t,
+    p: .r,
+    g: .g,
+    j: .y,
+    l: .u,
+    u: .i,
+    y: .o,
+    semicolon: .p,
+    leftSquareBracket: .leftBracket,
+    rightSquareBracket: .rightBracket,
+    backslash: .backslash,
+
+    a: .a,
+    r: .s,
+    s: .d,
+    t: .f,
+    d: .g,
+    h: .h,
+    n: .j,
+    e: .k,
+    i: .l,
+    o: .semicolon,
+    quote: .quote,
+
+    z: .z,
+    x: .x,
+    c: .c,
+    v: .v,
+    b: .b,
+    k: .n,
+    m: .m,
+    comma: .comma,
+    period: .period,
+    slash: .slash,
+
 ]
 
 let modifiersMap: [String: NSEvent.ModifierFlags] = [

--- a/Sources/AppBundle/config/keysMap.swift
+++ b/Sources/AppBundle/config/keysMap.swift
@@ -208,9 +208,9 @@ private let dvorakMap: [String: Key] = keyNotationToKeyCode + [
 private let colemakMap: [String: Key] = keyNotationToKeyCode + [
     q: .q,
     w: .w,
-    f: .t,
+    f: .e,
     p: .r,
-    g: .g,
+    g: .t,
     j: .y,
     l: .u,
     u: .i,

--- a/Sources/AppBundle/config/keysMap.swift
+++ b/Sources/AppBundle/config/keysMap.swift
@@ -242,7 +242,6 @@ private let colemakMap: [String: Key] = keyNotationToKeyCode + [
     comma: .comma,
     period: .period,
     slash: .slash,
-
 ]
 
 let modifiersMap: [String: NSEvent.ModifierFlags] = [

--- a/Sources/AppBundle/config/parseKeyMapping.swift
+++ b/Sources/AppBundle/config/parseKeyMapping.swift
@@ -9,7 +9,7 @@ private let keyMappingParser: [String: any ParserProtocol<KeyMapping>] = [
 
 struct KeyMapping: Copyable, Equatable, Sendable {
     enum Preset: String, CaseIterable, Sendable {
-        case qwerty, dvorak
+        case qwerty, dvorak, colemak
     }
 
     public init(

--- a/Sources/AppBundleTests/config/ConfigTest.swift
+++ b/Sources/AppBundleTests/config/ConfigTest.swift
@@ -387,6 +387,6 @@ final class ConfigTest: XCTestCase {
         )
         assertEquals(colemakErrors, [])
         assertEquals(colemakConfig.keyMapping, KeyMapping(preset: .colemak, rawKeyNotationToKeyCode: [:]))
-        assertEquals(colemakConfig.keyMapping.resolve()["f"], .t)
+        assertEquals(colemakConfig.keyMapping.resolve()["f"], .e)
     }
 }

--- a/Sources/AppBundleTests/config/ConfigTest.swift
+++ b/Sources/AppBundleTests/config/ConfigTest.swift
@@ -380,5 +380,14 @@ final class ConfigTest: XCTestCase {
         assertEquals(dvorakErrors, [])
         assertEquals(dvorakConfig.keyMapping, KeyMapping(preset: .dvorak, rawKeyNotationToKeyCode: [:]))
         assertEquals(dvorakConfig.keyMapping.resolve()["quote"], .q)
+        
+        let (colemakConfig, colemakErrors) = parseConfig(
+            """
+            key-mapping.preset = 'colemak'
+            """
+        )
+        assertEquals(colemakErrors, [])
+        assertEquals(colemakConfig.keyMapping, KeyMapping(preset: .colemak, rawKeyNotationToKeyCode: [:]))
+        assertEquals(colemakConfig.keyMapping.resolve()["f"], .t)
     }
 }

--- a/Sources/AppBundleTests/config/ConfigTest.swift
+++ b/Sources/AppBundleTests/config/ConfigTest.swift
@@ -173,7 +173,7 @@ final class ConfigTest: XCTestCase {
 
                 My recommendation: keep the normalizations enabled, and prefer 'join-with' over 'split'.
                 """],
-            errors.descriptions
+            errors.description
         )
     }
 

--- a/Sources/AppBundleTests/config/ConfigTest.swift
+++ b/Sources/AppBundleTests/config/ConfigTest.swift
@@ -173,7 +173,7 @@ final class ConfigTest: XCTestCase {
 
                 My recommendation: keep the normalizations enabled, and prefer 'join-with' over 'split'.
                 """],
-            errors.description
+            errors.descriptions
         )
     }
 
@@ -380,7 +380,6 @@ final class ConfigTest: XCTestCase {
         assertEquals(dvorakErrors, [])
         assertEquals(dvorakConfig.keyMapping, KeyMapping(preset: .dvorak, rawKeyNotationToKeyCode: [:]))
         assertEquals(dvorakConfig.keyMapping.resolve()["quote"], .q)
-        
         let (colemakConfig, colemakErrors) = parseConfig(
             """
             key-mapping.preset = 'colemak'

--- a/docs/config-examples/default-config.toml
+++ b/docs/config-examples/default-config.toml
@@ -43,7 +43,7 @@ on-focused-monitor-changed = ['move-mouse monitor-lazy-center']
 # Also see: https://nikitabobko.github.io/AeroSpace/goodies#disable-hide-app
 automatically-unhide-macos-hidden-apps = false
 
-# Possible values: (qwerty|dvorak)
+# Possible values: (qwerty|dvorak|colemak)
 # See https://nikitabobko.github.io/AeroSpace/guide#key-mapping
 [key-mapping]
     preset = 'qwerty'

--- a/docs/goodies.adoc
+++ b/docs/goodies.adoc
@@ -171,51 +171,6 @@ If `automatically-unhide-macos-hidden-apps` isn't enough, you can disable `cmd-h
     cmd-alt-h = [] # Disable "hide others"
 ----
 
-[#colemak-keys-remap]
-== Colemak keys remap
-
-.~/.aerospace.toml
-[source,toml]
-----
-[key-mapping.key-notation-to-key-code]
-    q = 'q'
-    w = 'w'
-    f = 'e'
-    p = 'r'
-    g = 't'
-    j = 'y'
-    l = 'u'
-    u = 'i'
-    y = 'o'
-    semicolon = 'p'
-    leftSquareBracket = 'leftSquareBracket'
-    rightSquareBracket = 'rightSquareBracket'
-    backslash = 'backslash'
-
-    a = 'a'
-    r = 's'
-    s = 'd'
-    t = 'f'
-    d = 'g'
-    h = 'h'
-    n = 'j'
-    e = 'k'
-    i = 'l'
-    o = 'semicolon'
-    quote = 'quote'
-
-    z = 'z'
-    x = 'x'
-    c = 'c'
-    v = 'v'
-    b = 'b'
-    k = 'n'
-    m = 'm'
-    comma = 'comma'
-    period = 'period'
-    slash = 'slash'
-----
-
 [#i3-like-config]
 == i3 like config
 

--- a/docs/guide.adoc
+++ b/docs/guide.adoc
@@ -179,20 +179,12 @@ If you use different layout, different alphabet, or you just want to have a fanc
     alt-unicorn = 'workspace wonderland' # (⁀ᗢ⁀)
 ----
 
-* For `dvorak` users, AeroSpace offers a preconfigured preset.
+* For `dvorak` and `colemak` users, AeroSpace offers preconfigured presets.
 +
 [source,toml]
 ----
 [key-mapping]
-    preset = 'dvorak'
-----
-
-* For `colemak` users, AeroSpace offers a preconfigured preset.
-+
-[source,toml]
-----
-[key-mapping]
-    preset = 'colemak'
+    preset = 'dvorak'  # or 'colemak'
 ----
 
 [#exec-env-vars]

--- a/docs/guide.adoc
+++ b/docs/guide.adoc
@@ -187,8 +187,13 @@ If you use different layout, different alphabet, or you just want to have a fanc
     preset = 'dvorak'
 ----
 
-* For `colemak` users, there is xref:./goodies.adoc#colemak-keys-remap[a compiled mapping].
-`colemak` may be added as preconfigured preset similar to `dvorak` in the future, if there is enough demand
+* For `colemak` users, AeroSpace offers a preconfigured preset.
++
+[source,toml]
+----
+[key-mapping]
+    preset = 'colemak'
+----
 
 [#exec-env-vars]
 === exec-* Environment Variables


### PR DESCRIPTION
## Description
This PR adds Colemak keyboard layout as a built-in preset option for AeroSpace, allowing Colemak users to easily configure their keyboard layouts without manual configuration.

## Changes
- Added `colemak` to the `Preset` enum in `parseKeyMapping.swift`
- Created `colemakMap` in `keysMap.swift` to map Colemak key notation to QWERTY key codes
- Updated `getKeysPreset` function to include the Colemak preset
- Added tests for the Colemak preset in `ConfigTest.swift`
- Updated documentation in `guide.adoc` and `goodies.adoc` to reflect Colemak as a built-in preset

## Implementation Approach
The implementation follows the existing pattern used for the Dvorak preset, mapping Colemak key notation to QWERTY key codes for seamless integration.

## Testing
- Added test cases in `ConfigTest.swift` to verify the Colemak key mapping works correctly
- Manually tested with Colemak layout to ensure proper functionality

## Related Issues
Closes #730
