### PR TITLE
Implement the swap command.

### DIFF
--- a/Sources/AppBundle/command/cmdManifest.swift
+++ b/Sources/AppBundle/command/cmdManifest.swift
@@ -64,12 +64,14 @@ extension CmdArgs {
                 command = ReloadConfigCommand(args: self as! ReloadConfigCmdArgs)
             case .resize:
                 command = ResizeCommand(args: self as! ResizeCmdArgs)
+            case .serverVersionInternalCommand:
+                command = ServerVersionInternalCommandCommand(args: self as! ServerVersionInternalCommandCmdArgs)
             case .split:
                 command = SplitCommand(args: self as! SplitCmdArgs)
             case .summonWorkspace:
                 command = SummonWorkspaceCommand(args: self as! SummonWorkspaceCmdArgs)
-            case .serverVersionInternalCommand:
-                command = ServerVersionInternalCommandCommand(args: self as! ServerVersionInternalCommandCmdArgs)
+            case .swap:
+                command = SwapCommand(args: self as! SwapCmdArgs)
             case .triggerBinding:
                 command = TriggerBindingCommand(args: self as! TriggerBindingCmdArgs)
             case .volume:

--- a/Sources/AppBundle/command/impl/FocusCommand.swift
+++ b/Sources/AppBundle/command/impl/FocusCommand.swift
@@ -36,6 +36,24 @@ struct FocusCommand: Command {
                 } else {
                     return io.err("Can't find window with DFS index \(dfsIndex)")
                 }
+            case .dfsRelative(let nextPrev):
+                let windows = target.workspace.rootTilingContainer.allLeafWindowsRecursive
+                guard let currentIndex = windows.firstIndex(where: { $0 == target.windowOrNil }) else {
+                    return false
+                }
+                var targetIndex = switch nextPrev {
+                    case .next: currentIndex + 1
+                    case .prev: currentIndex - 1
+                }
+                if targetIndex < 0 || targetIndex >= windows.count {
+                    switch args.boundariesAction {
+                        case .stop: return true
+                        case .fail: return false
+                        case .wrapAroundTheWorkspace: targetIndex = (targetIndex + windows.count) % windows.count
+                        case .wrapAroundAllMonitors: return errorT("Must be discarded by args parser")
+                    }
+                }
+                return windows[targetIndex].focusWindow()
         }
     }
 }

--- a/Sources/AppBundle/command/impl/FocusCommand.swift
+++ b/Sources/AppBundle/command/impl/FocusCommand.swift
@@ -162,7 +162,7 @@ private struct FloatingWindowData {
     let index: Int
 }
 
-private extension TreeNode {
+extension TreeNode {
     func findFocusTargetRecursive(snappedTo direction: CardinalDirection) -> Window? {
         switch nodeCases {
             case .workspace(let workspace):

--- a/Sources/AppBundle/command/impl/SwapCommand.swift
+++ b/Sources/AppBundle/command/impl/SwapCommand.swift
@@ -1,0 +1,51 @@
+import AppKit
+import Common
+
+struct SwapCommand: Command {
+    let args: SwapCmdArgs
+
+    func run(_ env: CmdEnv, _ io: CmdIo) -> Bool {
+        guard let target = args.resolveTargetOrReportError(env, io), let currentWindow = target.windowOrNil else {
+            return io.err(noWindowIsFocused)
+        }
+
+        var targetWindow: Window?
+        switch args.target.val {
+            case .direction(let direction):
+                if let (parent, ownIndex) = currentWindow.closestParent(hasChildrenInDirection: direction, withLayout: nil) {
+                    targetWindow = parent.children[ownIndex + direction.focusOffset].findFocusTargetRecursive(snappedTo: direction.opposite)
+                } else if args.wrapAround {
+                    targetWindow = target.workspace.findFocusTargetRecursive(snappedTo: direction.opposite)
+                } else {
+                    return false
+                }
+            case .dfsRelative(let nextPrev):
+                let windows = target.workspace.rootTilingContainer.allLeafWindowsRecursive
+                guard let currentIndex = windows.firstIndex(where: { $0 == target.windowOrNil }) else {
+                    return false
+                }
+                var targetIndex = switch nextPrev {
+                    case .next: currentIndex + 1
+                    case .prev: currentIndex - 1
+                }
+                if targetIndex < 0 || targetIndex >= windows.count {
+                    if !args.wrapAround {
+                        return false
+                    }
+                    targetIndex = (targetIndex + windows.count) % windows.count
+                }
+                targetWindow = windows[targetIndex]
+        }
+
+        guard let targetWindow else {
+            return false
+        }
+
+        swapWindows(currentWindow, targetWindow)
+
+        if args.swapFocus {
+            return targetWindow.focusWindow()
+        }
+        return currentWindow.focusWindow()
+    }
+}

--- a/Sources/AppBundleTests/command/SwapCommandTest.swift
+++ b/Sources/AppBundleTests/command/SwapCommandTest.swift
@@ -1,0 +1,128 @@
+@testable import AppBundle
+import Common
+import XCTest
+
+@MainActor
+final class SwapCommandTest: XCTestCase {
+    override func setUp() async throws { setUpWorkspacesForTests() }
+
+    func testSwap_swapWindows_Directional() {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            TilingContainer.newVTiles(parent: $0, adaptiveWeight: 1).apply {
+                assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)
+                TestWindow.new(id: 2, parent: $0)
+            }
+            TestWindow.new(id: 3, parent: $0)
+        }
+
+        SwapCommand(args: SwapCmdArgs(rawArgs: [], target: .direction(.right))).run(.defaultEnv, .emptyStdin)
+        assertEquals(root.layoutDescription,
+                     .h_tiles([.v_tiles([.window(3), .window(2)]),
+                               .window(1)]))
+        assertEquals(focus.windowOrNil?.windowId, 1)
+
+        SwapCommand(args: SwapCmdArgs(rawArgs: [], target: .direction(.left))).run(.defaultEnv, .emptyStdin)
+        assertEquals(root.layoutDescription,
+                     .h_tiles([.v_tiles([.window(1), .window(2)]),
+                               .window(3)]))
+        assertEquals(focus.windowOrNil?.windowId, 1)
+
+        SwapCommand(args: SwapCmdArgs(rawArgs: [], target: .direction(.down))).run(.defaultEnv, .emptyStdin)
+        assertEquals(root.layoutDescription,
+                     .h_tiles([.v_tiles([.window(2), .window(1)]),
+                               .window(3)]))
+        assertEquals(focus.windowOrNil?.windowId, 1)
+
+        SwapCommand(args: SwapCmdArgs(rawArgs: [], target: .direction(.up))).run(.defaultEnv, .emptyStdin)
+        assertEquals(root.layoutDescription,
+                     .h_tiles([.v_tiles([.window(1), .window(2)]),
+                               .window(3)]))
+        assertEquals(focus.windowOrNil?.windowId, 1)
+    }
+
+    func testSwap_swapWindows_DfsRelative() {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            TilingContainer.newVTiles(parent: $0, adaptiveWeight: 1).apply {
+                assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)
+                TestWindow.new(id: 2, parent: $0)
+            }
+            TestWindow.new(id: 3, parent: $0)
+        }
+
+        SwapCommand(args: SwapCmdArgs(rawArgs: [], target: .dfsRelative(.next))).run(.defaultEnv, .emptyStdin)
+        assertEquals(root.layoutDescription,
+                     .h_tiles([.v_tiles([.window(2), .window(1)]),
+                               .window(3)]))
+        assertEquals(focus.windowOrNil?.windowId, 1)
+
+        SwapCommand(args: SwapCmdArgs(rawArgs: [], target: .dfsRelative(.next))).run(.defaultEnv, .emptyStdin)
+        assertEquals(root.layoutDescription,
+                     .h_tiles([.v_tiles([.window(2), .window(3)]),
+                               .window(1)]))
+        assertEquals(focus.windowOrNil?.windowId, 1)
+
+        SwapCommand(args: SwapCmdArgs(rawArgs: [], target: .dfsRelative(.prev))).run(.defaultEnv, .emptyStdin)
+        assertEquals(root.layoutDescription,
+                     .h_tiles([.v_tiles([.window(2), .window(1)]),
+                               .window(3)]))
+        assertEquals(focus.windowOrNil?.windowId, 1)
+
+        SwapCommand(args: SwapCmdArgs(rawArgs: [], target: .dfsRelative(.prev))).run(.defaultEnv, .emptyStdin)
+        assertEquals(root.layoutDescription,
+                     .h_tiles([.v_tiles([.window(1), .window(2)]),
+                               .window(3)]))
+        assertEquals(focus.windowOrNil?.windowId, 1)
+    }
+
+    func testSwap_DirectionalWrapping() {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)
+            TestWindow.new(id: 2, parent: $0)
+            TestWindow.new(id: 3, parent: $0)
+        }
+
+        var args = SwapCmdArgs(rawArgs: [], target: .direction(.left))
+        args.wrapAround = true
+        SwapCommand(args: args).run(.defaultEnv, .emptyStdin)
+        assertEquals(root.layoutDescription, .h_tiles([.window(3), .window(2), .window(1)]))
+        assertEquals(focus.windowOrNil?.windowId, 1)
+
+        args.target = .initialized(.direction(.right))
+        SwapCommand(args: args).run(.defaultEnv, .emptyStdin)
+        assertEquals(root.layoutDescription, .h_tiles([.window(1), .window(2), .window(3)]))
+        assertEquals(focus.windowOrNil?.windowId, 1)
+    }
+
+    func testSwap_DfsRelativeWrapping() {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)
+            TestWindow.new(id: 2, parent: $0)
+            TestWindow.new(id: 3, parent: $0)
+        }
+
+        var args = SwapCmdArgs(rawArgs: [], target: .dfsRelative(.prev))
+        args.wrapAround = true
+        SwapCommand(args: args).run(.defaultEnv, .emptyStdin)
+        assertEquals(root.layoutDescription, .h_tiles([.window(3), .window(2), .window(1)]))
+        assertEquals(focus.windowOrNil?.windowId, 1)
+
+        args.target = .initialized(.dfsRelative(.next))
+        SwapCommand(args: args).run(.defaultEnv, .emptyStdin)
+        assertEquals(root.layoutDescription, .h_tiles([.window(1), .window(2), .window(3)]))
+        assertEquals(focus.windowOrNil?.windowId, 1)
+    }
+
+    func testSwap_SwapFocus() {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            assertEquals(TestWindow.new(id: 2, parent: $0).focusWindow(), true)
+            TestWindow.new(id: 3, parent: $0)
+        }
+
+        var args = SwapCmdArgs(rawArgs: [], target: .direction(.right))
+        args.swapFocus = true
+        SwapCommand(args: args).run(.defaultEnv, .emptyStdin)
+        assertEquals(root.layoutDescription, .h_tiles([.window(1), .window(3), .window(2)]))
+        assertEquals(focus.windowOrNil?.windowId, 3)
+    }
+}

--- a/Sources/Cli/subcommandDescriptionsGenerated.swift
+++ b/Sources/Cli/subcommandDescriptionsGenerated.swift
@@ -33,6 +33,7 @@ let subcommandDescriptions = [
     ["  resize", "Resize the focused window"],
     ["  split", "Split focused window"],
     ["  summon-workspace", "Move the requested workspace to the focused monitor."],
+    ["  swap", "Swaps the focused window with the nearest window in the given direction."],
     ["  trigger-binding", "Trigger AeroSpace binding as if it was pressed by user"],
     ["  volume", "Manipulate volume"],
     ["  workspace-back-and-forth", "Switch between the focused workspace and previously focused workspace back and forth"],

--- a/Sources/Common/cmdArgs/cmdArgsManifest.swift
+++ b/Sources/Common/cmdArgs/cmdArgsManifest.swift
@@ -33,6 +33,7 @@ public enum CmdKind: String, CaseIterable, Equatable, Sendable {
     case resize
     case split
     case summonWorkspace = "summon-workspace"
+    case swap
     case triggerBinding = "trigger-binding"
     case volume
     case workspace
@@ -109,14 +110,16 @@ func initSubcommands() -> [String: any SubCommandParserProtocol] {
                 result[kind.rawValue] = SubCommandParser(ReloadConfigCmdArgs.init)
             case .resize:
                 result[kind.rawValue] = SubCommandParser(parseResizeCmdArgs)
-            case .split:
-                result[kind.rawValue] = SubCommandParser(parseSplitCmdArgs)
-            case .summonWorkspace:
-                result[kind.rawValue] = SubCommandParser(SummonWorkspaceCmdArgs.init)
             case .serverVersionInternalCommand:
                 if isServer {
                     result[kind.rawValue] = SubCommandParser(ServerVersionInternalCommandCmdArgs.init)
                 }
+            case .split:
+                result[kind.rawValue] = SubCommandParser(parseSplitCmdArgs)
+            case .summonWorkspace:
+                result[kind.rawValue] = SubCommandParser(SummonWorkspaceCmdArgs.init)
+            case .swap:
+                result[kind.rawValue] = SubCommandParser(parseSwapCmdArgs)
             case .triggerBinding:
                 result[kind.rawValue] = SubCommandParser(parseTriggerBindingCmdArgs)
             case .volume:

--- a/Sources/Common/cmdArgs/impl/FocusMonitorCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/FocusMonitorCmdArgs.swift
@@ -42,10 +42,6 @@ func parseTarget(_ arg: String, _ nextArgs: inout [String]) -> Parsed<MonitorTar
     }
 }
 
-public enum NextPrev: Equatable, Sendable {
-    case next, prev
-}
-
 public enum MonitorTarget: Equatable, Sendable {
     case directional(CardinalDirection)
     case relative(NextPrev)

--- a/Sources/Common/cmdArgs/impl/SwapCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/SwapCmdArgs.swift
@@ -1,0 +1,29 @@
+public struct SwapCmdArgs: CmdArgs {
+    public let rawArgs: EquatableNoop<[String]>
+    public init(rawArgs: [String]) { self.rawArgs = .init(rawArgs) }
+    public static let parser: CmdParser<Self> = cmdParser(
+        kind: .swap,
+        allowInConfig: true,
+        help: swap_help_generated,
+        options: [
+            "--swap-focus": trueBoolFlag(\.swapFocus),
+            "--wrap-around": trueBoolFlag(\.wrapAround),
+        ],
+        arguments: [newArgParser(\.target, parseFocusTargetArg, mandatoryArgPlaceholder: "(left|down|up|right|dfs-next|dfs-prev)")]
+    )
+
+    public var target: Lateinit<FocusTargetArg> = .uninitialized
+    public var swapFocus: Bool = false
+    public var wrapAround: Bool = false
+    public var windowId: UInt32?
+    public var workspaceName: WorkspaceName?
+
+    public init(rawArgs: [String], target: FocusTargetArg) {
+        self.rawArgs = .init(rawArgs)
+        self.target = .initialized(target)
+    }
+}
+
+public func parseSwapCmdArgs(_ args: [String]) -> ParsedCmd<SwapCmdArgs> {
+    return parseSpecificCmdArgs(SwapCmdArgs(rawArgs: args), args)
+}

--- a/Sources/Common/cmdHelpGenerated.swift
+++ b/Sources/Common/cmdHelpGenerated.swift
@@ -42,6 +42,9 @@ let focus_help_generated = """
     USAGE: focus [-h|--help] [--ignore-floating]
                  [--boundaries <boundary>] [--boundaries-action <action>]
                  (left|down|up|right)
+       OR: focus [-h|--help] [--ignore-floating]
+                 [--boundaries <boundary>] [--boundaries-action <action>]
+                 (dfs-next|dfs-prev)
        OR: focus [-h|--help] --window-id <window-id>
        OR: focus [-h|--help] --dfs-index <dfs-index>
     """

--- a/Sources/Common/cmdHelpGenerated.swift
+++ b/Sources/Common/cmdHelpGenerated.swift
@@ -131,6 +131,10 @@ let split_help_generated = """
 let summon_workspace_help_generated = """
     USAGE: summon-workspace [-h|--help] [--fail-if-noop] <workspace>
     """
+let swap_help_generated = """
+    USAGE: swap [-h|--help] [--move-focus-to-target] [--wrap-around]
+                (left|down|up|right|dfs-next|dfs-prev)
+    """
 let trigger_binding_help_generated = """
     USAGE: trigger-binding [-h|--help] <binding> --mode <mode-id>
     """

--- a/Sources/Common/model/NextPrev.swift
+++ b/Sources/Common/model/NextPrev.swift
@@ -1,0 +1,3 @@
+public enum NextPrev: String, CaseIterable, Equatable, Sendable {
+    case next, prev
+}

--- a/docs/aerospace-focus.adoc
+++ b/docs/aerospace-focus.adoc
@@ -12,6 +12,9 @@ include::util/man-attributes.adoc[]
 aerospace focus [-h|--help] [--ignore-floating]
                 [--boundaries <boundary>] [--boundaries-action <action>]
                 (left|down|up|right)
+aerospace focus [-h|--help] [--ignore-floating]
+                [--boundaries <boundary>] [--boundaries-action <action>]
+                (dfs-next|dfs-prev)
 aerospace focus [-h|--help] --window-id <window-id>
 aerospace focus [-h|--help] --dfs-index <dfs-index>
 
@@ -31,6 +34,15 @@ This behavior can be disabled with `--ignore-floating` flag.
 
 `focus child|parent` isn't supported because the necessity of this operation is under the question.
 https://github.com/nikitabobko/AeroSpace/issues/5
+
+*1. (left|down|up|right) arguments*
+
+{manpurpose}
+
+*2. (dfs-next|dfs-prev) arguments*
+
+Set focus to the window before or after the current window in the depth-first order (top-to-bottom and left-to-right) of windows in the current workspace tree.
+In this mode, `--boundaries` must be `workspace` (the default) and `--boundaries-action` can be set to one of `(stop|fail|wrap-around-the-workspace)`.
 
 // =========================================================== Options
 include::util/conditional-options-header.adoc[]

--- a/docs/aerospace-swap.adoc
+++ b/docs/aerospace-swap.adoc
@@ -1,0 +1,45 @@
+= aerospace-swap(1)
+include::util/man-attributes.adoc[]
+:manname: aerospace-swap
+// tag::purpose[]
+:manpurpose: Swaps the focused window with the nearest window in the given direction.
+// end::purpose[]
+
+// =========================================================== Synopsis
+== Synopsis
+[verse]
+// tag::synopsis[]
+aerospace swap [-h|--help] [--move-focus-to-target] [--wrap-around]
+               (left|down|up|right|dfs-next|dfs-prev)
+
+// end::synopsis[]
+
+// =========================================================== Description
+== Description
+
+// tag::body[]
+{manpurpose}
+
+*1. (left|down|up|right) arguments*
+
+{manpurpose}
+
+*2. (dfs-next|dfs-prev) arguments*
+
+Swaps the focused window with the next or previous window in the depth-first order (top-to-bottom and left-to-right) of windows in the current workspace tree.
+
+// =========================================================== Options
+include::util/conditional-options-header.adoc[]
+
+-h, --help:: Print help
+
+--swap-focus::
+Swap focus away from the currently focused window. By default, this command does not change the focused window.
+
+--wrap-around::
+Wrap around if the window is at the edge of the workspace (for `(left|down|up|right)`) or the start/end of the depth first order (for `(dfs-next|dfs-prev)`).
+
+// end::body[]
+
+// =========================================================== Footer
+include::util/man-footer.adoc[]

--- a/grammar/commands-bnf-grammar.txt
+++ b/grammar/commands-bnf-grammar.txt
@@ -64,6 +64,8 @@ aerospace -h;
 
     | split [--window-id <window_id>] (horizontal|vertical|opposite) [--window-id <window_id>]
 
+    | swap [--swap-focus|--wrap-around] (left|down|up|right|dfs-next|dfs-prev) [--swap-focus|--wrap-around]
+
     | summon-workspace [--fail-if-noop] <workspace> [--fail-if-noop]
 
     | trigger-binding <binding> --mode <mode_id>

--- a/grammar/commands-bnf-grammar.txt
+++ b/grammar/commands-bnf-grammar.txt
@@ -20,9 +20,10 @@ aerospace -h;
 
     | flatten-workspace-tree [--workspace <workspace>]
 
-    | focus [<focus_flag>]... (left|down|up|right) [<focus_flag>]...
+    | focus [<focus_dir_flag>]... (left|down|up|right) [<focus_dir_flag>]...
     | focus --window-id <window_id>
     | focus --dfs-index <number>
+    | focus [<focus_dfs_relative_flag>]... (dfs-next|dfs-prev) [<focus_dfs_relative_flag>]...
 
     | focus-back-and-forth
 
@@ -111,8 +112,10 @@ aerospace -h;
 <move_node_to_monitor1_flag> ::= --window-id <window_id>|--focus-follows-window|--fail-if-noop|--wrap-around;
 <move_node_to_monitor2_flag> ::= --window-id <window_id>|--focus-follows-window|--fail-if-noop;
 
-<focus_flag> ::= --boundaries <boundary>|--boundaries-action <boundaries_action>|--ignore-floating;
-<boundaries_action> ::= stop|fail|wrap-around-the-workspace|wrap-around-all-monitors;
+<focus_dir_flag> ::= --boundaries <boundary>|--boundaries-action <dir_boundaries_action>|--ignore-floating;
+<focus_dfs_relative_flag> ::= --boundaries-action <dfs_relative_boundaries_action>|--ignore-floating;
+<dir_boundaries_action> ::= stop|fail|wrap-around-the-workspace|wrap-around-all-monitors;
+<dfs_relative_boundaries_action> ::= stop|fail|wrap-around-the-workspace;
 <boundary> ::= workspace|all-monitors-outer-frame;
 
 <list_windows_filter_flag> ::= --workspace (visible | focused | <workspace>)...


### PR DESCRIPTION
`aerospace swap` swaps the currently focused window with a window in a
cardinal direction or with the next/prev window in the depth first order
of windows in the workspace.

Target window selection works identically to the focus command (so the
cardinal directions respect MRU).

_fixes https://github.com/nikitabobko/AeroSpace/issues/8
