### PR TITLE
Implement focus dfs-next/dfs-prev.

### DIFF
--- a/Sources/AppBundle/command/cmdManifest.swift
+++ b/Sources/AppBundle/command/cmdManifest.swift
@@ -68,6 +68,8 @@ extension CmdArgs {
                 command = SplitCommand(args: self as! SplitCmdArgs)
             case .summonWorkspace:
                 command = SummonWorkspaceCommand(args: self as! SummonWorkspaceCmdArgs)
+            case .swap:
+                command = SwapCommand(args: self as! SwapCmdArgs)
             case .triggerBinding:
                 command = TriggerBindingCommand(args: self as! TriggerBindingCmdArgs)
             case .volume:

--- a/Sources/AppBundle/command/impl/FocusCommand.swift
+++ b/Sources/AppBundle/command/impl/FocusCommand.swift
@@ -162,7 +162,7 @@ private struct FloatingWindowData {
 
 extension TreeNode {
     @MainActor
-    fileprivate func findFocusTargetRecursive(snappedTo direction: CardinalDirection) -> Window? {
+    func findFocusTargetRecursive(snappedTo direction: CardinalDirection) -> Window? {
         switch nodeCases {
             case .workspace(let workspace):
                 return workspace.rootTilingContainer.findFocusTargetRecursive(snappedTo: direction)

--- a/Sources/AppBundle/command/impl/FocusCommand.swift
+++ b/Sources/AppBundle/command/impl/FocusCommand.swift
@@ -36,6 +36,24 @@ struct FocusCommand: Command {
                 } else {
                     return io.err("Can't find window with DFS index \(dfsIndex)")
                 }
+            case .dfsRelative(let nextPrev):
+                let windows = target.workspace.rootTilingContainer.allLeafWindowsRecursive
+                guard let currentIndex = windows.firstIndex(where: { $0 == target.windowOrNil }) else {
+                    return false
+                }
+                var targetIndex = switch nextPrev {
+                    case .dfsNext: currentIndex + 1
+                    case .dfsPrev: currentIndex - 1
+                }
+                if targetIndex < 0 || targetIndex >= windows.count {
+                    switch args.boundariesAction {
+                        case .stop: return true
+                        case .fail: return false
+                        case .wrapAroundTheWorkspace: targetIndex = (targetIndex + windows.count) % windows.count
+                        case .wrapAroundAllMonitors: return dieT("Must be discarded by args parser")
+                    }
+                }
+                return windows[targetIndex].focusWindow()
         }
     }
 }

--- a/Sources/AppBundle/command/impl/SwapCommand.swift
+++ b/Sources/AppBundle/command/impl/SwapCommand.swift
@@ -1,0 +1,55 @@
+import AppKit
+import Common
+
+struct SwapCommand: Command {
+    let args: SwapCmdArgs
+
+    func run(_ env: CmdEnv, _ io: CmdIo) async throws -> Bool {
+        guard let target = args.resolveTargetOrReportError(env, io) else {
+            return false
+        }
+
+        guard let currentWindow = target.windowOrNil else {
+            return io.err(noWindowIsFocused)
+        }
+
+        let targetWindow: Window?
+        switch args.target.val {
+            case .direction(let direction):
+                if let (parent, ownIndex) = currentWindow.closestParent(hasChildrenInDirection: direction, withLayout: nil) {
+                    targetWindow = parent.children[ownIndex + direction.focusOffset].findFocusTargetRecursive(snappedTo: direction.opposite)
+                } else if args.wrapAround {
+                    targetWindow = target.workspace.findFocusTargetRecursive(snappedTo: direction.opposite)
+                } else {
+                    return false
+                }
+            case .dfsRelative(let nextPrev):
+                let windows = target.workspace.rootTilingContainer.allLeafWindowsRecursive
+                guard let currentIndex = windows.firstIndex(where: { $0 == target.windowOrNil }) else {
+                    return false
+                }
+                var targetIndex = switch nextPrev {
+                    case .dfsNext: currentIndex + 1
+                    case .dfsPrev: currentIndex - 1
+                }
+                if targetIndex < 0 || targetIndex >= windows.count {
+                    if !args.wrapAround {
+                        return false
+                    }
+                    targetIndex = (targetIndex + windows.count) % windows.count
+                }
+                targetWindow = windows[targetIndex]
+        }
+
+        guard let targetWindow else {
+            return false
+        }
+
+        swapWindows(currentWindow, targetWindow)
+
+        if args.swapFocus {
+            return targetWindow.focusWindow()
+        }
+        return currentWindow.focusWindow()
+    }
+}

--- a/Sources/AppBundleTests/command/FocusCommandTest.swift
+++ b/Sources/AppBundleTests/command/FocusCommandTest.swift
@@ -25,7 +25,7 @@ final class FocusCommandTest: XCTestCase {
 
     func testParse() {
         XCTAssertTrue(parseCommand("focus --boundaries left").errorOrNil?.contains("Possible values") == true)
-        var expected = FocusCmdArgs(rawArgs: [], direction: .left)
+        var expected = FocusCmdArgs(rawArgs: [], cardinalOrDfsDirection: .direction(.left))
         expected.rawBoundaries = .workspace
         testParseCommandSucc("focus --boundaries workspace left", expected)
 
@@ -36,6 +36,10 @@ final class FocusCommandTest: XCTestCase {
         assertEquals(
             parseCommand("focus --window-id 42 --ignore-floating").errorOrNil,
             "--window-id is incompatible with other options",
+        )
+        assertEquals(
+            parseCommand("focus --boundaries all-monitors-outer-frame dfs-next").errorOrNil,
+            "(dfs-next|dfs-prev) only supports --boundaries workspace",
         )
     }
 
@@ -92,7 +96,7 @@ final class FocusCommandTest: XCTestCase {
         }
 
         assertEquals(focus.windowOrNil?.windowId, 1)
-        var args = FocusCmdArgs(rawArgs: [], direction: .left)
+        var args = FocusCmdArgs(rawArgs: [], cardinalOrDfsDirection: .direction(.left))
         args.rawBoundaries = .workspace
         args.rawBoundariesAction = .wrapAroundTheWorkspace
         try await FocusCommand(args: args).run(.defaultEnv, .emptyStdin)
@@ -156,10 +160,79 @@ final class FocusCommandTest: XCTestCase {
         try await FocusCommand.new(direction: .left).run(.defaultEnv, .emptyStdin)
         assertEquals(focus.windowOrNil?.windowId, 1)
     }
+
+    func testFocusDfsRelative() async throws {
+        Workspace.get(byName: name).rootTilingContainer.apply {
+            TilingContainer.newVTiles(parent: $0, adaptiveWeight: 1).apply {
+                assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)
+                TilingContainer.newHTiles(parent: $0, adaptiveWeight: 1).apply {
+                    TestWindow.new(id: 2, parent: $0)
+                    TestWindow.new(id: 3, parent: $0)
+                }
+            }
+            TestWindow.new(id: 4, parent: $0)
+        }
+
+        assertEquals(focus.windowOrNil?.windowId, 1)
+
+        try await FocusCommand.new(dfsRelative: .dfsNext).run(.defaultEnv, .emptyStdin)
+        assertEquals(focus.windowOrNil?.windowId, 2)
+        try await FocusCommand.new(dfsRelative: .dfsNext).run(.defaultEnv, .emptyStdin)
+        assertEquals(focus.windowOrNil?.windowId, 3)
+        try await FocusCommand.new(dfsRelative: .dfsNext).run(.defaultEnv, .emptyStdin)
+        assertEquals(focus.windowOrNil?.windowId, 4)
+
+        try await FocusCommand.new(dfsRelative: .dfsPrev).run(.defaultEnv, .emptyStdin)
+        assertEquals(focus.windowOrNil?.windowId, 3)
+        try await FocusCommand.new(dfsRelative: .dfsPrev).run(.defaultEnv, .emptyStdin)
+        assertEquals(focus.windowOrNil?.windowId, 2)
+        try await FocusCommand.new(dfsRelative: .dfsPrev).run(.defaultEnv, .emptyStdin)
+        assertEquals(focus.windowOrNil?.windowId, 1)
+    }
+
+    func testFocusDfsRelativeWrapping() async throws {
+        Workspace.get(byName: name).rootTilingContainer.apply {
+            assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)
+            TestWindow.new(id: 2, parent: $0)
+        }
+
+        assertEquals(focus.windowOrNil?.windowId, 1)
+
+        var args = FocusCmdArgs(rawArgs: [], cardinalOrDfsDirection: .dfsRelative(.dfsPrev))
+
+        args.rawBoundariesAction = .stop
+        assertEquals(try await FocusCommand(args: args).run(.defaultEnv, .emptyStdin).exitCode, 0)
+        assertEquals(focus.windowOrNil?.windowId, 1)
+
+        args.rawBoundariesAction = .fail
+        assertEquals(try await FocusCommand(args: args).run(.defaultEnv, .emptyStdin).exitCode, 1)
+        assertEquals(focus.windowOrNil?.windowId, 1)
+
+        args.rawBoundariesAction = .wrapAroundTheWorkspace
+        assertEquals(try await FocusCommand(args: args).run(.defaultEnv, .emptyStdin).exitCode, 0)
+        assertEquals(focus.windowOrNil?.windowId, 2)
+
+        args.cardinalOrDfsDirection = .dfsRelative(.dfsNext)
+
+        args.rawBoundariesAction = .stop
+        assertEquals(try await FocusCommand(args: args).run(.defaultEnv, .emptyStdin).exitCode, 0)
+        assertEquals(focus.windowOrNil?.windowId, 2)
+
+        args.rawBoundariesAction = .fail
+        assertEquals(try await FocusCommand(args: args).run(.defaultEnv, .emptyStdin).exitCode, 1)
+        assertEquals(focus.windowOrNil?.windowId, 2)
+
+        args.rawBoundariesAction = .wrapAroundTheWorkspace
+        assertEquals(try await FocusCommand(args: args).run(.defaultEnv, .emptyStdin).exitCode, 0)
+        assertEquals(focus.windowOrNil?.windowId, 1)
+    }
 }
 
 extension FocusCommand {
     static func new(direction: CardinalDirection) -> FocusCommand {
-        FocusCommand(args: FocusCmdArgs(rawArgs: [], direction: direction))
+        FocusCommand(args: FocusCmdArgs(rawArgs: [], cardinalOrDfsDirection: .direction(direction)))
+    }
+    static func new(dfsRelative: DfsNextPrev) -> FocusCommand {
+        FocusCommand(args: FocusCmdArgs(rawArgs: [], cardinalOrDfsDirection: .dfsRelative(dfsRelative)))
     }
 }

--- a/Sources/AppBundleTests/command/SwapCommandTest.swift
+++ b/Sources/AppBundleTests/command/SwapCommandTest.swift
@@ -1,0 +1,128 @@
+@testable import AppBundle
+import Common
+import XCTest
+
+@MainActor
+final class SwapCommandTest: XCTestCase {
+    override func setUp() async throws { setUpWorkspacesForTests() }
+
+    func testSwap_swapWindows_Directional() async throws {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            TilingContainer.newVTiles(parent: $0, adaptiveWeight: 1).apply {
+                assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)
+                TestWindow.new(id: 2, parent: $0)
+            }
+            TestWindow.new(id: 3, parent: $0)
+        }
+
+        try await SwapCommand(args: SwapCmdArgs(rawArgs: [], target: .direction(.right))).run(.defaultEnv, .emptyStdin)
+        assertEquals(root.layoutDescription,
+                     .h_tiles([.v_tiles([.window(3), .window(2)]),
+                               .window(1)]))
+        assertEquals(focus.windowOrNil?.windowId, 1)
+
+        try await SwapCommand(args: SwapCmdArgs(rawArgs: [], target: .direction(.left))).run(.defaultEnv, .emptyStdin)
+        assertEquals(root.layoutDescription,
+                     .h_tiles([.v_tiles([.window(1), .window(2)]),
+                               .window(3)]))
+        assertEquals(focus.windowOrNil?.windowId, 1)
+
+        try await SwapCommand(args: SwapCmdArgs(rawArgs: [], target: .direction(.down))).run(.defaultEnv, .emptyStdin)
+        assertEquals(root.layoutDescription,
+                     .h_tiles([.v_tiles([.window(2), .window(1)]),
+                               .window(3)]))
+        assertEquals(focus.windowOrNil?.windowId, 1)
+
+        try await SwapCommand(args: SwapCmdArgs(rawArgs: [], target: .direction(.up))).run(.defaultEnv, .emptyStdin)
+        assertEquals(root.layoutDescription,
+                     .h_tiles([.v_tiles([.window(1), .window(2)]),
+                               .window(3)]))
+        assertEquals(focus.windowOrNil?.windowId, 1)
+    }
+
+    func testSwap_swapWindows_DfsRelative() async throws {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            TilingContainer.newVTiles(parent: $0, adaptiveWeight: 1).apply {
+                assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)
+                TestWindow.new(id: 2, parent: $0)
+            }
+            TestWindow.new(id: 3, parent: $0)
+        }
+
+        try await SwapCommand(args: SwapCmdArgs(rawArgs: [], target: .dfsRelative(.dfsNext))).run(.defaultEnv, .emptyStdin)
+        assertEquals(root.layoutDescription,
+                     .h_tiles([.v_tiles([.window(2), .window(1)]),
+                               .window(3)]))
+        assertEquals(focus.windowOrNil?.windowId, 1)
+
+        try await SwapCommand(args: SwapCmdArgs(rawArgs: [], target: .dfsRelative(.dfsNext))).run(.defaultEnv, .emptyStdin)
+        assertEquals(root.layoutDescription,
+                     .h_tiles([.v_tiles([.window(2), .window(3)]),
+                               .window(1)]))
+        assertEquals(focus.windowOrNil?.windowId, 1)
+
+        try await SwapCommand(args: SwapCmdArgs(rawArgs: [], target: .dfsRelative(.dfsPrev))).run(.defaultEnv, .emptyStdin)
+        assertEquals(root.layoutDescription,
+                     .h_tiles([.v_tiles([.window(2), .window(1)]),
+                               .window(3)]))
+        assertEquals(focus.windowOrNil?.windowId, 1)
+
+        try await SwapCommand(args: SwapCmdArgs(rawArgs: [], target: .dfsRelative(.dfsPrev))).run(.defaultEnv, .emptyStdin)
+        assertEquals(root.layoutDescription,
+                     .h_tiles([.v_tiles([.window(1), .window(2)]),
+                               .window(3)]))
+        assertEquals(focus.windowOrNil?.windowId, 1)
+    }
+
+    func testSwap_DirectionalWrapping() async throws {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)
+            TestWindow.new(id: 2, parent: $0)
+            TestWindow.new(id: 3, parent: $0)
+        }
+
+        var args = SwapCmdArgs(rawArgs: [], target: .direction(.left))
+        args.wrapAround = true
+        try await SwapCommand(args: args).run(.defaultEnv, .emptyStdin)
+        assertEquals(root.layoutDescription, .h_tiles([.window(3), .window(2), .window(1)]))
+        assertEquals(focus.windowOrNil?.windowId, 1)
+
+        args.target = .initialized(.direction(.right))
+        try await SwapCommand(args: args).run(.defaultEnv, .emptyStdin)
+        assertEquals(root.layoutDescription, .h_tiles([.window(1), .window(2), .window(3)]))
+        assertEquals(focus.windowOrNil?.windowId, 1)
+    }
+
+    func testSwap_DfsRelativeWrapping() async throws {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)
+            TestWindow.new(id: 2, parent: $0)
+            TestWindow.new(id: 3, parent: $0)
+        }
+
+        var args = SwapCmdArgs(rawArgs: [], target: .dfsRelative(.dfsPrev))
+        args.wrapAround = true
+        try await SwapCommand(args: args).run(.defaultEnv, .emptyStdin)
+        assertEquals(root.layoutDescription, .h_tiles([.window(3), .window(2), .window(1)]))
+        assertEquals(focus.windowOrNil?.windowId, 1)
+
+        args.target = .initialized(.dfsRelative(.dfsNext))
+        try await SwapCommand(args: args).run(.defaultEnv, .emptyStdin)
+        assertEquals(root.layoutDescription, .h_tiles([.window(1), .window(2), .window(3)]))
+        assertEquals(focus.windowOrNil?.windowId, 1)
+    }
+
+    func testSwap_SwapFocus() async throws {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            assertEquals(TestWindow.new(id: 2, parent: $0).focusWindow(), true)
+            TestWindow.new(id: 3, parent: $0)
+        }
+
+        var args = SwapCmdArgs(rawArgs: [], target: .direction(.right))
+        args.swapFocus = true
+        try await SwapCommand(args: args).run(.defaultEnv, .emptyStdin)
+        assertEquals(root.layoutDescription, .h_tiles([.window(1), .window(3), .window(2)]))
+        assertEquals(focus.windowOrNil?.windowId, 3)
+    }
+}

--- a/Sources/Cli/subcommandDescriptionsGenerated.swift
+++ b/Sources/Cli/subcommandDescriptionsGenerated.swift
@@ -33,6 +33,7 @@ let subcommandDescriptions = [
     ["  resize", "Resize the focused window"],
     ["  split", "Split focused window"],
     ["  summon-workspace", "Move the requested workspace to the focused monitor."],
+    ["  swap", "Swaps the focused window with another window."],
     ["  trigger-binding", "Trigger AeroSpace binding as if it was pressed by user"],
     ["  volume", "Manipulate volume"],
     ["  workspace-back-and-forth", "Switch between the focused workspace and previously focused workspace back and forth"],

--- a/Sources/Cli/subcommandDescriptionsGenerated.swift
+++ b/Sources/Cli/subcommandDescriptionsGenerated.swift
@@ -11,7 +11,7 @@ let subcommandDescriptions = [
     ["  flatten-workspace-tree", "Flatten the tree of the focused workspace"],
     ["  focus-back-and-forth", "Switch between the current and previously focused elements back and forth"],
     ["  focus-monitor", "Focus monitor by relative direction, by order, or by pattern"],
-    ["  focus", "Set focus to the nearest window in the given direction."],
+    ["  focus", "Set focus to a window."],
     ["  fullscreen", "Toggle the fullscreen mode for the focused window"],
     ["  join-with", "Put the focused window and the nearest node in the specified direction under a common parent container"],
     ["  layout", "Change layout of the focused window to the given layout"],

--- a/Sources/Common/cmdArgs/ArgParser.swift
+++ b/Sources/Common/cmdArgs/ArgParser.swift
@@ -96,6 +96,10 @@ public func parseCardinalDirectionArg(arg: String, nextArgs: inout [String]) -> 
     parseEnum(arg, CardinalDirection.self)
 }
 
+func parseCardinalOrDfsDirection(_ arg: String, _ nextArgs: inout [String]) -> Parsed<CardinalOrDfsDirection> {
+    parseEnum(arg, CardinalOrDfsDirection.self)
+}
+
 public func parseArgWithUInt32(arg: String, nextArgs: inout [String]) -> Parsed<UInt32> {
     if let arg = nextArgs.nextNonFlagOrNil() {
         return UInt32(arg).orFailure("Can't parse '\(arg)'. It must be a positive number")

--- a/Sources/Common/cmdArgs/cmdArgsManifest.swift
+++ b/Sources/Common/cmdArgs/cmdArgsManifest.swift
@@ -33,6 +33,7 @@ public enum CmdKind: String, CaseIterable, Equatable, Sendable {
     case resize
     case split
     case summonWorkspace = "summon-workspace"
+    case swap
     case triggerBinding = "trigger-binding"
     case volume
     case workspace
@@ -111,6 +112,8 @@ func initSubcommands() -> [String: any SubCommandParserProtocol] {
                 result[kind.rawValue] = SubCommandParser(parseSplitCmdArgs)
             case .summonWorkspace:
                 result[kind.rawValue] = SubCommandParser(SummonWorkspaceCmdArgs.init)
+            case .swap:
+                result[kind.rawValue] = SubCommandParser(parseSwapCmdArgs)
             case .triggerBinding:
                 result[kind.rawValue] = SubCommandParser(parseTriggerBindingCmdArgs)
             case .volume:

--- a/Sources/Common/cmdArgs/impl/FocusMonitorCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/FocusMonitorCmdArgs.swift
@@ -42,10 +42,6 @@ func parseTarget(_ arg: String, _ nextArgs: inout [String]) -> Parsed<MonitorTar
     }
 }
 
-public enum NextPrev: String, Equatable, Sendable, CaseIterable {
-    case next, prev
-}
-
 public enum MonitorTarget: Equatable, Sendable {
     case direction(CardinalDirection)
     case relative(NextPrev)

--- a/Sources/Common/cmdArgs/impl/SwapCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/SwapCmdArgs.swift
@@ -1,0 +1,29 @@
+public struct SwapCmdArgs: CmdArgs {
+    public let rawArgs: EquatableNoop<[String]>
+    public init(rawArgs: [String]) { self.rawArgs = .init(rawArgs) }
+    public static let parser: CmdParser<Self> = cmdParser(
+        kind: .swap,
+        allowInConfig: true,
+        help: swap_help_generated,
+        options: [
+            "--swap-focus": trueBoolFlag(\.swapFocus),
+            "--wrap-around": trueBoolFlag(\.wrapAround),
+        ],
+        arguments: [newArgParser(\.target, parseCardinalOrDfsDirection, mandatoryArgPlaceholder: CardinalOrDfsDirection.unionLiteral)],
+    )
+
+    public var target: Lateinit<CardinalOrDfsDirection> = .uninitialized
+    public var swapFocus: Bool = false
+    public var wrapAround: Bool = false
+    public var windowId: UInt32?
+    public var workspaceName: WorkspaceName?
+
+    public init(rawArgs: [String], target: CardinalOrDfsDirection) {
+        self.rawArgs = .init(rawArgs)
+        self.target = .initialized(target)
+    }
+}
+
+public func parseSwapCmdArgs(_ args: [String]) -> ParsedCmd<SwapCmdArgs> {
+    return parseSpecificCmdArgs(SwapCmdArgs(rawArgs: args), args)
+}

--- a/Sources/Common/cmdHelpGenerated.swift
+++ b/Sources/Common/cmdHelpGenerated.swift
@@ -131,6 +131,10 @@ let split_help_generated = """
 let summon_workspace_help_generated = """
     USAGE: summon-workspace [-h|--help] [--fail-if-noop] <workspace>
     """
+let swap_help_generated = """
+    USAGE: swap [-h|--help] [--swap-focus] [--wrap-around]
+                (left|down|up|right|dfs-next|dfs-prev)
+    """
 let trigger_binding_help_generated = """
     USAGE: trigger-binding [-h|--help] <binding> --mode <mode-id>
     """

--- a/Sources/Common/cmdHelpGenerated.swift
+++ b/Sources/Common/cmdHelpGenerated.swift
@@ -42,6 +42,9 @@ let focus_help_generated = """
     USAGE: focus [-h|--help] [--ignore-floating]
                  [--boundaries <boundary>] [--boundaries-action <action>]
                  (left|down|up|right)
+       OR: focus [-h|--help] [--ignore-floating]
+                 [--boundaries <boundary>] [--boundaries-action <action>]
+                 (dfs-next|dfs-prev)
        OR: focus [-h|--help] --window-id <window-id>
        OR: focus [-h|--help] --dfs-index <dfs-index>
     """

--- a/Sources/Common/model/CardinalOrDfsDirection.swift
+++ b/Sources/Common/model/CardinalOrDfsDirection.swift
@@ -1,0 +1,31 @@
+public enum CardinalOrDfsDirection: Equatable, Sendable {
+    case direction(CardinalDirection)
+    case dfsRelative(DfsNextPrev)
+}
+
+extension CardinalOrDfsDirection: CaseIterable {
+    public static var allCases: [CardinalOrDfsDirection] {
+        CardinalDirection.allCases.map { .direction($0) } + DfsNextPrev.allCases.map { .dfsRelative($0) }
+    }
+}
+
+extension CardinalOrDfsDirection: RawRepresentable {
+    public typealias RawValue = String
+
+    public init?(rawValue: RawValue) {
+        if let d = CardinalDirection(rawValue: rawValue) {
+            self = .direction(d)
+        } else if let np = DfsNextPrev(rawValue: rawValue) {
+            self = .dfsRelative(np)
+        } else {
+            return nil
+        }
+    }
+
+    public var rawValue: RawValue {
+        return switch self {
+            case .direction(let d): d.rawValue
+            case .dfsRelative(let np): np.rawValue
+        }
+    }
+}

--- a/Sources/Common/model/DfsNextPrev.swift
+++ b/Sources/Common/model/DfsNextPrev.swift
@@ -1,0 +1,4 @@
+public enum DfsNextPrev: String, CaseIterable, Equatable, Sendable {
+    case dfsNext = "dfs-next"
+    case dfsPrev = "dfs-prev"
+}

--- a/Sources/Common/model/NextPrev.swift
+++ b/Sources/Common/model/NextPrev.swift
@@ -1,0 +1,3 @@
+public enum NextPrev: String, Equatable, Sendable, CaseIterable {
+    case next, prev
+}

--- a/docs/aerospace-focus.adoc
+++ b/docs/aerospace-focus.adoc
@@ -2,7 +2,7 @@
 include::util/man-attributes.adoc[]
 :manname: aerospace-focus
 // tag::purpose[]
-:manpurpose: Set focus to the nearest window in the given direction.
+:manpurpose: Set focus to a window.
 // end::purpose[]
 
 // =========================================================== Synopsis
@@ -12,6 +12,9 @@ include::util/man-attributes.adoc[]
 aerospace focus [-h|--help] [--ignore-floating]
                 [--boundaries <boundary>] [--boundaries-action <action>]
                 (left|down|up|right)
+aerospace focus [-h|--help] [--ignore-floating]
+                [--boundaries <boundary>] [--boundaries-action <action>]
+                (dfs-next|dfs-prev)
 aerospace focus [-h|--help] --window-id <window-id>
 aerospace focus [-h|--help] --dfs-index <dfs-index>
 
@@ -57,6 +60,16 @@ Index is 0-based.
 --ignore-floating::
 Don't perceive floating windows as part of the tree.
 It may be useful for more reliable scripting.
+
+// =========================================================== Arguments
+include::./util/conditional-arguments-header.adoc[]
+
+(left|down|up|right)::
+Set focus to the nearest window in the given direction.
+
+(dfs-next|dfs-prev)::
+Set focus to the window before or after the current window in the depth-first order (top-to-bottom and left-to-right) of windows in the current workspace tree.
+In this mode, `--boundaries` must be `workspace` (the default) and `--boundaries-action` can be set to one of `(stop|fail|wrap-around-the-workspace)`.
 
 // end::body[]
 

--- a/docs/aerospace-swap.adoc
+++ b/docs/aerospace-swap.adoc
@@ -1,0 +1,46 @@
+= aerospace-swap(1)
+include::util/man-attributes.adoc[]
+:manname: aerospace-swap
+// tag::purpose[]
+:manpurpose: Swaps the focused window with another window.
+// end::purpose[]
+
+// =========================================================== Synopsis
+== Synopsis
+[verse]
+// tag::synopsis[]
+aerospace swap [-h|--help] [--swap-focus] [--wrap-around]
+               (left|down|up|right|dfs-next|dfs-prev)
+
+// end::synopsis[]
+
+// =========================================================== Description
+== Description
+
+// tag::body[]
+{manpurpose}
+
+// =========================================================== Options
+include::util/conditional-options-header.adoc[]
+
+-h, --help:: Print help
+
+--swap-focus::
+Swap focus away from the currently focused window. By default, this command does not change the focused window.
+
+--wrap-around::
+Wrap around if the window is at the edge of the workspace (for `(left|down|up|right)`) or the start/end of the depth first order (for `(dfs-next|dfs-prev)`).
+
+// =========================================================== Arguments
+include::./util/conditional-arguments-header.adoc[]
+
+(left|down|up|right)::
+Swaps the focused window with the nearest window in the given direction.
+
+(dfs-next|dfs-prev)::
+Swaps the focused window with the next or previous window in the depth-first order (top-to-bottom and left-to-right) of windows in the current workspace tree.
+
+// end::body[]
+
+// =========================================================== Footer
+include::util/man-footer.adoc[]

--- a/docs/commands.adoc
+++ b/docs/commands.adoc
@@ -168,6 +168,13 @@ include::aerospace-split.adoc[tags=synopsis]
 include::aerospace-split.adoc[tags=purpose]
 include::aerospace-split.adoc[tags=body]
 
+== swap
+----
+include::aerospace-swap.adoc[tags=synopsis]
+----
+include::aerospace-swap.adoc[tags=purpose]
+include::aerospace-swap.adoc[tags=body]
+
 == summon-workspace
 ----
 include::./aerospace-summon-workspace.adoc[tags=synopsis]

--- a/grammar/commands-bnf-grammar.txt
+++ b/grammar/commands-bnf-grammar.txt
@@ -20,9 +20,10 @@ aerospace -h;
 
     | flatten-workspace-tree [--workspace <workspace>]
 
-    | focus [<focus_flag>]... (left|down|up|right) [<focus_flag>]...
+    | focus [<focus_direction_flag>]... (left|down|up|right) [<focus_direction_flag>]...
     | focus --window-id <window_id>
     | focus --dfs-index <number>
+    | focus [<focus_dfs_relative_flag>]... (dfs-next|dfs-prev) [<focus_dfs_relative_flag>]...
 
     | focus-back-and-forth
 
@@ -114,7 +115,8 @@ aerospace -h;
 <move_node_to_monitor1_flag> ::= --window-id <window_id>|--focus-follows-window|--fail-if-noop|--wrap-around;
 <move_node_to_monitor2_flag> ::= --window-id <window_id>|--focus-follows-window|--fail-if-noop;
 
-<focus_flag> ::= --boundaries <boundary>|--boundaries-action <boundaries_action>|--ignore-floating;
+<focus_direction_flag> ::= --boundaries <boundary>|--boundaries-action <boundaries_action>|--ignore-floating;
+<focus_dfs_relative_flag> ::= --boundaries-action <boundaries_action>|--ignore-floating;
 <boundaries_action> ::= stop|fail|wrap-around-the-workspace|wrap-around-all-monitors;
 <boundary> ::= workspace|all-monitors-outer-frame;
 

--- a/grammar/commands-bnf-grammar.txt
+++ b/grammar/commands-bnf-grammar.txt
@@ -64,6 +64,8 @@ aerospace -h;
 
     | split [--window-id <window_id>] (horizontal|vertical|opposite) [--window-id <window_id>]
 
+    | swap [--swap-focus|--wrap-around] (left|down|up|right|dfs-next|dfs-prev) [--swap-focus|--wrap-around]
+
     | summon-workspace [--fail-if-noop] <workspace> [--fail-if-noop]
 
     | trigger-binding <binding> --mode <mode_id>


### PR DESCRIPTION
This allows switching to the next/prev window from the current one in
the depth-first order of the windows in the current workspace tree.

This is convenient, as it allows users to shift focus through a
workspace's windows in a more predictable way than the directional
movement commands, where the move target can depend on invisible
most-recently-used state.

_fixes https://github.com/nikitabobko/AeroSpace/issues/248
