### PR TITLE
Add support for --json flag to format output as json to `list-modes` command

### DIFF
--- a/Sources/AppBundle/command/impl/ListModesCommand.swift
+++ b/Sources/AppBundle/command/impl/ListModesCommand.swift
@@ -7,6 +7,14 @@ struct ListModesCommand: Command {
     func run(_ env: CmdEnv, _ io: CmdIo) -> Bool {
         if args.current {
             return io.out(activeMode ?? mainModeId)
+        } else if args.json {
+            let modeNames: [String] = config.modes.map { $0.key }
+            return switch JSONEncoder.aeroSpaceDefault.encodeToString(modeNames).map(Result.success)
+                ?? .failure("Can't encode '\(modeNames)' to JSON")
+            {
+                case .success(let json): io.out(json)
+                case .failure(let msg): io.err(msg)
+            }
         } else {
             let modeNames: [String] = config.modes.map { $0.key }
             return io.out(modeNames)

--- a/Sources/AppBundleTests/command/ListModesTest.swift
+++ b/Sources/AppBundleTests/command/ListModesTest.swift
@@ -6,5 +6,6 @@ final class ListModesTest: XCTestCase {
     func testParseListModesCommand() {
         testParseCommandSucc("list-modes", ListModesCmdArgs(rawArgs: []))
         testParseCommandSucc("list-modes --current", ListModesCmdArgs(rawArgs: []).copy(\.current, true))
+        testParseCommandSucc("list-modes --json", ListModesCmdArgs(rawArgs: []).copy(\.json, true))
     }
 }

--- a/Sources/Common/cmdArgs/impl/ListModesCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/ListModesCmdArgs.swift
@@ -9,6 +9,7 @@ public struct ListModesCmdArgs: CmdArgs {
         help: list_modes_help_generated,
         options: [
             "--current": trueBoolFlag(\.current),
+            "--json": trueBoolFlag(\.json),
         ],
         arguments: []
     )
@@ -16,6 +17,7 @@ public struct ListModesCmdArgs: CmdArgs {
     public var windowId: UInt32?               // unused
     public var workspaceName: WorkspaceName?   // unused
     public var current: Bool = false
+    public var json: Bool = false
 }
 
 public func parseListModesCmdArgs(_ args: [String]) -> ParsedCmd<ListModesCmdArgs> {


### PR DESCRIPTION
Implemented this for https://github.com/nikitabobko/AeroSpace/issues/1026