### PR TITLE
Added 'layout' inter variable to "list-windows" output. 

### DIFF
--- a/Sources/AppBundle/command/format.swift
+++ b/Sources/AppBundle/command/format.swift
@@ -78,6 +78,7 @@ enum FormatVar: Equatable {
         case windowId = "window-id"
         case windowIsFullscreen = "window-is-fullscreen"
         case windowTitle = "window-title"
+        case windowLayout = "layout"
     }
 
     enum WorkspaceFormatVar: String, Equatable, CaseIterable {
@@ -182,6 +183,7 @@ extension String {
                     case .windowId: .success(.uint32(w.windowId))
                     case .windowIsFullscreen: .success(.bool(w.isFullscreen))
                     case .windowTitle: .success(.string(title))
+                    case .windowLayout: .success(.string(w.isFloating ? "floating" : "tiling"))
                 }
             case (.workspace(let w), .workspace(let f)):
                 return switch f {

--- a/Sources/Common/cmdArgs/impl/ListWindowsCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/ListWindowsCmdArgs.swift
@@ -58,7 +58,8 @@ public extension ListWindowsCmdArgs {
             ? [
                 .interVar("window-id"), .interVar("right-padding"), .literal(" | "),
                 .interVar("app-name"), .interVar("right-padding"), .literal(" | "),
-                .interVar("window-title"),
+                .interVar("window-title"), .interVar("right-padding"), .literal(" | "),
+                .interVar("layout")
             ]
             : _format
     }


### PR DESCRIPTION
This makes it so programs like JankyBorders can change the border color based on "floating" or "tiling" layout.
E.g. the border is red if if it is floating and yellow if it is tiling, by checking the value on change of focus.