### PR TITLE
Implement smart gaps like i3-gaps

### DIFF
--- a/Sources/AppBundle/config/parseGaps.swift
+++ b/Sources/AppBundle/config/parseGaps.swift
@@ -2,10 +2,11 @@ import Common
 import TOMLKit
 
 struct Gaps: Copyable, Equatable, Sendable {
+    var smart: Bool
     var inner: Inner
     var outer: Outer
 
-    static let zero = Gaps(inner: .zero, outer: .zero)
+    static let zero = Gaps(smart: false, inner: .zero, outer: .zero)
 
     struct Inner: Copyable, Equatable, Sendable {
         var vertical: DynamicConfigValue<Int>
@@ -49,6 +50,7 @@ struct Gaps: Copyable, Equatable, Sendable {
 }
 
 struct ResolvedGaps {
+    let smartGaps: Bool
     let inner: Inner
     let outer: Outer
 
@@ -69,6 +71,8 @@ struct ResolvedGaps {
     }
 
     init(gaps: Gaps, monitor: any Monitor) {
+        smartGaps = gaps.smart
+
         inner = .init(
             vertical: gaps.inner.vertical.getValue(for: monitor),
             horizontal: gaps.inner.horizontal.getValue(for: monitor)
@@ -84,6 +88,7 @@ struct ResolvedGaps {
 }
 
 private let gapsParser: [String: any ParserProtocol<Gaps>] = [
+    "smart": Parser(\.smart, parseBool),
     "inner": Parser(\.inner, parseInner),
     "outer": Parser(\.outer, parseOuter),
 ]

--- a/Sources/AppBundle/layout/layoutRecursive.swift
+++ b/Sources/AppBundle/layout/layoutRecursive.swift
@@ -3,7 +3,11 @@ import AppKit
 extension Workspace {
     func layoutWorkspace() {
         if isEffectivelyEmpty { return }
-        let rect = workspaceMonitor.visibleRectPaddedByOuterGaps
+        var rect = workspaceMonitor.visibleRect
+        let windowCount = workspaceMonitor.activeWorkspace.allLeafWindowsRecursive.filter { !$0.isFloating }.count
+        if (windowCount > 1 || !config.gaps.smart) {
+            rect = workspaceMonitor.visibleRectPaddedByOuterGaps
+        }
         // If monitors are aligned vertically and the monitor below has smaller width, then macOS may not allow the
         // window on the upper monitor to take full width. rect.height - 1 resolves this problem
         // But I also faced this problem in mointors horizontal configuration. ¯\_(ツ)_/¯

--- a/Sources/AppBundleTests/config/ConfigTest.swift
+++ b/Sources/AppBundleTests/config/ConfigTest.swift
@@ -293,6 +293,7 @@ final class ConfigTest: XCTestCase {
         let (config, errors1) = parseConfig(
             """
             [gaps]
+            smart = true
             inner.horizontal = 10
             inner.vertical = [{ monitor."main" = 1 }, { monitor."secondary" = 2 }, 5]
             outer.left = 12
@@ -305,6 +306,7 @@ final class ConfigTest: XCTestCase {
         assertEquals(
             config.gaps,
             Gaps(
+                smart: true,
                 inner: .init(
                     vertical: .perMonitor(
                         [PerMonitorValue(description: .main, value: 1), PerMonitorValue(description: .secondary, value: 2)],

--- a/docs/config-examples/default-config.toml
+++ b/docs/config-examples/default-config.toml
@@ -49,6 +49,8 @@ automatically-unhide-macos-hidden-apps = false
     preset = 'qwerty'
 
 # Gaps between windows (inner-*) and between monitor edges (outer-*).
+# The smart property, if set to true, will remove outer gaps when there is only one tiled 
+# window in the workspace.
 # Possible values:
 # - Constant:     gaps.outer.top = 8
 # - Per monitor:  gaps.outer.top = [{ monitor.main = 16 }, { monitor."some-pattern" = 32 }, 24]
@@ -57,6 +59,7 @@ automatically-unhide-macos-hidden-apps = false
 #                 See:
 #                 https://nikitabobko.github.io/AeroSpace/guide#assign-workspaces-to-monitors
 [gaps]
+    smart =            false
     inner.horizontal = 0
     inner.vertical =   0
     outer.left =       0


### PR DESCRIPTION
I did a simple implementation for smart gaps that behaves more or less as i3-gaps.

I tested the various scenarios:
- property missing: standard behaviour, default false
- smart = true: if only one tiled window is present remove outer gaps, once more than one are there add outer gaps

let me know if some tests are needed