### PR TITLE
Coalesce idempotent refreshSession calls triggered by event handlers

### DIFF
--- a/Sources/AppBundle/GlobalObserver.swift
+++ b/Sources/AppBundle/GlobalObserver.swift
@@ -11,7 +11,7 @@ class GlobalObserver {
         }
         let notifName = notification.name.rawValue
         MainActor.assumeIsolated {
-            refreshAndLayout(.globalObserver(notifName), screenIsDefinitelyUnlocked: false)
+            scheduleRefreshAndLayout(.globalObserver(notifName), screenIsDefinitelyUnlocked: false)
         }
     }
 
@@ -67,7 +67,7 @@ class GlobalObserver {
                 // Detect close button clicks for unfocused windows. Yes, kAXUIElementDestroyedNotification is that unreliable
                 //  And trigger new window detection that could be delayed due to mouseDown event
                 default:
-                    refreshAndLayout(.globalObserverLeftMouseUp, screenIsDefinitelyUnlocked: true)
+                    scheduleRefreshAndLayout(.globalObserverLeftMouseUp, screenIsDefinitelyUnlocked: true)
             }
         }
     }

--- a/Sources/AppBundle/mouse/moveWithMouse.swift
+++ b/Sources/AppBundle/mouse/moveWithMouse.swift
@@ -9,7 +9,7 @@ func movedObs(_ obs: AXObserver, ax: AXUIElement, notif: CFString, data: UnsafeM
         if let windowId, let window = Window.get(byId: windowId), TrayMenuModel.shared.isEnabled {
             moveWithMouseIfTheCase(window)
         }
-        refreshAndLayout(.ax(notif), screenIsDefinitelyUnlocked: false)
+        scheduleRefreshAndLayout(.ax(notif), screenIsDefinitelyUnlocked: false)
     }
 }
 

--- a/Sources/AppBundle/mouse/resizeWithMouse.swift
+++ b/Sources/AppBundle/mouse/resizeWithMouse.swift
@@ -9,7 +9,7 @@ func resizedObs(_ obs: AXObserver, ax: AXUIElement, notif: CFString, data: Unsaf
         if let windowId, let window = Window.get(byId: windowId), TrayMenuModel.shared.isEnabled {
             resizeWithMouseIfTheCase(window)
         }
-        refreshAndLayout(.ax(notif), screenIsDefinitelyUnlocked: false)
+        scheduleRefreshAndLayout(.ax(notif), screenIsDefinitelyUnlocked: false)
     }
 }
 
@@ -21,7 +21,7 @@ func resetManipulatedWithMouseIfPossible() {
         for workspace in Workspace.all {
             workspace.resetResizeWeightBeforeResizeRecursive()
         }
-        refreshAndLayout(.resetManipulatedWithMouse, screenIsDefinitelyUnlocked: true)
+        scheduleRefreshAndLayout(.resetManipulatedWithMouse, screenIsDefinitelyUnlocked: true)
     }
 }
 


### PR DESCRIPTION
On operations like workspace changes, AeroSpace receives a stampede of
accessibility events, each of which triggers a serial call to
`refreshSession()` on the main thread. Since these `refreshSession()` calls
are idempotent, we can coalesce these calls so that
multiple accessibility events can be handled by a single
`refreshSession()`.

With this change, operations like workspace switch go from
O(num_source_windows + num_dest_windows) to O(1) `refreshSession()`
calls (with similar improvements for operations like closing windows or
resizing windows).
