### PR TITLE
Add --when-visible (focus|swap) option to the summon-workspace command [updated]

### DIFF
--- a/Sources/AppBundle/command/impl/SummonWorkspaceCommand.swift
+++ b/Sources/AppBundle/command/impl/SummonWorkspaceCommand.swift
@@ -15,15 +15,22 @@ struct SummonWorkspaceCommand: Command {
                     .succ(io.err("Workspace '\(workspace.name)' is already visible on the focused monitor. Tip: use --fail-if-noop to exit with non-zero code"))
             }
         }
-        let prevMonitor = workspace.isVisible ? workspace.workspaceMonitor : nil
-        if monitor.setActiveWorkspace(workspace) {
-            if let prevMonitor {
-                let stubWorkspace = getStubWorkspace(for: prevMonitor)
-                check(
-                    prevMonitor.setActiveWorkspace(stubWorkspace),
-                    "getStubWorkspace generated incompatible stub workspace (\(stubWorkspace)) for the monitor (\(prevMonitor)",
-                )
+        if workspace.isVisible {
+            // The workspace is already visible on another monitor
+            let otherMonitor = workspace.workspaceMonitor
+            switch args.whenVisible {
+                case .swap:
+                    let currentWorkspace = monitor.activeWorkspace
+                    if otherMonitor.setActiveWorkspace(currentWorkspace) && monitor.setActiveWorkspace(workspace) {
+                        return .from(bool: workspace.focusWorkspace())
+                    } else {
+                        return .fail(io.err("Can't swap workspaces due to workspace-to-monitor-force-assignment restrictions"))
+                    }
+                case .focus:
+                    return .from(bool: workspace.focusWorkspace())
             }
+        }
+        if monitor.setActiveWorkspace(workspace) {
             return .from(bool: workspace.focusWorkspace())
         } else {
             return .fail(io.err("Can't move workspace '\(workspace.name)' to monitor '\(monitor.name)'. workspace-to-monitor-force-assignment doesn't allow it"))

--- a/Sources/Common/cmdArgs/impl/SummonWorkspaceCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/SummonWorkspaceCmdArgs.swift
@@ -6,6 +6,7 @@ public struct SummonWorkspaceCmdArgs: CmdArgs {
         help: summon_workspace_help_generated,
         flags: [
             "--fail-if-noop": trueBoolFlag(\.failIfNoop),
+            "--when-visible": ArgParser(\.rawWhenVisibleAction, upcastArgParserFun(parseWhenVisibleAction)),
         ],
         posArgs: [
             dashDashArg(mandatory: false),
@@ -15,8 +16,26 @@ public struct SummonWorkspaceCmdArgs: CmdArgs {
 
     public var target: Lateinit<WorkspaceName> = .uninitialized
     public var failIfNoop: Bool = false
+    public var rawWhenVisibleAction: WhenVisible? = nil
+
+    public enum WhenVisible: String, CaseIterable, Equatable, Sendable {
+        case focus = "focus"
+        case swap = "swap"
+    }
+}
+
+extension SummonWorkspaceCmdArgs {
+    public var whenVisible: WhenVisible { rawWhenVisibleAction ?? .focus }
 }
 
 private func parseWorkspaceName(i: PosArgParserInput) -> ParsedCliArgs<WorkspaceName> {
     .init(WorkspaceName.parse(i.arg), advanceBy: 1)
+}
+
+private func parseWhenVisibleAction(i: SubArgParserInput) -> ParsedCliArgs<SummonWorkspaceCmdArgs.WhenVisible> {
+    if let arg = i.nonFlagArgOrNil() {
+        return .init(parseEnum(arg, SummonWorkspaceCmdArgs.WhenVisible.self), advanceBy: 1)
+    } else {
+        return .fail("<action> is mandatory", advanceBy: 0)
+    }
 }

--- a/Sources/Common/cmdHelpGenerated.swift
+++ b/Sources/Common/cmdHelpGenerated.swift
@@ -150,7 +150,7 @@ let subscribe_help_generated = """
     USAGE: subscribe [-h|--help] [--all] [--no-send-initial] [<event>...]
     """
 let summon_workspace_help_generated = """
-    USAGE: summon-workspace [-h|--help] [--fail-if-noop] [--] <workspace>
+    USAGE: summon-workspace [-h|--help] [--fail-if-noop] [--when-visible (focus|swap)] [--] <workspace>
     """
 let swap_help_generated = """
     USAGE: swap [-h|--help] [--window-id <window-id>] [--swap-focus]

--- a/docs/aerospace-summon-workspace.adoc
+++ b/docs/aerospace-summon-workspace.adoc
@@ -9,7 +9,7 @@ include::util/man-attributes.adoc[]
 == Synopsis
 [verse]
 // tag::synopsis[]
-aerospace summon-workspace [-h|--help] [--fail-if-noop] [--] <workspace>
+aerospace summon-workspace [-h|--help] [--fail-if-noop] [--when-visible (focus|swap)] [--] <workspace>
 
 // end::synopsis[]
 
@@ -29,6 +29,11 @@ include::./util/conditional-options-header.adoc[]
 
 -h, --help:: Print help
 --fail-if-noop:: Exit with non-zero exit code if the workspace is already visible on the focused monitor.
+
+--when-visible <action>::
+Defines the behavior if the workspace is already visible on another monitor.
+`<action>` possible values: `(focus|swap)`. +
+The default is: `focus`
 
 // =========================================================== Arguments
 include::./util/conditional-arguments-header.adoc[]


### PR DESCRIPTION
This is an updated version of https://github.com/nikitabobko/AeroSpace/pull/681, [edit] rebasing on main. I enabled the code mentioned in the other PR comment:

```
on-focused-monitor-changed = ['move-mouse monitor-lazy-center']
on-focus-changed = ['move-mouse window-lazy-center']
```

and everything is working the way it should -- the mouse cursor stays on the monitor where it started. I've been using this for a bit and all is working GREAT!! Thank you @ilyaluk!

I'd be happy to add anything else you might need to make this mergeable, let me know!