### PR TITLE
Add on-window-detected info to debug-windows command resolves #1326

### DIFF
--- a/Sources/AppBundle/command/impl/DebugWindowsCommand.swift
+++ b/Sources/AppBundle/command/impl/DebugWindowsCommand.swift
@@ -88,7 +88,13 @@ private func dumpWindowDebugInfo(_ window: Window) async throws -> String {
 
     result["Aero.AXApp"] = .dict(try await window.macApp.dumpAppAxInfo())
     // todo add app bundle version to debug log
-
+    
+    var matchingCallbacks: [Json] = []
+    for callback in config.onWindowDetected where try await callback.matches(window) {
+        matchingCallbacks.append(callback.debugInfo)
+    }
+    result["Aero.on-window-detected"] = .array(matchingCallbacks)
+    
     return (JSONEncoder.aeroSpaceDefault.encodeToString(result) ?? "nil").prefixLines(with: "\(window.app.bundleId ?? "nil-bundle-id") ||| ")
 }
 

--- a/Sources/AppBundle/config/parseOnWindowDetected.swift
+++ b/Sources/AppBundle/config/parseOnWindowDetected.swift
@@ -12,7 +12,7 @@ struct WindowDetectedCallback: ConvenienceCopyable, Equatable {
 
     var debugInfo: Json {
         var result: [String: Json] = [:]
-        result ["matcher"] = matcher.debugInfo
+        result["matcher"] = matcher.debugInfo
         if let commands = rawRun {
             let commandsJson: [Json] = commands.map { command in
                 let args = command.args.rawArgs.value.joined(separator: ",")
@@ -35,16 +35,16 @@ struct WindowDetectedCallbackMatcher: ConvenienceCopyable, Equatable {
     var windowTitleRegexSubstring: Regex<AnyRegexOutput>?
     var workspace: String?
     var duringAeroSpaceStartup: Bool?
-    
+
     var debugInfo: Json {
         var resultParts: [String] = []
         if let appId = appId {
             resultParts.append("appId=\"\(appId)\"")
         }
-        if let _ = appNameRegexSubstring {
+        if appNameRegexSubstring != nil {
             resultParts.append("appNameRegexSubstrin=Regex")
         }
-        if let _ = windowTitleRegexSubstring {
+        if windowTitleRegexSubstring != nil {
             resultParts.append("windowTitleRegexSubstring=Regex")
         }
         if let workspace = workspace {

--- a/Sources/AppBundle/config/parseOnWindowDetected.swift
+++ b/Sources/AppBundle/config/parseOnWindowDetected.swift
@@ -10,6 +10,19 @@ struct WindowDetectedCallback: ConvenienceCopyable, Equatable {
         rawRun ?? dieT("ID-46D063B2 should have discarded nil")
     }
 
+    var debugInfo: Json {
+        var result: [String: Json] = [:]
+        result ["matcher"] = matcher.debugInfo
+        if let commands = rawRun {
+            let commandsJson: [Json] = commands.map { command in
+                let args = command.args.rawArgs.value.joined(separator: ",")
+                return .string("\(command.info.kind.rawValue) \(args)")
+            }
+            result["commands"] = .array(commandsJson)
+        }
+        return .dict(result)
+    }
+    
     static func == (lhs: WindowDetectedCallback, rhs: WindowDetectedCallback) -> Bool {
         return lhs.matcher == rhs.matcher && lhs.checkFurtherCallbacks == rhs.checkFurtherCallbacks &&
             zip(lhs.run, rhs.run).allSatisfy { $0.equals($1) }
@@ -22,7 +35,27 @@ struct WindowDetectedCallbackMatcher: ConvenienceCopyable, Equatable {
     var windowTitleRegexSubstring: Regex<AnyRegexOutput>?
     var workspace: String?
     var duringAeroSpaceStartup: Bool?
-
+    
+    var debugInfo: Json {
+        var resultParts: [String] = []
+        if let appId = appId {
+            resultParts.append("appId=\"\(appId)\"")
+        }
+        if let _ = appNameRegexSubstring {
+            resultParts.append("appNameRegexSubstrin=Regex")
+        }
+        if let _ = windowTitleRegexSubstring {
+            resultParts.append("windowTitleRegexSubstring=Regex")
+        }
+        if let workspace = workspace {
+            resultParts.append("workspace=\"\(workspace)\"")
+        }
+        if let duringAeroSpaceStartup = duringAeroSpaceStartup {
+            resultParts.append("duringAeroSpaceStartup=\(duringAeroSpaceStartup)")
+        }
+        return .string(resultParts.joined(separator: ", "))
+    }
+    
     static func == (lhs: WindowDetectedCallbackMatcher, rhs: WindowDetectedCallbackMatcher) -> Bool {
         check(
             lhs.appNameRegexSubstring == nil &&


### PR DESCRIPTION
Adds matching on-window-detected debug info to the debug-windows command.

I wasn't sure what info you wanted so I included everything. Also, I'm happy to change formatting if you would like something different. 

# Example Output: 
### Typical/simple case

<img width="600" alt="owd-simple" src="https://github.com/user-attachments/assets/fd84228f-a41d-4103-8d7e-3989e8b3a0a5" />

### Full case
<img width="1128" alt="owd-full" src="https://github.com/user-attachments/assets/907e2154-8797-4295-a08c-383b4b6440a5" />

```
"Aero.on-window-detected" : [
  {
    "commands" : [
      "layout floating",
      "move-node-to-workspace M"
    ],
    "matcher" : "appId=\"com.splice.Splice\", appNameRegexSubstrin=Regex, windowTitleRegexSubstring=Regex, duringAeroSpaceStartup=false"
  }
],
```
