### PR TITLE
Fix Command equality operator parameter type.

### DIFF
--- a/Sources/AppBundle/command/Command.swift
+++ b/Sources/AppBundle/command/Command.swift
@@ -9,7 +9,7 @@ protocol Command: AeroAny, Equatable, Sendable {
 }
 
 extension Command {
-    static func == (lhs: any Command, rhs: any Command) -> Bool {
+    static func == (lhs: Self, rhs: Self) -> Bool {
         return lhs.args.equals(rhs.args)
     }
 


### PR DESCRIPTION
As of https://github.com/swiftlang/swift/pull/73204 in Swift 6.1,
protocol member operators are required to have a parameter of type Self.
Fix the Command equality operator to conform to this requirement.
Command already has a separate `equals` method that allows for
comparison between different subtypes.
