### PR TITLE
Set ProcessType to Interactive on LaunchAgent plist

### DIFF
--- a/Sources/AppBundle/config/startAtLogin.swift
+++ b/Sources/AppBundle/config/startAtLogin.swift
@@ -15,6 +15,8 @@ func syncStartAtLogin() {
             <dict>
                 <key>Label</key>
                 <string>\(aeroSpaceAppId)</string>
+                <key>ProcessType</key>
+                <string>Interactive</string>
                 <key>ProgramArguments</key>
                 <array>
                     <string>\(URL(filePath: CommandLine.arguments.first ?? errorT("Can't get first argument")).absoluteURL.path)</string>


### PR DESCRIPTION
Hey all, I love the app and use it every day. As others have reported (seemingly many times), I have occasionally experienced poor performance when switching workspaces or apps while other resource-intensive processes are running. Generally, I have just accepted it, as the utility that AeroSpace provides far outweighs the occasional slowdown.

However, recently I’ve been experimenting with creating and managing LaunchAgents, and I discovered the ProcessType key in the LaunchAgent plist file. When set to Interactive, it grants the process higher CPU priority. From the [man page](https://www.manpagez.com/man/5/launchd.plist/#:~:text=ProcessType):

> Interactive jobs run with the same resource limitations as apps, that is to say, none. Interactive jobs are critical to maintaining a responsive user experience, and this key should only be used if an app's ability to be responsive depends on it, and cannot be made Adaptive.

This PR simply adds the Interactive ProcessType to the LaunchAgent plist. I have tested this locally by manually modifying the LaunchAgent plist and reloading the app via launchctl. I have not encountered any issues in my testing, though I don’t have a way to formally measure performance improvements.

I’m not an expert in Mac app development, so there may be more going on here than I realize. However, after searching the issues and discussion pages, I haven’t seen this suggestion mentioned anywhere, so I thought it would be worthwhile to bring it up.