### PR TITLE
Add key-mapping.mod-notation-to-mod-flags config option

### DIFF
--- a/Sources/AppBundle/config/Mode.swift
+++ b/Sources/AppBundle/config/Mode.swift
@@ -10,14 +10,14 @@ struct Mode: Copyable, Equatable, Sendable {
     static let zero = Mode(name: nil, bindings: [:])
 }
 
-func parseModes(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError], _ mapping: [String: Key]) -> [String: Mode] {
+func parseModes(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError], _ keyMapping: KeyMapping) -> [String: Mode] {
     guard let rawTable = raw.table else {
         errors += [expectedActualTypeError(expected: .table, actual: raw.type, backtrace)]
         return [:]
     }
     var result: [String: Mode] = [:]
     for (key, value) in rawTable {
-        result[key] = parseMode(value, backtrace + .key(key), &errors, mapping)
+        result[key] = parseMode(value, backtrace + .key(key), &errors, keyMapping)
     }
     if !result.keys.contains(mainModeId) {
         errors += [.semantic(backtrace, "Please specify '\(mainModeId)' mode")]
@@ -25,7 +25,7 @@ func parseModes(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ error
     return result
 }
 
-func parseMode(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError], _ mapping: [String: Key]) -> Mode {
+func parseMode(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError], _ keyMapping: KeyMapping) -> Mode {
     guard let rawTable: TOMLTable = raw.table else {
         errors += [expectedActualTypeError(expected: .table, actual: raw.type, backtrace)]
         return .zero
@@ -36,7 +36,7 @@ func parseMode(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors
         let backtrace = backtrace + .key(key)
         switch key {
             case "binding":
-                result.bindings = parseBindings(value, backtrace, &errors, mapping)
+                result.bindings = parseBindings(value, backtrace, &errors, keyMapping)
             default:
                 errors += [unknownKeyError(backtrace)]
         }

--- a/Sources/AppBundle/config/parseConfig.swift
+++ b/Sources/AppBundle/config/parseConfig.swift
@@ -172,7 +172,7 @@ func parseCommandOrCommands(_ raw: TOMLValueConvertible) -> Parsed<[any Command]
         config.keyMapping = mapping
     }
 
-    if let modes = rawTable[modeConfigRootKey].flatMap({ parseModes($0, .rootKey(modeConfigRootKey), &errors, config.keyMapping.resolve()) }) {
+    if let modes = rawTable[modeConfigRootKey].flatMap({ parseModes($0, .rootKey(modeConfigRootKey), &errors, config.keyMapping) }) {
         config.modes = modes
     }
 

--- a/Sources/AppBundleTests/config/ConfigTest.swift
+++ b/Sources/AppBundleTests/config/ConfigTest.swift
@@ -379,7 +379,7 @@ final class ConfigTest: XCTestCase {
         )
         assertEquals(dvorakErrors, [])
         assertEquals(dvorakConfig.keyMapping, KeyMapping(preset: .dvorak, rawKeyNotationToKeyCode: [:]))
-        assertEquals(dvorakConfig.keyMapping.resolve()["quote"], .q)
+        assertEquals(dvorakConfig.keyMapping.resolveKeys()["quote"], .q)
         let (colemakConfig, colemakErrors) = parseConfig(
             """
             key-mapping.preset = 'colemak'
@@ -387,6 +387,6 @@ final class ConfigTest: XCTestCase {
         )
         assertEquals(colemakErrors, [])
         assertEquals(colemakConfig.keyMapping, KeyMapping(preset: .colemak, rawKeyNotationToKeyCode: [:]))
-        assertEquals(colemakConfig.keyMapping.resolve()["f"], .e)
+        assertEquals(colemakConfig.keyMapping.resolveKeys()["f"], .e)
     }
 }

--- a/docs/guide.adoc
+++ b/docs/guide.adoc
@@ -167,7 +167,7 @@ For the list of available commands see: xref:commands.adoc[]
 
 By default, key bindings in the config are perceived as `qwerty` layout.
 
-If you use different layout, different alphabet, or you just want to have a fancy alias for the existing key, you can use `key-mapping.key-notation-to-key-code`.
+If you use different layout, different alphabet, or you just want to have a fancy alias for the existing key, you can use `key-mapping.key-notation-to-key-code`. Similarly, an alias for modifier keys can also be added under `key-mapping.mod-notation-to-mod-flags`.
 
 [source,toml]
 ----
@@ -175,8 +175,13 @@ If you use different layout, different alphabet, or you just want to have a fanc
 [key-mapping.key-notation-to-key-code]
     unicorn = 'u'
 
+# Define my hyper key notation
+[key-mapping.mod-notation-to-mod-flags]
+    hyper = 'ctrl-shift-alt-cmd'
+
 [mode.main.binding]
     alt-unicorn = 'workspace wonderland' # (⁀ᗢ⁀)
+    hyper-unicorn = 'workspace hyprland'
 ----
 
 * For `dvorak` and `colemak` users, AeroSpace offers preconfigured presets.


### PR DESCRIPTION
Hi, first off, I just want to say that AeroSpace is really awesome, so thanks for creating and maintaining this project! In particular, I think virtual workspaces was a great decision, and one of the main factors for me to switch over from yabai. I would also like to acknowledge the excellently organized codebase, helper scripts and docs, as they really make development such a smooth experience.

This is my first PR for an open-source project, ever, so please let me know if I have overlooked any formalities/best practicees, I'd be glad to make any necessary changes.


### About this PR

This PR addresses the introduction of custom modifier keys discussed in #224

Similar to `key-mapping.key-notation-to-key-code`, the new `key-mapping.mod-notation-to-mod-flags` alias allows any arbitrary modifier notation to represent one or more modifier keys.

This implementation differs slightly from the suggestion in https://github.com/nikitabobko/AeroSpace/issues/224#issuecomment-2111556500 due to how keys and mods are fundamentally treated differently, as well as the use of different types to represent each of them (i.e. `Key` and `NSEvent.ModifierFlags`). Because of this, I found it suitable to introduce a new TOML key for this functionality. 

This implementation also addresses the main concern raised in https://github.com/nikitabobko/AeroSpace/pull/389#issuecomment-2298994576 -that hardcoding certain combinations of modifiers is not extensible.

Looking forward to your feedback!