### PR TITLE
Migrate from H

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "61d7d37be674d8792e9370480fdc91f76651cbbf9011b58bf8de5e671ef59d2b",
+  "originHash" : "26a72fab44133b00beab50dc3d48000c4f5e3cd8a74eab55168a15b174489ab7",
   "pins" : [
     {
       "identity" : "antlr4",
@@ -20,30 +20,12 @@
       }
     },
     {
-      "identity" : "globpattern",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ChimeHQ/GlobPattern",
-      "state" : {
-        "revision" : "4ebb9e89e07cc475efa74f87dc6d21f4a9e060f8",
-        "version" : "0.1.1"
-      }
-    },
-    {
       "identity" : "issoundadditions",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/InerziaSoft/ISSoundAdditions",
       "state" : {
         "revision" : "4b555f0354e6c280917bae8a598a258efe87ab98",
         "version" : "2.0.1"
-      }
-    },
-    {
-      "identity" : "sparkle",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/sparkle-project/Sparkle",
-      "state" : {
-        "revision" : "0ca3004e98712ea2b39dd881d28448630cce1c99",
-        "version" : "2.7.0"
       }
     },
     {
@@ -56,39 +38,12 @@
       }
     },
     {
-      "identity" : "swiftpredicate",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/YOCKOW/SwiftPredicate",
-      "state" : {
-        "revision" : "24842ad4386598882890cc369f5580ef165ed634",
-        "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "swiftranges",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/YOCKOW/SwiftRanges.git",
-      "state" : {
-        "revision" : "97a25be1410234d03de69e1ac93f54ba853b04ef",
-        "version" : "3.2.1"
-      }
-    },
-    {
       "identity" : "tomlkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/LebJe/TOMLKit",
       "state" : {
         "revision" : "404c4dd011743461bff12d00a5118d0ed59d630c",
         "version" : "0.5.5"
-      }
-    },
-    {
-      "identity" : "xmlcoder",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/MaxDesiatov/XMLCoder",
-      "state" : {
-        "revision" : "b1e944cbd0ef33787b13f639a5418d55b3bed501",
-        "version" : "0.17.1"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ce497cf9fcf14272fedb221cc48e1102e7d3c1bb2ab918cedfbfa9120f32fca3",
+  "originHash" : "61d7d37be674d8792e9370480fdc91f76651cbbf9011b58bf8de5e671ef59d2b",
   "pins" : [
     {
       "identity" : "antlr4",
@@ -20,12 +20,12 @@
       }
     },
     {
-      "identity" : "hotkey",
+      "identity" : "globpattern",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/soffes/HotKey",
+      "location" : "https://github.com/ChimeHQ/GlobPattern",
       "state" : {
-        "revision" : "a3cf605d7a96f6ff50e04fcb6dea6e2613cfcbe4",
-        "version" : "0.2.1"
+        "revision" : "4ebb9e89e07cc475efa74f87dc6d21f4a9e060f8",
+        "version" : "0.1.1"
       }
     },
     {
@@ -38,6 +38,15 @@
       }
     },
     {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "0ca3004e98712ea2b39dd881d28448630cce1c99",
+        "version" : "2.7.0"
+      }
+    },
+    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
@@ -47,12 +56,39 @@
       }
     },
     {
+      "identity" : "swiftpredicate",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/YOCKOW/SwiftPredicate",
+      "state" : {
+        "revision" : "24842ad4386598882890cc369f5580ef165ed634",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swiftranges",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/YOCKOW/SwiftRanges.git",
+      "state" : {
+        "revision" : "97a25be1410234d03de69e1ac93f54ba853b04ef",
+        "version" : "3.2.1"
+      }
+    },
+    {
       "identity" : "tomlkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/LebJe/TOMLKit",
       "state" : {
         "revision" : "404c4dd011743461bff12d00a5118d0ed59d630c",
         "version" : "0.5.5"
+      }
+    },
+    {
+      "identity" : "xmlcoder",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/MaxDesiatov/XMLCoder",
+      "state" : {
+        "revision" : "b1e944cbd0ef33787b13f639a5418d55b3bed501",
+        "version" : "0.17.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -22,10 +22,10 @@ let package = Package(
         .package(url: "https://github.com/Kitura/BlueSocket", exact: "2.0.4"),
         .package(url: "https://github.com/LebJe/TOMLKit", exact: "0.5.5"),
         .package(url: "https://github.com/apple/swift-collections", exact: "1.1.4"),
-        .package(url: "https://github.com/ChimeHQ/GlobPattern", from: "0.1.1"),
-        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.4.1"),
-        .package(url: "https://github.com/YOCKOW/SwiftPredicate", from: "1.1.1"),
-        .package(url: "https://github.com/MaxDesiatov/XMLCoder", from: "0.17.1"),
+        .package(url: "https://github.com/ChimeHQ/GlobPattern", exact: "0.1.1"),
+        .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.4.1"),
+        .package(url: "https://github.com/YOCKOW/SwiftPredicate", exact: "1.1.1"),
+        .package(url: "https://github.com/MaxDesiatov/XMLCoder", exact: "0.17.1"),
     ],
     // Targets are the basic building blocks of a package, defining a module or a test suite.
     // Targets can depend on other targets in this package and products from dependencies.
@@ -39,7 +39,7 @@ let package = Package(
         .target(
             name: "Common",
             dependencies: [
-                .product(name: "Collections", package: "swift-collections"),
+                .product(name: "Collections", package: "swift-collections")
             ]
         ),
         .target(
@@ -61,7 +61,7 @@ let package = Package(
         .executableTarget(
             name: "AeroSpaceApp",
             dependencies: [
-                .target(name: "AppBundle"),
+                .target(name: "AppBundle")
             ]
         ),
         .executableTarget(
@@ -74,7 +74,7 @@ let package = Package(
         .testTarget(
             name: "AppBundleTests",
             dependencies: [
-                .target(name: "AppBundle"),
+                .target(name: "AppBundle")
             ]
         ),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -22,10 +22,6 @@ let package = Package(
         .package(url: "https://github.com/Kitura/BlueSocket", exact: "2.0.4"),
         .package(url: "https://github.com/LebJe/TOMLKit", exact: "0.5.5"),
         .package(url: "https://github.com/apple/swift-collections", exact: "1.1.4"),
-        // .package(url: "https://github.com/ChimeHQ/GlobPattern", exact: "0.1.1"), // Removing GlobPattern
-        // .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.4.1"), // Removing Sparkle
-        // .package(url: "https://github.com/YOCKOW/SwiftPredicate", exact: "1.3.0"), // Removed
-        // .package(url: "https://github.com/MaxDesiatov/XMLCoder", exact: "0.17.1"), // Removed
     ],
     // Targets are the basic building blocks of a package, defining a module or a test suite.
     // Targets can depend on other targets in this package and products from dependencies.
@@ -52,10 +48,6 @@ let package = Package(
                 .product(name: "TOMLKit", package: "TOMLKit"),
                 .target(name: "Common"),
                 .target(name: "PrivateApi"),
-                // .product(name: "GlobPattern", package: "GlobPattern"), // Removing GlobPattern
-                // .product(name: "Sparkle", package: "Sparkle"), // Removing Sparkle
-                // .product(name: "SwiftPredicate", package: "SwiftPredicate"), // Removed
-                // .product(name: "XMLCoder", package: "XMLCoder"), // Removed
             ]
         ),
         .executableTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -22,10 +22,10 @@ let package = Package(
         .package(url: "https://github.com/Kitura/BlueSocket", exact: "2.0.4"),
         .package(url: "https://github.com/LebJe/TOMLKit", exact: "0.5.5"),
         .package(url: "https://github.com/apple/swift-collections", exact: "1.1.4"),
-        .package(url: "https://github.com/ChimeHQ/GlobPattern", exact: "0.1.1"),
-        .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.4.1"),
-        .package(url: "https://github.com/YOCKOW/SwiftPredicate", exact: "1.1.1"),
-        .package(url: "https://github.com/MaxDesiatov/XMLCoder", exact: "0.17.1"),
+        // .package(url: "https://github.com/ChimeHQ/GlobPattern", exact: "0.1.1"), // Removing GlobPattern
+        // .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.4.1"), // Removing Sparkle
+        // .package(url: "https://github.com/YOCKOW/SwiftPredicate", exact: "1.3.0"), // Removed
+        // .package(url: "https://github.com/MaxDesiatov/XMLCoder", exact: "0.17.1"), // Removed
     ],
     // Targets are the basic building blocks of a package, defining a module or a test suite.
     // Targets can depend on other targets in this package and products from dependencies.
@@ -39,7 +39,7 @@ let package = Package(
         .target(
             name: "Common",
             dependencies: [
-                .product(name: "Collections", package: "swift-collections")
+                .product(name: "Collections", package: "swift-collections"),
             ]
         ),
         .target(
@@ -52,16 +52,16 @@ let package = Package(
                 .product(name: "TOMLKit", package: "TOMLKit"),
                 .target(name: "Common"),
                 .target(name: "PrivateApi"),
-                .product(name: "GlobPattern", package: "GlobPattern"),
-                .product(name: "Sparkle", package: "Sparkle"),
-                .product(name: "SwiftPredicate", package: "SwiftPredicate"),
-                .product(name: "XMLCoder", package: "XMLCoder"),
+                // .product(name: "GlobPattern", package: "GlobPattern"), // Removing GlobPattern
+                // .product(name: "Sparkle", package: "Sparkle"), // Removing Sparkle
+                // .product(name: "SwiftPredicate", package: "SwiftPredicate"), // Removed
+                // .product(name: "XMLCoder", package: "XMLCoder"), // Removed
             ]
         ),
         .executableTarget(
             name: "AeroSpaceApp",
             dependencies: [
-                .target(name: "AppBundle")
+                .target(name: "AppBundle"),
             ]
         ),
         .executableTarget(
@@ -74,7 +74,7 @@ let package = Package(
         .testTarget(
             name: "AppBundleTests",
             dependencies: [
-                .target(name: "AppBundle")
+                .target(name: "AppBundle"),
             ]
         ),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
         .target(
             name: "Common",
             dependencies: [
-                .product(name: "Collections", package: "swift-collections"),
+                .product(name: "Collections", package: "swift-collections")
             ]
         ),
         .target(
@@ -61,7 +61,7 @@ let package = Package(
         .executableTarget(
             name: "AeroSpaceApp",
             dependencies: [
-                .target(name: "AppBundle"),
+                .target(name: "AppBundle")
             ]
         ),
         .executableTarget(
@@ -74,7 +74,7 @@ let package = Package(
         .testTarget(
             name: "AppBundleTests",
             dependencies: [
-                .target(name: "AppBundle"),
+                .target(name: "AppBundle")
             ]
         ),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
         .target(
             name: "Common",
             dependencies: [
-                .product(name: "Collections", package: "swift-collections")
+                .product(name: "Collections", package: "swift-collections"),
             ]
         ),
         .target(
@@ -61,7 +61,7 @@ let package = Package(
         .executableTarget(
             name: "AeroSpaceApp",
             dependencies: [
-                .target(name: "AppBundle")
+                .target(name: "AppBundle"),
             ]
         ),
         .executableTarget(
@@ -74,7 +74,7 @@ let package = Package(
         .testTarget(
             name: "AppBundleTests",
             dependencies: [
-                .target(name: "AppBundle")
+                .target(name: "AppBundle"),
             ]
         ),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,10 @@ let package = Package(
         .package(url: "https://github.com/Kitura/BlueSocket", exact: "2.0.4"),
         .package(url: "https://github.com/LebJe/TOMLKit", exact: "0.5.5"),
         .package(url: "https://github.com/apple/swift-collections", exact: "1.1.4"),
-        .package(url: "https://github.com/soffes/HotKey", exact: "0.2.1"),
+        .package(url: "https://github.com/ChimeHQ/GlobPattern", from: "0.1.1"),
+        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.4.1"),
+        .package(url: "https://github.com/YOCKOW/SwiftPredicate", from: "1.1.1"),
+        .package(url: "https://github.com/MaxDesiatov/XMLCoder", from: "0.17.1"),
     ],
     // Targets are the basic building blocks of a package, defining a module or a test suite.
     // Targets can depend on other targets in this package and products from dependencies.
@@ -36,26 +39,29 @@ let package = Package(
         .target(
             name: "Common",
             dependencies: [
-                .product(name: "Collections", package: "swift-collections"),
+                .product(name: "Collections", package: "swift-collections")
             ]
         ),
         .target(
             name: "AppBundle",
             dependencies: [
                 .product(name: "Collections", package: "swift-collections"),
-                .product(name: "HotKey", package: "HotKey"),
                 .product(name: "ISSoundAdditions", package: "ISSoundAdditions"),
                 .product(name: "ShellParserGenerated", package: "ShellParserGenerated"),
                 .product(name: "Socket", package: "BlueSocket"),
                 .product(name: "TOMLKit", package: "TOMLKit"),
                 .target(name: "Common"),
                 .target(name: "PrivateApi"),
+                .product(name: "GlobPattern", package: "GlobPattern"),
+                .product(name: "Sparkle", package: "Sparkle"),
+                .product(name: "SwiftPredicate", package: "SwiftPredicate"),
+                .product(name: "XMLCoder", package: "XMLCoder"),
             ]
         ),
         .executableTarget(
             name: "AeroSpaceApp",
             dependencies: [
-                .target(name: "AppBundle"),
+                .target(name: "AppBundle")
             ]
         ),
         .executableTarget(
@@ -68,7 +74,7 @@ let package = Package(
         .testTarget(
             name: "AppBundleTests",
             dependencies: [
-                .target(name: "AppBundle"),
+                .target(name: "AppBundle")
             ]
         ),
     ]

--- a/Sources/AppBundle/GlobalHotkeyMonitor.swift
+++ b/Sources/AppBundle/GlobalHotkeyMonitor.swift
@@ -3,277 +3,319 @@ import Common  // For Config, Command, etc.
 
 // We will not import HotKey here as we are replacing it.
 
-@MainActor
 class GlobalHotkeyMonitor {
-    private var eventTap: CFMachPort?
-    private var runLoopSource: CFRunLoopSource?
+	private var eventTap: CFMachPort?
+	private var runLoopSource: CFRunLoopSource?
+	private let lock = NSLock()  // Lock for protecting pressedModifierKeyCodes
 
-    // State to track pressed keys
-    // Using UInt16 for virtual key codes
-    private var pressedModifierKeyCodes: Set<UInt16> = []
-    // Optional: could also track all pressed keys if complex multi-non-modifier chords were needed
-    // private var pressedKeyCodes: Set<UInt16> = []
+	// State to track pressed keys
+	// Using UInt16 for virtual key codes
+	private var pressedModifierKeyCodes: Set<UInt16> = []
+	// Optional: could also track all pressed keys if complex multi-non-modifier chords were needed
+	// private var pressedKeyCodes: Set<UInt16> = []
 
-    // The mechanism is to read from global `config` and `activeMode`
-    // For now, assuming access to 'config' and 'activeMode' (defined in HotkeyBinding.swift context)
+	// For optimized hotkey lookup
+	private var bindingsByKeyCode: [UInt16: [HotkeyBinding]] = [:]
+	private var lastKnownModeName: String?  // To track when to rebuild bindingsByKeyCode
 
-    init() {
-        // Initialization if needed
-    }
+	// The mechanism is to read from global `config` and `activeMode`
+	// For now, assuming access to 'config' and 'activeMode' (defined in HotkeyBinding.swift context)
 
-    func start() {
-        guard eventTap == nil else {
-            print("WARN: GlobalHotkeyMonitor already started.")
-            return
-        }
+	init() {
+		// Initialization if needed
+	}
 
-        // The types of events we want to tap.
-        // We need keyDown and keyUp to track all key states, including modifiers.
-        // flagsChanged can be supplementary or primary for modifiers if direct key up/down for them is noisy or problematic.
-        // Let's start with keyDown and keyUp.
-        let eventsToTap: CGEventMask =
-            (1 << CGEventType.keyDown.rawValue) | (1 << CGEventType.keyUp.rawValue)
-                | (1 << CGEventType.flagsChanged.rawValue)
+	func start() {
+		guard eventTap == nil else {
+			print("WARN: GlobalHotkeyMonitor already started.")
+			return
+		}
 
-        // Create the event tap.
-        // '.cghidEventTap' is a common choice for system-wide hardware events.
-        guard
-            let tap = CGEvent.tapCreate(
-                tap: .cgSessionEventTap,  // Tap into the session event stream. Others: .cgHIDEventTap, .cgAnnotatedSessionEventTap
-                place: .headInsertEventTap,  // Insert at the head of the event tap list
-                options: .defaultTap,  // Default options
-                eventsOfInterest: eventsToTap,
-                callback: { proxy, type, event, refcon -> Unmanaged<CGEvent>? in
-                    // 'refcon' is the UnsafeMutableRawPointer to 'self'
-                    guard let refcon else {
-                        return Unmanaged.passUnretained(event)
-                    }
-                    let monitor = Unmanaged<GlobalHotkeyMonitor>.fromOpaque(
-                        refcon
-                    ).takeUnretainedValue()
-                    return monitor.handleEvent(
-                        proxy: proxy, type: type, event: event)
-                },
-                userInfo: Unmanaged.passUnretained(self).toOpaque()  // Pass 'self' to the callback
-            )
-        else {
-            printStderr(
-                "ERROR: Failed to create event tap. This usually means AeroSpace requires Accessibility permissions. "
-                    + "Please go to System Settings > Privacy & Security > Accessibility, and ensure AeroSpace is enabled. "
-                    + "You may need to restart AeroSpace after granting permissions."
-            )
-            // TODO: Better error handling - inform user, guide to permissions.
-            // Consider showing a user-facing alert if possible from this context,
-            // or setting a flag that the UI can pick up to show an alert.
-            // Example to open settings (use with caution, might need main thread if called from background):
-            // NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!)
-            return
-        }
+		// The types of events we want to tap.
+		// We need keyDown and keyUp to track all key states, including modifiers.
+		// flagsChanged can be supplementary or primary for modifiers if direct key up/down for them is noisy or problematic.
+		// Let's start with keyDown and keyUp.
+		let eventsToTap: CGEventMask =
+			(1 << CGEventType.keyDown.rawValue) | (1 << CGEventType.keyUp.rawValue)
+			| (1 << CGEventType.flagsChanged.rawValue)
 
-        // Create a run loop source and add it to the current run loop.
-        guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
-            printStderr("ERROR: Failed to create run loop source for event tap.")
-            return
-        }
+		// Create the event tap.
+		// '.cghidEventTap' is a common choice for system-wide hardware events.
+		guard
+			let tap = CGEvent.tapCreate(
+				tap: .cgSessionEventTap,  // Tap into the session event stream. Others: .cgHIDEventTap, .cgAnnotatedSessionEventTap
+				place: .headInsertEventTap,  // Insert at the head of the event tap list
+				options: .defaultTap,  // Default options
+				eventsOfInterest: eventsToTap,
+				callback: { proxy, type, event, refcon -> Unmanaged<CGEvent>? in
+					// 'refcon' is the UnsafeMutableRawPointer to 'self'
+					guard let refcon else {
+						return Unmanaged.passUnretained(event)
+					}
+					let monitor = Unmanaged<GlobalHotkeyMonitor>.fromOpaque(
+						refcon
+					).takeUnretainedValue()
+					return monitor.handleEvent(
+						proxy: proxy, type: type, event: event)
+				},
+				userInfo: Unmanaged.passUnretained(self).toOpaque()  // Pass 'self' to the callback
+			)
+		else {
+			printStderr(
+				"ERROR: Failed to create event tap. This usually means AeroSpace requires Accessibility permissions. "
+					+ "Please go to System Settings > Privacy & Security > Accessibility, and ensure AeroSpace is enabled. "
+					+ "You may need to restart AeroSpace after granting permissions."
+			)
+			// TODO: Better error handling - inform user, guide to permissions.
+			// Consider showing a user-facing alert if possible from this context,
+			// or setting a flag that the UI can pick up to show an alert.
+			// Example to open settings (use with caution, might need main thread if called from background):
+			// NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!)
+			return
+		}
 
-        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
-        CGEvent.tapEnable(tap: tap, enable: true)
+		// Create a run loop source and add it to the current run loop.
+		guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
+			printStderr("ERROR: Failed to create run loop source for event tap.")
+			return
+		}
 
-        self.eventTap = tap
-        self.runLoopSource = source
+		CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+		CGEvent.tapEnable(tap: tap, enable: true)
 
-        print("INFO: GlobalHotkeyMonitor started.")
-    }
+		self.eventTap = tap
+		self.runLoopSource = source
 
-    func stop() {
-        if let tap = eventTap {
-            CGEvent.tapEnable(tap: tap, enable: false)
-            // CFMachPortInvalidate(tap) // Invalidating the port also removes the run loop source.
-            // However, it's often better to remove the source explicitly.
-            if let source = runLoopSource {
-                CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
-            }
-            // CFRelease(tap) // tap is a CFMachPort, managed by ARC when interacting with Swift types like CFMachPort?
-            // If directly using CFTypeRef, manual CFRelease would be needed.
-            // Swift handles this for optional CF types.
-            self.runLoopSource = nil
-            self.eventTap = nil
-            print("INFO: GlobalHotkeyMonitor stopped.")
-        }
-        pressedModifierKeyCodes.removeAll()
-    }
+		print("INFO: GlobalHotkeyMonitor started.")
+	}
 
-    private func handleEvent(proxy: CGEventTapProxy, type: CGEventType, event: CGEvent)
-        -> Unmanaged<CGEvent>?
-    {
-        let keyCode = UInt16(event.getIntegerValueField(.keyboardEventKeycode))
+	@MainActor
+	func stop() {
+		if let tap = eventTap {
+			CGEvent.tapEnable(tap: tap, enable: false)  // Disable event delivery
 
-        switch type {
-            case .keyDown:
-                if isModifierKeyCode(keyCode) {
-                    pressedModifierKeyCodes.insert(keyCode)
-                } else {
-                    if checkForHotkeyMatch(nonModifierKeyCode: keyCode, event: event) {
-                        return nil
-                    }
-                }
-            case .keyUp:
-                if isModifierKeyCode(keyCode) {
-                    pressedModifierKeyCodes.remove(keyCode)
-                } else {
-                    // Optionally handle keyUp for non-modifiers if needed for specific command types
-                }
-            case .flagsChanged:
-                // The keyCode in a flagsChanged event is the specific modifier key that changed.
-                let changedModifierKeyCode = keyCode
-                let newFlagsState = event.flags
+			// Invalidate the Mach port. This also removes its run loop sources.
+			// One call is sufficient.
+			CFMachPortInvalidate(tap)
 
-                // Determine if the specific modifier key that changed is now pressed or released.
-                // This requires knowing which generic flag corresponds to the specific modifier key code.
-                guard
-                    let physicalKey = physicalModifierKeyToKeyCode.first(where: {
-                        $0.value == changedModifierKeyCode
-                    })?.key
-                else {
-                    // Unknown modifier key code that caused flagsChanged, should not happen if our maps are complete.
-                    print(
-                        "WARN: flagsChanged event for unknown modifier keyCode: \(changedModifierKeyCode)"
-                    )
-                    break
-                }
+			// Explicitly removing the source after invalidation is generally not needed
+			// as CFMachPortInvalidate should handle it. However, it's kept for now.
+			if let source = runLoopSource {
+				CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+			}
 
-                var modifierIsPressed = false
-                switch physicalKey {
-                    case .leftOption, .rightOption:
-                        modifierIsPressed = newFlagsState.contains(.maskAlternate)
-                    case .leftCommand, .rightCommand:
-                        modifierIsPressed = newFlagsState.contains(.maskCommand)
-                    case .leftShift, .rightShift:
-                        modifierIsPressed = newFlagsState.contains(.maskShift)
-                    case .leftControl, .rightControl:
-                        modifierIsPressed = newFlagsState.contains(.maskControl)
-                    case .function:
-                        modifierIsPressed = newFlagsState.contains(.maskSecondaryFn)
-                }
+			// ARC will handle the release of 'tap' and 'source' when these are set to nil.
+			self.runLoopSource = nil
+			self.eventTap = nil
+			print("INFO: GlobalHotkeyMonitor stopped.")
+		}
+		lock.lock()
+		pressedModifierKeyCodes.removeAll()
+		lock.unlock()
 
-                if modifierIsPressed {
-                    pressedModifierKeyCodes.insert(changedModifierKeyCode)
-                } else {
-                    pressedModifierKeyCodes.remove(changedModifierKeyCode)
-                }
+		// Clear optimized lookup cache
+		bindingsByKeyCode.removeAll()
+		lastKnownModeName = nil
+	}
+
+	nonisolated(unsafe) private func handleEvent(
+		proxy: CGEventTapProxy, type: CGEventType, event: CGEvent
+	)
+		-> Unmanaged<CGEvent>?
+	{
+		let keyCode = UInt16(event.getIntegerValueField(.keyboardEventKeycode))
+
+		switch type {
+		case .keyDown:
+			lock.lock()
+			if isModifierKeyCode(keyCode) {
+				pressedModifierKeyCodes.insert(keyCode)
+				lock.unlock()
+			} else {
+				lock.unlock()
+				if checkForHotkeyMatch(nonModifierKeyCode: keyCode, event: event) {
+					return nil
+				}
+			}
+		case .keyUp:
+			lock.lock()
+			if isModifierKeyCode(keyCode) {
+				pressedModifierKeyCodes.remove(keyCode)
+			}
+			lock.unlock()
+		// Optionally handle keyUp for non-modifiers if needed for specific command types
+		case .flagsChanged:
+			// The keyCode in a flagsChanged event is the specific modifier key that changed.
+			let changedModifierKeyCode = keyCode
+			let newFlagsState = event.flags
+
+			// Determine if the specific modifier key that changed is now pressed or released.
+			// This requires knowing which generic flag corresponds to the specific modifier key code.
+			guard
+				let physicalKey = physicalModifierKeyToKeyCode.first(where: {
+					$0.value == changedModifierKeyCode
+				})?.key
+			else {
+				// Unknown modifier key code that caused flagsChanged, should not happen if our maps are complete.
+				print(
+					"WARN: flagsChanged event for unknown modifier keyCode: \(changedModifierKeyCode)"
+				)
+				break
+			}
+
+			var modifierIsPressed = false
+			switch physicalKey {
+			case .leftOption, .rightOption:
+				modifierIsPressed = newFlagsState.contains(.maskAlternate)
+			case .leftCommand, .rightCommand:
+				modifierIsPressed = newFlagsState.contains(.maskCommand)
+			case .leftShift, .rightShift:
+				modifierIsPressed = newFlagsState.contains(.maskShift)
+			case .leftControl, .rightControl:
+				modifierIsPressed = newFlagsState.contains(.maskControl)
+			case .function:
+				modifierIsPressed = newFlagsState.contains(.maskSecondaryFn)
+			}
+
+			lock.lock()
+			if modifierIsPressed {
+				pressedModifierKeyCodes.insert(changedModifierKeyCode)
+			} else {
+				pressedModifierKeyCodes.remove(changedModifierKeyCode)
+			}
+			lock.unlock()
 		// print("DEBUG: FlagsChanged: \(physicalKey) (kc: \(changedModifierKeyCode)) is now \(modifierIsPressed ? "pressed" : "released"). Current pressed: \(pressedModifierKeyCodes)")
 
-            default:
-                break
-        }
+		default:
+			break
+		}
 
-        return Unmanaged.passUnretained(event)
-    }
+		return Unmanaged.passUnretained(event)
+	}
 
-    private func isModifierKeyCode(_ keyCode: UInt16) -> Bool {
-        physicalModifierKeyToKeyCode.values.contains(keyCode)
-    }
+	private func isModifierKeyCode(_ keyCode: UInt16) -> Bool {
+		physicalModifierKeyToKeyCode.values.contains(keyCode)
+	}
 
-    private func checkForHotkeyMatch(nonModifierKeyCode: UInt16, event: CGEvent) -> Bool {
-        guard let currentActiveMode = activeMode,
-              let modeConfig = config.modes[currentActiveMode]
-        else {
-            return false
-        }
+	private func checkForHotkeyMatch(nonModifierKeyCode: UInt16, event: CGEvent) -> Bool {
+		guard let currentActiveModeName = activeMode?.name,  // Assuming activeMode has a name property or similar unique ID
+			let modeConfig = config.modes[currentActiveModeName]
+		else {
+			return false
+		}
 
-        // 1. Determine current state of pressed modifiers
-        var currentPhysicalKeys = Set<PhysicalModifierKey>()
-        var activeGenericTypes = Set<GenericModifierType>()
+		// Rebuild bindingsByKeyCode if mode changed or not initialized for current mode
+		if lastKnownModeName != currentActiveModeName
+			|| bindingsByKeyCode.isEmpty && !modeConfig.bindings.isEmpty
+		{
+			bindingsByKeyCode.removeAll()
+			for (_, binding) in modeConfig.bindings {
+				bindingsByKeyCode[binding.keyCode, default: []].append(binding)
+			}
+			lastKnownModeName = currentActiveModeName
+		}
 
-        for pressedKc in self.pressedModifierKeyCodes {
-            if let physicalKey = physicalModifierKeyToKeyCode.first(where: {
-                $0.value == pressedKc
-            })?.key {
-                currentPhysicalKeys.insert(physicalKey)
-                // Determine generic type from physical key
-                switch physicalKey {
-                    case .leftOption, .rightOption: activeGenericTypes.insert(.option)
-                    case .leftCommand, .rightCommand:
-                        activeGenericTypes.insert(.command)
-                    case .leftControl, .rightControl:
-                        activeGenericTypes.insert(.control)
-                    case .leftShift, .rightShift: activeGenericTypes.insert(.shift)
-                    case .function: break  // `fn` doesn't have a generic counterpart in GenericModifierType
-                }
-            }
-        }
+		guard let candidateBindings = bindingsByKeyCode[nonModifierKeyCode],
+			!candidateBindings.isEmpty
+		else {
+			return false  // No bindings for this specific non-modifier key
+		}
 
-        for (_, binding) in modeConfig.bindings {
-            if binding.keyCode == nonModifierKeyCode {
-                // Perform matching based on exact and generic modifiers
+		// 1. Determine current state of pressed modifiers
+		var currentPhysicalKeys = Set<PhysicalModifierKey>()
+		var activeGenericTypes = Set<GenericModifierType>()
 
-                // Rule A: All exact modifiers in the binding must be currently pressed
-                guard binding.exactModifiers.isSubset(of: currentPhysicalKeys)
-                else {
-                    continue  // Next binding
-                }
+		lock.lock()
+		let localPressedModifierKeyCodes = self.pressedModifierKeyCodes
+		for pressedKc in localPressedModifierKeyCodes {
+			if let physicalKey = physicalModifierKeyToKeyCode.first(where: {
+				$0.value == pressedKc
+			})?.key {
+				currentPhysicalKeys.insert(physicalKey)
+				// Determine generic type from physical key
+				switch physicalKey {
+				case .leftOption, .rightOption: activeGenericTypes.insert(.option)
+				case .leftCommand, .rightCommand:
+					activeGenericTypes.insert(.command)
+				case .leftControl, .rightControl:
+					activeGenericTypes.insert(.control)
+				case .leftShift, .rightShift: activeGenericTypes.insert(.shift)
+				case .function: break  // `fn` doesn't have a generic counterpart in GenericModifierType
+				}
+			}
+		}
+		lock.unlock()
 
-                // Rule B: All generic modifiers in the binding must be currently active
-                // AND ensure that if a generic is specified, no specific of that type is in exactModifiers (parser should prevent this, but good for safety)
-                var genericMatch = true
-                for genModType in binding.genericModifiers {
-                    if !activeGenericTypes.contains(genModType) {
-                        genericMatch = false
-                        break
-                    }
-                    // Parser validation should ensure exactModifiers doesn't contain specifics if generic is used for same type.
-                    // e.g. if binding.genericModifiers has .option, binding.exactModifiers shouldn't have .leftOption
-                }
-                guard genericMatch else {
-                    continue  // Next binding
-                }
+		// Iterate only over bindings that match the nonModifierKeyCode
+		for binding in candidateBindings {
+			// Perform matching based on exact and generic modifiers
 
-                // Rule C: Count check - the number of distinct physical modifiers pressed must match the number intended by the binding.
-                // Number of modifiers intended by binding:
-                // This assumes parser enforces that exactModifiers and genericModifiers are for distinct modifier *types*.
-                // e.g., can't have exact lalt AND generic alt. Only one defines the 'option' type part of the binding.
+			// Rule A: All exact modifiers in the binding must be currently pressed
+			guard binding.exactModifiers.isSubset(of: currentPhysicalKeys)
+			else {
+				continue  // Next binding
+			}
 
-                // More precise count: total number of active physical keys must match what the binding implies.
-                // A binding like `alt-shift-h` implies two distinct modifier keys are involved (one option, one shift).
-                // A binding like `lalt-ralt-h` implies two distinct modifier keys are involved (left option, right option).
-                let bindingEffectiveModifierCount =
-                    binding.exactModifiers.count
-                        + binding.genericModifiers.count
-                // This count must be validated by the parser: e.g. `alt-lalt-h` is invalid.
-                // If parser is correct, `binding.exactModifiers` and `binding.genericModifiers` don't specify the same base modifier type.
+			// Rule B: All generic modifiers in the binding must be currently active
+			// AND ensure that if a generic is specified, no specific of that type is in exactModifiers (parser should prevent this, but good for safety)
+			var genericMatch = true
+			for genModType in binding.genericModifiers {
+				if !activeGenericTypes.contains(genModType) {
+					genericMatch = false
+					break
+				}
+				// Parser validation should ensure exactModifiers doesn't contain specifics if generic is used for same type.
+				// e.g. if binding.genericModifiers has .option, binding.exactModifiers shouldn't have .leftOption
+			}
+			guard genericMatch else {
+				continue  // Next binding
+			}
 
-                if currentPhysicalKeys.count == bindingEffectiveModifierCount {
-                    // If all above checks pass, it's a match.
-                    print(
-                        "INFO: Hotkey matched: \(binding.descriptionWithKeyNotation)"
-                    )
-                    Task {
-                        try await runSession(
-                            .hotkeyBinding, .checkServerIsEnabledOrDie
-                        ) { () throws in
-                            _ = try await binding.commands.runCmdSeq(
-                                .defaultEnv, .emptyStdin)
-                        }
-                    }
-                    return true  // Consume event
-                }
-            }
-        }
-        return false
-    }
+			// Rule C: Count check - the number of distinct physical modifiers pressed must match the number intended by the binding.
+			// Number of modifiers intended by binding:
+			// This assumes parser enforces that exactModifiers and genericModifiers are for distinct modifier *types*.
+			// e.g., can't have exact lalt AND generic alt. Only one defines the 'option' type part of the binding.
+
+			// More precise count: total number of active physical keys must match what the binding implies.
+			// A binding like `alt-shift-h` implies two distinct modifier keys are involved (one option, one shift).
+			// A binding like `lalt-ralt-h` implies two distinct modifier keys are involved (left option, right option).
+			let bindingEffectiveModifierCount =
+				binding.exactModifiers.count
+				+ binding.genericModifiers.count
+			// This count must be validated by the parser: e.g. `alt-lalt-h` is invalid.
+			// If parser is correct, `binding.exactModifiers` and `binding.genericModifiers` don't specify the same base modifier type.
+
+			if currentPhysicalKeys.count == bindingEffectiveModifierCount {
+				// If all above checks pass, it's a match.
+				print(
+					"INFO: Hotkey matched: \(binding.descriptionWithKeyNotation)"
+				)
+				Task {
+					try await runSession(
+						.hotkeyBinding, .checkServerIsEnabledOrDie
+					) { () throws in
+						_ = try await binding.commands.runCmdSeq(
+							.defaultEnv, .emptyStdin)
+					}
+				}
+				return true  // Consume event
+			}
+		}
+		return false
+	}
 }
 
 // Helper extension for PhysicalModifierKey to get its generic type (if any)
 // This should ideally be in keysMap.swift or a shared location if GenericModifierType is there.
 // For now, adding it here for GlobalHotkeyMonitor's use.
-private extension PhysicalModifierKey {
-    var genericType: GenericModifierType? {
-        switch self {
-            case .leftOption, .rightOption: return .option
-            case .leftCommand, .rightCommand: return .command
-            case .leftControl, .rightControl: return .control
-            case .leftShift, .rightShift: return .shift
-            case .function: return nil  // Fn is always specific
-        }
-    }
+extension PhysicalModifierKey {
+	fileprivate var genericType: GenericModifierType? {
+		switch self {
+		case .leftOption, .rightOption: return .option
+		case .leftCommand, .rightCommand: return .command
+		case .leftControl, .rightControl: return .control
+		case .leftShift, .rightShift: return .shift
+		case .function: return nil  // Fn is always specific
+		}
+	}
 }

--- a/Sources/AppBundle/GlobalHotkeyMonitor.swift
+++ b/Sources/AppBundle/GlobalHotkeyMonitor.swift
@@ -2,313 +2,312 @@ import AppKit  // For NSEvent, CGEvent
 import Common  // For Config, Command, etc.
 
 class GlobalHotkeyMonitor {
-	private var eventTap: CFMachPort?
-	private var runLoopSource: CFRunLoopSource?
-	private let stateLock = NSLock()  // Lock for protecting shared state
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+    private let stateLock = NSLock()  // Lock for protecting shared state
 
-	// State to track pressed keys, accessed with stateLock
-	private var pressedModifierKeyCodes: Set<UInt16> = []
-	// Optional: could also track all pressed keys if complex multi-non-modifier chords were needed
-	// private var pressedKeyCodes: Set<UInt16> = []
+    // State to track pressed keys, accessed with stateLock
+    private var pressedModifierKeyCodes: Set<UInt16> = []
+    // Optional: could also track all pressed keys if complex multi-non-modifier chords were needed
+    // private var pressedKeyCodes: Set<UInt16> = []
 
-	// For optimized hotkey lookup, accessed with stateLock
-	private var bindingsByKeyCode: [UInt16: [HotkeyBinding]] = [:]
-	private var lastKnownModeName: String?  // Updated by updateBindingsCache, accessed with stateLock
+    // For optimized hotkey lookup, accessed with stateLock
+    private var bindingsByKeyCode: [UInt16: [HotkeyBinding]] = [:]
+    private var lastKnownModeName: String?  // Updated by updateBindingsCache, accessed with stateLock
 
-	// Static shared instance
-	@MainActor static let shared = GlobalHotkeyMonitor()
+    // Static shared instance
+    @MainActor static let shared = GlobalHotkeyMonitor()
 
-	private init() {
-		// Initialization if needed
-	}
+    private init() {
+        // Initialization if needed
+    }
 
-	@MainActor  // Added @MainActor
-	func updateBindingsCache() {
-		// This function runs on the MainActor, so it can safely access global activeMode and config.
-		guard let currentGlobalActiveModeName = activeMode,
-			let modeConfig = config.modes[currentGlobalActiveModeName]
-		else {
-			// If no active mode or mode config, clear local bindings
-			stateLock.lock()
-			self.bindingsByKeyCode.removeAll()
-			self.lastKnownModeName = nil
-			stateLock.unlock()
-			print(
-				"INFO: GlobalHotkeyMonitor cleared bindings cache due to no active mode/config."
-			)
-			return
-		}
+    @MainActor  // Added @MainActor
+    func updateBindingsCache() {
+        // This function runs on the MainActor, so it can safely access global activeMode and config.
+        guard let currentGlobalActiveModeName = activeMode,
+              let modeConfig = config.modes[currentGlobalActiveModeName]
+        else {
+            // If no active mode or mode config, clear local bindings
+            stateLock.lock()
+            self.bindingsByKeyCode.removeAll()
+            self.lastKnownModeName = nil
+            stateLock.unlock()
+            print(
+                "INFO: GlobalHotkeyMonitor cleared bindings cache due to no active mode/config."
+            )
+            return
+        }
 
-		stateLock.lock()
-		if self.lastKnownModeName != currentGlobalActiveModeName
-			|| (self.bindingsByKeyCode.isEmpty && !modeConfig.bindings.isEmpty)
-		{
-			print(
-				"INFO: GlobalHotkeyMonitor rebuilding bindings cache for mode: \(currentGlobalActiveModeName)."
-			)
-			self.bindingsByKeyCode.removeAll()
-			for (_, binding) in modeConfig.bindings {
-				self.bindingsByKeyCode[binding.keyCode, default: []].append(binding)
-			}
-			self.lastKnownModeName = currentGlobalActiveModeName
-		}
-		stateLock.unlock()
-	}
+        stateLock.lock()
+        if self.lastKnownModeName != currentGlobalActiveModeName
+            || (self.bindingsByKeyCode.isEmpty && !modeConfig.bindings.isEmpty)
+        {
+            print(
+                "INFO: GlobalHotkeyMonitor rebuilding bindings cache for mode: \(currentGlobalActiveModeName)."
+            )
+            self.bindingsByKeyCode.removeAll()
+            for (_, binding) in modeConfig.bindings {
+                self.bindingsByKeyCode[binding.keyCode, default: []].append(binding)
+            }
+            self.lastKnownModeName = currentGlobalActiveModeName
+        }
+        stateLock.unlock()
+    }
 
-	@MainActor  // Added @MainActor
-	func start() {
-		guard eventTap == nil else {
-			print("WARN: GlobalHotkeyMonitor already started.")
-			return
-		}
+    @MainActor  // Added @MainActor
+    func start() {
+        guard eventTap == nil else {
+            print("WARN: GlobalHotkeyMonitor already started.")
+            return
+        }
 
-		// Initial population of bindings cache
-		updateBindingsCache()
+        // Initial population of bindings cache
+        updateBindingsCache()
 
-		// The types of events we want to tap.
-		// We need keyDown and keyUp to track all key states, including modifiers.
-		// flagsChanged can be supplementary or primary for modifiers if direct key up/down for them is noisy or problematic.
-		// Let's start with keyDown and keyUp.
-		let eventsToTap: CGEventMask =
-			(1 << CGEventType.keyDown.rawValue) | (1 << CGEventType.keyUp.rawValue)
-			| (1 << CGEventType.flagsChanged.rawValue)
+        // The types of events we want to tap.
+        // We need keyDown and keyUp to track all key states, including modifiers.
+        // flagsChanged can be supplementary or primary for modifiers if direct key up/down for them is noisy or problematic.
+        // Let's start with keyDown and keyUp.
+        let eventsToTap: CGEventMask =
+            (1 << CGEventType.keyDown.rawValue) | (1 << CGEventType.keyUp.rawValue)
+                | (1 << CGEventType.flagsChanged.rawValue)
 
-		// Create the event tap.
-		// '.cghidEventTap' is a common choice for system-wide hardware events.
-		guard
-			let tap = CGEvent.tapCreate(
-				tap: .cgSessionEventTap,  // Tap into the session event stream. Others: .cgHIDEventTap, .cgAnnotatedSessionEventTap
-				place: .headInsertEventTap,  // Insert at the head of the event tap list
-				options: .defaultTap,  // Default options
-				eventsOfInterest: eventsToTap,
-				callback: { proxy, type, event, refcon -> Unmanaged<CGEvent>? in
-					// 'refcon' is the UnsafeMutableRawPointer to 'self'
-					guard let refcon else {
-						return Unmanaged.passUnretained(event)
-					}
-					let monitor = Unmanaged<GlobalHotkeyMonitor>.fromOpaque(
-						refcon
-					).takeUnretainedValue()
-					return monitor.handleEvent_Outer(
-						proxy: proxy, type: type, event: event)
-				},
-				userInfo: Unmanaged.passUnretained(self).toOpaque()  // Pass 'self' to the callback
-			)
-		else {
-			printStderr(
-				"ERROR: Failed to create event tap. This usually means AeroSpace requires Accessibility permissions. "
-					+ "Please go to System Settings > Privacy & Security > Accessibility, and ensure AeroSpace is enabled. "
-					+ "You may need to restart AeroSpace after granting permissions."
-			)
-			return
-		}
+        // Create the event tap.
+        // '.cghidEventTap' is a common choice for system-wide hardware events.
+        guard
+            let tap = CGEvent.tapCreate(
+                tap: .cgSessionEventTap,  // Tap into the session event stream. Others: .cgHIDEventTap, .cgAnnotatedSessionEventTap
+                place: .headInsertEventTap,  // Insert at the head of the event tap list
+                options: .defaultTap,  // Default options
+                eventsOfInterest: eventsToTap,
+                callback: { proxy, type, event, refcon -> Unmanaged<CGEvent>? in
+                    // 'refcon' is the UnsafeMutableRawPointer to 'self'
+                    guard let refcon else {
+                        return Unmanaged.passUnretained(event)
+                    }
+                    let monitor = Unmanaged<GlobalHotkeyMonitor>.fromOpaque(
+                        refcon
+                    ).takeUnretainedValue()
+                    return monitor.handleEvent_Outer(
+                        proxy: proxy, type: type, event: event)
+                },
+                userInfo: Unmanaged.passUnretained(self).toOpaque()  // Pass 'self' to the callback
+            )
+        else {
+            printStderr(
+                "ERROR: Failed to create event tap. This usually means AeroSpace requires Accessibility permissions. "
+                    + "Please go to System Settings > Privacy & Security > Accessibility, and ensure AeroSpace is enabled. "
+                    + "You may need to restart AeroSpace after granting permissions."
+            )
+            return
+        }
 
-		// Create a run loop source and add it to the current run loop.
-		guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
-			printStderr("ERROR: Failed to create run loop source for event tap.")
-			return
-		}
+        // Create a run loop source and add it to the current run loop.
+        guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
+            printStderr("ERROR: Failed to create run loop source for event tap.")
+            return
+        }
 
-		CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
-		CGEvent.tapEnable(tap: tap, enable: true)
+        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+        CGEvent.tapEnable(tap: tap, enable: true)
 
-		self.eventTap = tap
-		self.runLoopSource = source
+        self.eventTap = tap
+        self.runLoopSource = source
 
-		print("INFO: GlobalHotkeyMonitor started.")
-	}
+        print("INFO: GlobalHotkeyMonitor started.")
+    }
 
-	@MainActor  // Added @MainActor
-	func stop() {
-		if let tap = eventTap {
-			CGEvent.tapEnable(tap: tap, enable: false)  // Disable event delivery
+    @MainActor  // Added @MainActor
+    func stop() {
+        if let tap = eventTap {
+            CGEvent.tapEnable(tap: tap, enable: false)  // Disable event delivery
 
-			// Invalidate the Mach port. This also removes its run loop sources.
-			// One call is sufficient.
-			CFMachPortInvalidate(tap)
+            // Invalidate the Mach port. This also removes its run loop sources.
+            // One call is sufficient.
+            CFMachPortInvalidate(tap)
 
-			// Explicitly removing the source after invalidation is generally not needed
-			// as CFMachPortInvalidate should handle it. However, it's kept for now.
-			if let source = runLoopSource {
-				CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
-			}
+            // Explicitly removing the source after invalidation is generally not needed
+            // as CFMachPortInvalidate should handle it. However, it's kept for now.
+            if let source = runLoopSource {
+                CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+            }
 
-			// ARC will handle the release of 'tap' and 'source' when these are set to nil.
-			self.runLoopSource = nil
-			self.eventTap = nil
-			print("INFO: GlobalHotkeyMonitor stopped.")
-		}
-		stateLock.lock()  // Use lock
-		pressedModifierKeyCodes.removeAll()
-		// Clear optimized lookup cache
-		bindingsByKeyCode.removeAll()
-		lastKnownModeName = nil
-		stateLock.unlock()  // Use lock
-	}
+            // ARC will handle the release of 'tap' and 'source' when these are set to nil.
+            self.runLoopSource = nil
+            self.eventTap = nil
+            print("INFO: GlobalHotkeyMonitor stopped.")
+        }
+        stateLock.lock()  // Use lock
+        pressedModifierKeyCodes.removeAll()
+        // Clear optimized lookup cache
+        bindingsByKeyCode.removeAll()
+        lastKnownModeName = nil
+        stateLock.unlock()  // Use lock
+    }
 
-	// Entry point from C callback. Runs on event tap thread.
-	private nonisolated func handleEvent_Outer(
-		proxy: CGEventTapProxy, type cgEventType: CGEventType, event: CGEvent
-	) -> Unmanaged<CGEvent>? {
-		let keyCode = UInt16(event.getIntegerValueField(.keyboardEventKeycode))
-		let flags = event.flags
-		var consumed = false
+    // Entry point from C callback. Runs on event tap thread.
+    private nonisolated func handleEvent_Outer(
+        proxy: CGEventTapProxy, type cgEventType: CGEventType, event: CGEvent
+    ) -> Unmanaged<CGEvent>? {
+        let keyCode = UInt16(event.getIntegerValueField(.keyboardEventKeycode))
+        let flags = event.flags
+        var consumed = false
 
-		switch cgEventType {
-		case .keyDown:
-			stateLock.lock()
-			if isModifierKeyCode_Raw(keyCode) {  // Use a raw checker that doesn't need self if possible, or call it on self.
-				pressedModifierKeyCodes.insert(keyCode)
-				stateLock.unlock()
-			} else {
-				stateLock.unlock()  // Unlock before calling potentially complex logic
-				if findAndExecuteHotkeyMatch_TapThread(nonModifierKeyCode: keyCode)
-				{
-					consumed = true
-				}
-			}
-		case .keyUp:
-			stateLock.lock()
-			if isModifierKeyCode_Raw(keyCode) {
-				pressedModifierKeyCodes.remove(keyCode)
-			}
-			stateLock.unlock()
-		case .flagsChanged:
-			stateLock.lock()
-			let changedModifierKeyCode = keyCode
-			// Determine if the specific modifier key that changed is now pressed or released.
-			guard
-				let physicalKey = physicalModifierKeyToKeyCode.first(where: {
-					$0.value == changedModifierKeyCode
-				})?.key
-			else {
-				print(
-					"WARN: flagsChanged event for unknown modifier keyCode: \(changedModifierKeyCode) (raw flags: \(flags))"
-				)
-				stateLock.unlock()
-				break
-			}
+        switch cgEventType {
+            case .keyDown:
+                stateLock.lock()
+                if isModifierKeyCode_Raw(keyCode) {  // Use a raw checker that doesn't need self if possible, or call it on self.
+                    pressedModifierKeyCodes.insert(keyCode)
+                    stateLock.unlock()
+                } else {
+                    stateLock.unlock()  // Unlock before calling potentially complex logic
+                    if findAndExecuteHotkeyMatch_TapThread(nonModifierKeyCode: keyCode) {
+                        consumed = true
+                    }
+                }
+            case .keyUp:
+                stateLock.lock()
+                if isModifierKeyCode_Raw(keyCode) {
+                    pressedModifierKeyCodes.remove(keyCode)
+                }
+                stateLock.unlock()
+            case .flagsChanged:
+                stateLock.lock()
+                let changedModifierKeyCode = keyCode
+                // Determine if the specific modifier key that changed is now pressed or released.
+                guard
+                    let physicalKey = physicalModifierKeyToKeyCode.first(where: {
+                        $0.value == changedModifierKeyCode
+                    })?.key
+                else {
+                    print(
+                        "WARN: flagsChanged event for unknown modifier keyCode: \(changedModifierKeyCode) (raw flags: \(flags))"
+                    )
+                    stateLock.unlock()
+                    break
+                }
 
-			var modifierIsPressed = false
-			switch physicalKey {
-			case .leftOption, .rightOption:
-				modifierIsPressed = flags.contains(.maskAlternate)
-			case .leftCommand, .rightCommand:
-				modifierIsPressed = flags.contains(.maskCommand)
-			case .leftShift, .rightShift: modifierIsPressed = flags.contains(.maskShift)
-			case .leftControl, .rightControl:
-				modifierIsPressed = flags.contains(.maskControl)
-			case .function: modifierIsPressed = flags.contains(.maskSecondaryFn)
-			}
+                var modifierIsPressed = false
+                switch physicalKey {
+                    case .leftOption, .rightOption:
+                        modifierIsPressed = flags.contains(.maskAlternate)
+                    case .leftCommand, .rightCommand:
+                        modifierIsPressed = flags.contains(.maskCommand)
+                    case .leftShift, .rightShift: modifierIsPressed = flags.contains(.maskShift)
+                    case .leftControl, .rightControl:
+                        modifierIsPressed = flags.contains(.maskControl)
+                    case .function: modifierIsPressed = flags.contains(.maskSecondaryFn)
+                }
 
-			if modifierIsPressed {
-				pressedModifierKeyCodes.insert(changedModifierKeyCode)
-			} else {
-				pressedModifierKeyCodes.remove(changedModifierKeyCode)
-			}
-			stateLock.unlock()
-		default:
-			break
-		}
-		return consumed ? nil : Unmanaged.passUnretained(event)
-	}
+                if modifierIsPressed {
+                    pressedModifierKeyCodes.insert(changedModifierKeyCode)
+                } else {
+                    pressedModifierKeyCodes.remove(changedModifierKeyCode)
+                }
+                stateLock.unlock()
+            default:
+                break
+        }
+        return consumed ? nil : Unmanaged.passUnretained(event)
+    }
 
-	// This function will be called from the tap thread (nonisolated context)
-	// It needs to handle its own synchronization for shared state.
-	private func findAndExecuteHotkeyMatch_TapThread(nonModifierKeyCode: UInt16) -> Bool {
-		stateLock.lock()  // Lock at the beginning
+    // This function will be called from the tap thread (nonisolated context)
+    // It needs to handle its own synchronization for shared state.
+    private func findAndExecuteHotkeyMatch_TapThread(nonModifierKeyCode: UInt16) -> Bool {
+        stateLock.lock()  // Lock at the beginning
 
-		// bindingsByKeyCode and lastKnownModeName are now populated by updateBindingsCache()
-		// No need to check activeMode or config directly here.
-		// The cache (self.bindingsByKeyCode) is assumed to be up-to-date for the current mode.
+        // bindingsByKeyCode and lastKnownModeName are now populated by updateBindingsCache()
+        // No need to check activeMode or config directly here.
+        // The cache (self.bindingsByKeyCode) is assumed to be up-to-date for the current mode.
 
-		guard let candidateBindings = self.bindingsByKeyCode[nonModifierKeyCode],
-			!candidateBindings.isEmpty
-		else {
-			stateLock.unlock()
-			return false
-		}
+        guard let candidateBindings = self.bindingsByKeyCode[nonModifierKeyCode],
+              !candidateBindings.isEmpty
+        else {
+            stateLock.unlock()
+            return false
+        }
 
-		let localPressedModifierKeyCodes = self.pressedModifierKeyCodes  // Copy while holding lock
+        let localPressedModifierKeyCodes = self.pressedModifierKeyCodes  // Copy while holding lock
 
-		var currentPhysicalKeys = Set<PhysicalModifierKey>()
-		var activeGenericTypes = Set<GenericModifierType>()
+        var currentPhysicalKeys = Set<PhysicalModifierKey>()
+        var activeGenericTypes = Set<GenericModifierType>()
 
-		// Unlock *after* copying shared data needed for matching, but *before* iterating if possible,
-		// or keep lock if iteration logic is simple and doesn't call out.
-		// For now, keep lock for simplicity during matching as well, as it involves reading config too.
+        // Unlock *after* copying shared data needed for matching, but *before* iterating if possible,
+        // or keep lock if iteration logic is simple and doesn't call out.
+        // For now, keep lock for simplicity during matching as well, as it involves reading config too.
 
-		for pressedKc in localPressedModifierKeyCodes {
-			if let physicalKey = physicalModifierKeyToKeyCode.first(where: {
-				$0.value == pressedKc
-			})?.key {
-				currentPhysicalKeys.insert(physicalKey)
-				if let genericType = physicalKey.genericType {  // Using the extension method
-					activeGenericTypes.insert(genericType)
-				}
-			}
-		}
-		// At this point, localPressedModifierKeyCodes, currentPhysicalKeys, activeGenericTypes are derived.
-		// The candidateBindings are also from shared state (bindingsByKeyCode).
+        for pressedKc in localPressedModifierKeyCodes {
+            if let physicalKey = physicalModifierKeyToKeyCode.first(where: {
+                $0.value == pressedKc
+            })?.key {
+                currentPhysicalKeys.insert(physicalKey)
+                if let genericType = physicalKey.genericType {  // Using the extension method
+                    activeGenericTypes.insert(genericType)
+                }
+            }
+        }
+        // At this point, localPressedModifierKeyCodes, currentPhysicalKeys, activeGenericTypes are derived.
+        // The candidateBindings are also from shared state (bindingsByKeyCode).
 
-		// Iterate only over bindings that match the nonModifierKeyCode
-		for binding in candidateBindings {  // candidateBindings was derived from shared state under lock
-			guard binding.exactModifiers.isSubset(of: currentPhysicalKeys) else {
-				continue
-			}
+        // Iterate only over bindings that match the nonModifierKeyCode
+        for binding in candidateBindings {  // candidateBindings was derived from shared state under lock
+            guard binding.exactModifiers.isSubset(of: currentPhysicalKeys) else {
+                continue
+            }
 
-			var genericMatch = true
-			for genModType in binding.genericModifiers {
-				if !activeGenericTypes.contains(genModType) {
-					genericMatch = false
-					break
-				}
-			}
-			guard genericMatch else { continue }
+            var genericMatch = true
+            for genModType in binding.genericModifiers {
+                if !activeGenericTypes.contains(genModType) {
+                    genericMatch = false
+                    break
+                }
+            }
+            guard genericMatch else { continue }
 
-			let bindingEffectiveModifierCount =
-				binding.exactModifiers.count + binding.genericModifiers.count
-			if currentPhysicalKeys.count == bindingEffectiveModifierCount {
-				// Match found!
-				stateLock.unlock()  // Unlock before dispatching to main actor
+            let bindingEffectiveModifierCount =
+                binding.exactModifiers.count + binding.genericModifiers.count
+            if currentPhysicalKeys.count == bindingEffectiveModifierCount {
+                // Match found!
+                stateLock.unlock()  // Unlock before dispatching to main actor
 
-				print("INFO: Hotkey matched: \(binding.descriptionWithKeyNotation)")
-				DispatchQueue.main.async {  // Dispatch command execution to main actor
-					Task {  // Task on MainActor to run async commands
-						try await runSession(
-							.hotkeyBinding, .checkServerIsEnabledOrDie
-						) { () throws in
-							_ = try await binding.commands.runCmdSeq(
-								.defaultEnv, .emptyStdin)
-						}
-					}
-				}
-				return true  // Consume event
-			}
-		}
+                print("INFO: Hotkey matched: \(binding.descriptionWithKeyNotation)")
+                DispatchQueue.main.async {  // Dispatch command execution to main actor
+                    Task {  // Task on MainActor to run async commands
+                        try await runSession(
+                            .hotkeyBinding, .checkServerIsEnabledOrDie
+                        ) { () throws in
+                            _ = try await binding.commands.runCmdSeq(
+                                .defaultEnv, .emptyStdin)
+                        }
+                    }
+                }
+                return true  // Consume event
+            }
+        }
 
-		stateLock.unlock()  // Ensure unlock if no match found
-		return false
-	}
+        stateLock.unlock()  // Ensure unlock if no match found
+        return false
+    }
 
-	// Helper function to check if a keycode is a modifier. Can be called with lock held or not, doesn't modify state.
-	// Renamed from isModifierKeyCode to avoid confusion with any potential @MainActor version.
-	private func isModifierKeyCode_Raw(_ keyCode: UInt16) -> Bool {
-		physicalModifierKeyToKeyCode.values.contains(keyCode)
-	}
+    // Helper function to check if a keycode is a modifier. Can be called with lock held or not, doesn't modify state.
+    // Renamed from isModifierKeyCode to avoid confusion with any potential @MainActor version.
+    private func isModifierKeyCode_Raw(_ keyCode: UInt16) -> Bool {
+        physicalModifierKeyToKeyCode.values.contains(keyCode)
+    }
 }
 
 // Helper extension for PhysicalModifierKey to get its generic type (if any)
 // This should ideally be in keysMap.swift or a shared location if GenericModifierType is there.
 // For now, adding it here for GlobalHotkeyMonitor's use.
-extension PhysicalModifierKey {
-	fileprivate var genericType: GenericModifierType? {
-		switch self {
-		case .leftOption, .rightOption: return .option
-		case .leftCommand, .rightCommand: return .command
-		case .leftControl, .rightControl: return .control
-		case .leftShift, .rightShift: return .shift
-		case .function: return nil  // Fn is always specific
-		}
-	}
+private extension PhysicalModifierKey {
+    var genericType: GenericModifierType? {
+        switch self {
+            case .leftOption, .rightOption: return .option
+            case .leftCommand, .rightCommand: return .command
+            case .leftControl, .rightControl: return .control
+            case .leftShift, .rightShift: return .shift
+            case .function: return nil  // Fn is always specific
+        }
+    }
 }

--- a/Sources/AppBundle/GlobalHotkeyMonitor.swift
+++ b/Sources/AppBundle/GlobalHotkeyMonitor.swift
@@ -5,275 +5,275 @@ import Common  // For Config, Command, etc.
 
 @MainActor
 class GlobalHotkeyMonitor {
-	private var eventTap: CFMachPort?
-	private var runLoopSource: CFRunLoopSource?
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
 
-	// State to track pressed keys
-	// Using UInt16 for virtual key codes
-	private var pressedModifierKeyCodes: Set<UInt16> = []
-	// Optional: could also track all pressed keys if complex multi-non-modifier chords were needed
-	// private var pressedKeyCodes: Set<UInt16> = []
+    // State to track pressed keys
+    // Using UInt16 for virtual key codes
+    private var pressedModifierKeyCodes: Set<UInt16> = []
+    // Optional: could also track all pressed keys if complex multi-non-modifier chords were needed
+    // private var pressedKeyCodes: Set<UInt16> = []
 
-	// The mechanism is to read from global `config` and `activeMode`
-	// For now, assuming access to 'config' and 'activeMode' (defined in HotkeyBinding.swift context)
+    // The mechanism is to read from global `config` and `activeMode`
+    // For now, assuming access to 'config' and 'activeMode' (defined in HotkeyBinding.swift context)
 
-	init() {
-		// Initialization if needed
-	}
+    init() {
+        // Initialization if needed
+    }
 
-	func start() {
-		guard eventTap == nil else {
-			print("WARN: GlobalHotkeyMonitor already started.")
-			return
-		}
+    func start() {
+        guard eventTap == nil else {
+            print("WARN: GlobalHotkeyMonitor already started.")
+            return
+        }
 
-		// The types of events we want to tap.
-		// We need keyDown and keyUp to track all key states, including modifiers.
-		// flagsChanged can be supplementary or primary for modifiers if direct key up/down for them is noisy or problematic.
-		// Let's start with keyDown and keyUp.
-		let eventsToTap: CGEventMask =
-			(1 << CGEventType.keyDown.rawValue) | (1 << CGEventType.keyUp.rawValue)
-			| (1 << CGEventType.flagsChanged.rawValue)
+        // The types of events we want to tap.
+        // We need keyDown and keyUp to track all key states, including modifiers.
+        // flagsChanged can be supplementary or primary for modifiers if direct key up/down for them is noisy or problematic.
+        // Let's start with keyDown and keyUp.
+        let eventsToTap: CGEventMask =
+            (1 << CGEventType.keyDown.rawValue) | (1 << CGEventType.keyUp.rawValue)
+                | (1 << CGEventType.flagsChanged.rawValue)
 
-		// Create the event tap.
-		// '.cghidEventTap' is a common choice for system-wide hardware events.
-		guard
-			let tap = CGEvent.tapCreate(
-				tap: .cgSessionEventTap,  // Tap into the session event stream. Others: .cgHIDEventTap, .cgAnnotatedSessionEventTap
-				place: .headInsertEventTap,  // Insert at the head of the event tap list
-				options: .defaultTap,  // Default options
-				eventsOfInterest: eventsToTap,
-				callback: { proxy, type, event, refcon -> Unmanaged<CGEvent>? in
-					// 'refcon' is the UnsafeMutableRawPointer to 'self'
-					guard let refcon else {
-						return Unmanaged.passUnretained(event)
-					}
-					let monitor = Unmanaged<GlobalHotkeyMonitor>.fromOpaque(
-						refcon
-					).takeUnretainedValue()
-					return monitor.handleEvent(
-						proxy: proxy, type: type, event: event)
-				},
-				userInfo: Unmanaged.passUnretained(self).toOpaque()  // Pass 'self' to the callback
-			)
-		else {
-			printStderr(
-				"ERROR: Failed to create event tap. This usually means AeroSpace requires Accessibility permissions. "
-					+ "Please go to System Settings > Privacy & Security > Accessibility, and ensure AeroSpace is enabled. "
-					+ "You may need to restart AeroSpace after granting permissions."
-			)
-			// TODO: Better error handling - inform user, guide to permissions.
-			// Consider showing a user-facing alert if possible from this context,
-			// or setting a flag that the UI can pick up to show an alert.
-			// Example to open settings (use with caution, might need main thread if called from background):
-			// NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!)
-			return
-		}
+        // Create the event tap.
+        // '.cghidEventTap' is a common choice for system-wide hardware events.
+        guard
+            let tap = CGEvent.tapCreate(
+                tap: .cgSessionEventTap,  // Tap into the session event stream. Others: .cgHIDEventTap, .cgAnnotatedSessionEventTap
+                place: .headInsertEventTap,  // Insert at the head of the event tap list
+                options: .defaultTap,  // Default options
+                eventsOfInterest: eventsToTap,
+                callback: { proxy, type, event, refcon -> Unmanaged<CGEvent>? in
+                    // 'refcon' is the UnsafeMutableRawPointer to 'self'
+                    guard let refcon else {
+                        return Unmanaged.passUnretained(event)
+                    }
+                    let monitor = Unmanaged<GlobalHotkeyMonitor>.fromOpaque(
+                        refcon
+                    ).takeUnretainedValue()
+                    return monitor.handleEvent(
+                        proxy: proxy, type: type, event: event)
+                },
+                userInfo: Unmanaged.passUnretained(self).toOpaque()  // Pass 'self' to the callback
+            )
+        else {
+            printStderr(
+                "ERROR: Failed to create event tap. This usually means AeroSpace requires Accessibility permissions. "
+                    + "Please go to System Settings > Privacy & Security > Accessibility, and ensure AeroSpace is enabled. "
+                    + "You may need to restart AeroSpace after granting permissions."
+            )
+            // TODO: Better error handling - inform user, guide to permissions.
+            // Consider showing a user-facing alert if possible from this context,
+            // or setting a flag that the UI can pick up to show an alert.
+            // Example to open settings (use with caution, might need main thread if called from background):
+            // NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!)
+            return
+        }
 
-		// Create a run loop source and add it to the current run loop.
-		guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
-			printStderr("ERROR: Failed to create run loop source for event tap.")
-			return
-		}
+        // Create a run loop source and add it to the current run loop.
+        guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
+            printStderr("ERROR: Failed to create run loop source for event tap.")
+            return
+        }
 
-		CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
-		CGEvent.tapEnable(tap: tap, enable: true)
+        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+        CGEvent.tapEnable(tap: tap, enable: true)
 
-		self.eventTap = tap
-		self.runLoopSource = source
+        self.eventTap = tap
+        self.runLoopSource = source
 
-		print("INFO: GlobalHotkeyMonitor started.")
-	}
+        print("INFO: GlobalHotkeyMonitor started.")
+    }
 
-	func stop() {
-		if let tap = eventTap {
-			CGEvent.tapEnable(tap: tap, enable: false)
-			// CFMachPortInvalidate(tap) // Invalidating the port also removes the run loop source.
-			// However, it's often better to remove the source explicitly.
-			if let source = runLoopSource {
-				CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
-			}
-			// CFRelease(tap) // tap is a CFMachPort, managed by ARC when interacting with Swift types like CFMachPort?
-			// If directly using CFTypeRef, manual CFRelease would be needed.
-			// Swift handles this for optional CF types.
-			self.runLoopSource = nil
-			self.eventTap = nil
-			print("INFO: GlobalHotkeyMonitor stopped.")
-		}
-		pressedModifierKeyCodes.removeAll()
-	}
+    func stop() {
+        if let tap = eventTap {
+            CGEvent.tapEnable(tap: tap, enable: false)
+            // CFMachPortInvalidate(tap) // Invalidating the port also removes the run loop source.
+            // However, it's often better to remove the source explicitly.
+            if let source = runLoopSource {
+                CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+            }
+            // CFRelease(tap) // tap is a CFMachPort, managed by ARC when interacting with Swift types like CFMachPort?
+            // If directly using CFTypeRef, manual CFRelease would be needed.
+            // Swift handles this for optional CF types.
+            self.runLoopSource = nil
+            self.eventTap = nil
+            print("INFO: GlobalHotkeyMonitor stopped.")
+        }
+        pressedModifierKeyCodes.removeAll()
+    }
 
-	private func handleEvent(proxy: CGEventTapProxy, type: CGEventType, event: CGEvent)
-		-> Unmanaged<CGEvent>?
-	{
-		let keyCode = UInt16(event.getIntegerValueField(.keyboardEventKeycode))
+    private func handleEvent(proxy: CGEventTapProxy, type: CGEventType, event: CGEvent)
+        -> Unmanaged<CGEvent>?
+    {
+        let keyCode = UInt16(event.getIntegerValueField(.keyboardEventKeycode))
 
-		switch type {
-		case .keyDown:
-			if isModifierKeyCode(keyCode) {
-				pressedModifierKeyCodes.insert(keyCode)
-			} else {
-				if checkForHotkeyMatch(nonModifierKeyCode: keyCode, event: event) {
-					return nil
-				}
-			}
-		case .keyUp:
-			if isModifierKeyCode(keyCode) {
-				pressedModifierKeyCodes.remove(keyCode)
-			} else {
-				// Optionally handle keyUp for non-modifiers if needed for specific command types
-			}
-		case .flagsChanged:
-			// The keyCode in a flagsChanged event is the specific modifier key that changed.
-			let changedModifierKeyCode = keyCode
-			let newFlagsState = event.flags
+        switch type {
+            case .keyDown:
+                if isModifierKeyCode(keyCode) {
+                    pressedModifierKeyCodes.insert(keyCode)
+                } else {
+                    if checkForHotkeyMatch(nonModifierKeyCode: keyCode, event: event) {
+                        return nil
+                    }
+                }
+            case .keyUp:
+                if isModifierKeyCode(keyCode) {
+                    pressedModifierKeyCodes.remove(keyCode)
+                } else {
+                    // Optionally handle keyUp for non-modifiers if needed for specific command types
+                }
+            case .flagsChanged:
+                // The keyCode in a flagsChanged event is the specific modifier key that changed.
+                let changedModifierKeyCode = keyCode
+                let newFlagsState = event.flags
 
-			// Determine if the specific modifier key that changed is now pressed or released.
-			// This requires knowing which generic flag corresponds to the specific modifier key code.
-			guard
-				let physicalKey = physicalModifierKeyToKeyCode.first(where: {
-					$0.value == changedModifierKeyCode
-				})?.key
-			else {
-				// Unknown modifier key code that caused flagsChanged, should not happen if our maps are complete.
-				print(
-					"WARN: flagsChanged event for unknown modifier keyCode: \(changedModifierKeyCode)"
-				)
-				break
-			}
+                // Determine if the specific modifier key that changed is now pressed or released.
+                // This requires knowing which generic flag corresponds to the specific modifier key code.
+                guard
+                    let physicalKey = physicalModifierKeyToKeyCode.first(where: {
+                        $0.value == changedModifierKeyCode
+                    })?.key
+                else {
+                    // Unknown modifier key code that caused flagsChanged, should not happen if our maps are complete.
+                    print(
+                        "WARN: flagsChanged event for unknown modifier keyCode: \(changedModifierKeyCode)"
+                    )
+                    break
+                }
 
-			var modifierIsPressed = false
-			switch physicalKey {
-			case .leftOption, .rightOption:
-				modifierIsPressed = newFlagsState.contains(.maskAlternate)
-			case .leftCommand, .rightCommand:
-				modifierIsPressed = newFlagsState.contains(.maskCommand)
-			case .leftShift, .rightShift:
-				modifierIsPressed = newFlagsState.contains(.maskShift)
-			case .leftControl, .rightControl:
-				modifierIsPressed = newFlagsState.contains(.maskControl)
-			case .function:
-				modifierIsPressed = newFlagsState.contains(.maskSecondaryFn)
-			}
+                var modifierIsPressed = false
+                switch physicalKey {
+                    case .leftOption, .rightOption:
+                        modifierIsPressed = newFlagsState.contains(.maskAlternate)
+                    case .leftCommand, .rightCommand:
+                        modifierIsPressed = newFlagsState.contains(.maskCommand)
+                    case .leftShift, .rightShift:
+                        modifierIsPressed = newFlagsState.contains(.maskShift)
+                    case .leftControl, .rightControl:
+                        modifierIsPressed = newFlagsState.contains(.maskControl)
+                    case .function:
+                        modifierIsPressed = newFlagsState.contains(.maskSecondaryFn)
+                }
 
-			if modifierIsPressed {
-				pressedModifierKeyCodes.insert(changedModifierKeyCode)
-			} else {
-				pressedModifierKeyCodes.remove(changedModifierKeyCode)
-			}
+                if modifierIsPressed {
+                    pressedModifierKeyCodes.insert(changedModifierKeyCode)
+                } else {
+                    pressedModifierKeyCodes.remove(changedModifierKeyCode)
+                }
 		// print("DEBUG: FlagsChanged: \(physicalKey) (kc: \(changedModifierKeyCode)) is now \(modifierIsPressed ? "pressed" : "released"). Current pressed: \(pressedModifierKeyCodes)")
 
-		default:
-			break
-		}
+            default:
+                break
+        }
 
-		return Unmanaged.passUnretained(event)
-	}
+        return Unmanaged.passUnretained(event)
+    }
 
-	private func isModifierKeyCode(_ keyCode: UInt16) -> Bool {
-		physicalModifierKeyToKeyCode.values.contains(keyCode)
-	}
+    private func isModifierKeyCode(_ keyCode: UInt16) -> Bool {
+        physicalModifierKeyToKeyCode.values.contains(keyCode)
+    }
 
-	private func checkForHotkeyMatch(nonModifierKeyCode: UInt16, event: CGEvent) -> Bool {
-		guard let currentActiveMode = activeMode,
-			let modeConfig = config.modes[currentActiveMode]
-		else {
-			return false
-		}
+    private func checkForHotkeyMatch(nonModifierKeyCode: UInt16, event: CGEvent) -> Bool {
+        guard let currentActiveMode = activeMode,
+              let modeConfig = config.modes[currentActiveMode]
+        else {
+            return false
+        }
 
-		// 1. Determine current state of pressed modifiers
-		var currentPhysicalKeys = Set<PhysicalModifierKey>()
-		var activeGenericTypes = Set<GenericModifierType>()
+        // 1. Determine current state of pressed modifiers
+        var currentPhysicalKeys = Set<PhysicalModifierKey>()
+        var activeGenericTypes = Set<GenericModifierType>()
 
-		for pressedKc in self.pressedModifierKeyCodes {
-			if let physicalKey = physicalModifierKeyToKeyCode.first(where: {
-				$0.value == pressedKc
-			})?.key {
-				currentPhysicalKeys.insert(physicalKey)
-				// Determine generic type from physical key
-				switch physicalKey {
-				case .leftOption, .rightOption: activeGenericTypes.insert(.option)
-				case .leftCommand, .rightCommand:
-					activeGenericTypes.insert(.command)
-				case .leftControl, .rightControl:
-					activeGenericTypes.insert(.control)
-				case .leftShift, .rightShift: activeGenericTypes.insert(.shift)
-				case .function: break  // `fn` doesn't have a generic counterpart in GenericModifierType
-				}
-			}
-		}
+        for pressedKc in self.pressedModifierKeyCodes {
+            if let physicalKey = physicalModifierKeyToKeyCode.first(where: {
+                $0.value == pressedKc
+            })?.key {
+                currentPhysicalKeys.insert(physicalKey)
+                // Determine generic type from physical key
+                switch physicalKey {
+                    case .leftOption, .rightOption: activeGenericTypes.insert(.option)
+                    case .leftCommand, .rightCommand:
+                        activeGenericTypes.insert(.command)
+                    case .leftControl, .rightControl:
+                        activeGenericTypes.insert(.control)
+                    case .leftShift, .rightShift: activeGenericTypes.insert(.shift)
+                    case .function: break  // `fn` doesn't have a generic counterpart in GenericModifierType
+                }
+            }
+        }
 
-		for (_, binding) in modeConfig.bindings {
-			if binding.keyCode == nonModifierKeyCode {
-				// Perform matching based on exact and generic modifiers
+        for (_, binding) in modeConfig.bindings {
+            if binding.keyCode == nonModifierKeyCode {
+                // Perform matching based on exact and generic modifiers
 
-				// Rule A: All exact modifiers in the binding must be currently pressed
-				guard binding.exactModifiers.isSubset(of: currentPhysicalKeys)
-				else {
-					continue  // Next binding
-				}
+                // Rule A: All exact modifiers in the binding must be currently pressed
+                guard binding.exactModifiers.isSubset(of: currentPhysicalKeys)
+                else {
+                    continue  // Next binding
+                }
 
-				// Rule B: All generic modifiers in the binding must be currently active
-				// AND ensure that if a generic is specified, no specific of that type is in exactModifiers (parser should prevent this, but good for safety)
-				var genericMatch = true
-				for genModType in binding.genericModifiers {
-					if !activeGenericTypes.contains(genModType) {
-						genericMatch = false
-						break
-					}
-					// Parser validation should ensure exactModifiers doesn't contain specifics if generic is used for same type.
-					// e.g. if binding.genericModifiers has .option, binding.exactModifiers shouldn't have .leftOption
-				}
-				guard genericMatch else {
-					continue  // Next binding
-				}
+                // Rule B: All generic modifiers in the binding must be currently active
+                // AND ensure that if a generic is specified, no specific of that type is in exactModifiers (parser should prevent this, but good for safety)
+                var genericMatch = true
+                for genModType in binding.genericModifiers {
+                    if !activeGenericTypes.contains(genModType) {
+                        genericMatch = false
+                        break
+                    }
+                    // Parser validation should ensure exactModifiers doesn't contain specifics if generic is used for same type.
+                    // e.g. if binding.genericModifiers has .option, binding.exactModifiers shouldn't have .leftOption
+                }
+                guard genericMatch else {
+                    continue  // Next binding
+                }
 
-				// Rule C: Count check - the number of distinct physical modifiers pressed must match the number intended by the binding.
-				// Number of modifiers intended by binding:
-				// This assumes parser enforces that exactModifiers and genericModifiers are for distinct modifier *types*.
-				// e.g., can't have exact lalt AND generic alt. Only one defines the 'option' type part of the binding.
+                // Rule C: Count check - the number of distinct physical modifiers pressed must match the number intended by the binding.
+                // Number of modifiers intended by binding:
+                // This assumes parser enforces that exactModifiers and genericModifiers are for distinct modifier *types*.
+                // e.g., can't have exact lalt AND generic alt. Only one defines the 'option' type part of the binding.
 
-				// More precise count: total number of active physical keys must match what the binding implies.
-				// A binding like `alt-shift-h` implies two distinct modifier keys are involved (one option, one shift).
-				// A binding like `lalt-ralt-h` implies two distinct modifier keys are involved (left option, right option).
-				let bindingEffectiveModifierCount =
-					binding.exactModifiers.count
-					+ binding.genericModifiers.count
-				// This count must be validated by the parser: e.g. `alt-lalt-h` is invalid.
-				// If parser is correct, `binding.exactModifiers` and `binding.genericModifiers` don't specify the same base modifier type.
+                // More precise count: total number of active physical keys must match what the binding implies.
+                // A binding like `alt-shift-h` implies two distinct modifier keys are involved (one option, one shift).
+                // A binding like `lalt-ralt-h` implies two distinct modifier keys are involved (left option, right option).
+                let bindingEffectiveModifierCount =
+                    binding.exactModifiers.count
+                        + binding.genericModifiers.count
+                // This count must be validated by the parser: e.g. `alt-lalt-h` is invalid.
+                // If parser is correct, `binding.exactModifiers` and `binding.genericModifiers` don't specify the same base modifier type.
 
-				if currentPhysicalKeys.count == bindingEffectiveModifierCount {
-					// If all above checks pass, it's a match.
-					print(
-						"INFO: Hotkey matched: \(binding.descriptionWithKeyNotation)"
-					)
-					Task {
-						try await runSession(
-							.hotkeyBinding, .checkServerIsEnabledOrDie
-						) { () throws in
-							_ = try await binding.commands.runCmdSeq(
-								.defaultEnv, .emptyStdin)
-						}
-					}
-					return true  // Consume event
-				}
-			}
-		}
-		return false
-	}
+                if currentPhysicalKeys.count == bindingEffectiveModifierCount {
+                    // If all above checks pass, it's a match.
+                    print(
+                        "INFO: Hotkey matched: \(binding.descriptionWithKeyNotation)"
+                    )
+                    Task {
+                        try await runSession(
+                            .hotkeyBinding, .checkServerIsEnabledOrDie
+                        ) { () throws in
+                            _ = try await binding.commands.runCmdSeq(
+                                .defaultEnv, .emptyStdin)
+                        }
+                    }
+                    return true  // Consume event
+                }
+            }
+        }
+        return false
+    }
 }
 
 // Helper extension for PhysicalModifierKey to get its generic type (if any)
 // This should ideally be in keysMap.swift or a shared location if GenericModifierType is there.
 // For now, adding it here for GlobalHotkeyMonitor's use.
-extension PhysicalModifierKey {
-	fileprivate var genericType: GenericModifierType? {
-		switch self {
-		case .leftOption, .rightOption: return .option
-		case .leftCommand, .rightCommand: return .command
-		case .leftControl, .rightControl: return .control
-		case .leftShift, .rightShift: return .shift
-		case .function: return nil  // Fn is always specific
-		}
-	}
+private extension PhysicalModifierKey {
+    var genericType: GenericModifierType? {
+        switch self {
+            case .leftOption, .rightOption: return .option
+            case .leftCommand, .rightCommand: return .command
+            case .leftControl, .rightControl: return .control
+            case .leftShift, .rightShift: return .shift
+            case .function: return nil  // Fn is always specific
+        }
+    }
 }

--- a/Sources/AppBundle/GlobalHotkeyMonitor.swift
+++ b/Sources/AppBundle/GlobalHotkeyMonitor.swift
@@ -1,329 +1,314 @@
 import AppKit  // For NSEvent, CGEvent
 import Common  // For Config, Command, etc.
 
-@MainActor  // Class is MainActor isolated
 class GlobalHotkeyMonitor {
-    private var eventTap: CFMachPort?
-    private var runLoopSource: CFRunLoopSource?
-    private let lock = NSLock()  // Lock for protecting pressedModifierKeyCodes
+	private var eventTap: CFMachPort?
+	private var runLoopSource: CFRunLoopSource?
+	private let stateLock = NSLock()  // Lock for protecting shared state
 
-    // State to track pressed keys
-    // Using UInt16 for virtual key codes
-    private var pressedModifierKeyCodes: Set<UInt16> = []
-    // Optional: could also track all pressed keys if complex multi-non-modifier chords were needed
-    // private var pressedKeyCodes: Set<UInt16> = []
+	// State to track pressed keys, accessed with stateLock
+	private var pressedModifierKeyCodes: Set<UInt16> = []
+	// Optional: could also track all pressed keys if complex multi-non-modifier chords were needed
+	// private var pressedKeyCodes: Set<UInt16> = []
 
-    // For optimized hotkey lookup
-    private var bindingsByKeyCode: [UInt16: [HotkeyBinding]] = [:]
-    private var lastKnownModeName: String?  // To track when to rebuild bindingsByKeyCode
+	// For optimized hotkey lookup, accessed with stateLock
+	private var bindingsByKeyCode: [UInt16: [HotkeyBinding]] = [:]
+	private var lastKnownModeName: String?  // Updated by updateBindingsCache, accessed with stateLock
 
-    // The mechanism is to read from global `config` and `activeMode`
-    // For now, assuming access to 'config' and 'activeMode' (defined in HotkeyBinding.swift context)
+	// Static shared instance
+	@MainActor static let shared = GlobalHotkeyMonitor()
 
-    init() {
-        // Initialization if needed
-    }
+	private init() {
+		// Initialization if needed
+	}
 
-    func start() {
-        guard eventTap == nil else {
-            print("WARN: GlobalHotkeyMonitor already started.")
-            return
-        }
+	@MainActor  // Added @MainActor
+	func updateBindingsCache() {
+		// This function runs on the MainActor, so it can safely access global activeMode and config.
+		guard let currentGlobalActiveModeName = activeMode,
+			let modeConfig = config.modes[currentGlobalActiveModeName]
+		else {
+			// If no active mode or mode config, clear local bindings
+			stateLock.lock()
+			self.bindingsByKeyCode.removeAll()
+			self.lastKnownModeName = nil
+			stateLock.unlock()
+			print(
+				"INFO: GlobalHotkeyMonitor cleared bindings cache due to no active mode/config."
+			)
+			return
+		}
 
-        // The types of events we want to tap.
-        // We need keyDown and keyUp to track all key states, including modifiers.
-        // flagsChanged can be supplementary or primary for modifiers if direct key up/down for them is noisy or problematic.
-        // Let's start with keyDown and keyUp.
-        let eventsToTap: CGEventMask =
-            (1 << CGEventType.keyDown.rawValue) | (1 << CGEventType.keyUp.rawValue)
-                | (1 << CGEventType.flagsChanged.rawValue)
+		stateLock.lock()
+		if self.lastKnownModeName != currentGlobalActiveModeName
+			|| (self.bindingsByKeyCode.isEmpty && !modeConfig.bindings.isEmpty)
+		{
+			print(
+				"INFO: GlobalHotkeyMonitor rebuilding bindings cache for mode: \(currentGlobalActiveModeName)."
+			)
+			self.bindingsByKeyCode.removeAll()
+			for (_, binding) in modeConfig.bindings {
+				self.bindingsByKeyCode[binding.keyCode, default: []].append(binding)
+			}
+			self.lastKnownModeName = currentGlobalActiveModeName
+		}
+		stateLock.unlock()
+	}
 
-        // Create the event tap.
-        // '.cghidEventTap' is a common choice for system-wide hardware events.
-        guard
-            let tap = CGEvent.tapCreate(
-                tap: .cgSessionEventTap,  // Tap into the session event stream. Others: .cgHIDEventTap, .cgAnnotatedSessionEventTap
-                place: .headInsertEventTap,  // Insert at the head of the event tap list
-                options: .defaultTap,  // Default options
-                eventsOfInterest: eventsToTap,
-                callback: { proxy, type, event, refcon -> Unmanaged<CGEvent>? in
-                    // 'refcon' is the UnsafeMutableRawPointer to 'self'
-                    guard let refcon else {
-                        return Unmanaged.passUnretained(event)
-                    }
-                    let monitor = Unmanaged<GlobalHotkeyMonitor>.fromOpaque(
-                        refcon
-                    ).takeUnretainedValue()
-                    return monitor.handleEvent_Outer(
-                        proxy: proxy, type: type, event: event)
-                },
-                userInfo: Unmanaged.passUnretained(self).toOpaque()  // Pass 'self' to the callback
-            )
-        else {
-            printStderr(
-                "ERROR: Failed to create event tap. This usually means AeroSpace requires Accessibility permissions. "
-                    + "Please go to System Settings > Privacy & Security > Accessibility, and ensure AeroSpace is enabled. "
-                    + "You may need to restart AeroSpace after granting permissions."
-            )
-            // TODO: Better error handling - inform user, guide to permissions.
-            // Consider showing a user-facing alert if possible from this context,
-            // or setting a flag that the UI can pick up to show an alert.
-            // Example to open settings (use with caution, might need main thread if called from background):
-            // NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!)
-            return
-        }
+	@MainActor  // Added @MainActor
+	func start() {
+		guard eventTap == nil else {
+			print("WARN: GlobalHotkeyMonitor already started.")
+			return
+		}
 
-        // Create a run loop source and add it to the current run loop.
-        guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
-            printStderr("ERROR: Failed to create run loop source for event tap.")
-            return
-        }
+		// Initial population of bindings cache
+		updateBindingsCache()
 
-        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
-        CGEvent.tapEnable(tap: tap, enable: true)
+		// The types of events we want to tap.
+		// We need keyDown and keyUp to track all key states, including modifiers.
+		// flagsChanged can be supplementary or primary for modifiers if direct key up/down for them is noisy or problematic.
+		// Let's start with keyDown and keyUp.
+		let eventsToTap: CGEventMask =
+			(1 << CGEventType.keyDown.rawValue) | (1 << CGEventType.keyUp.rawValue)
+			| (1 << CGEventType.flagsChanged.rawValue)
 
-        self.eventTap = tap
-        self.runLoopSource = source
+		// Create the event tap.
+		// '.cghidEventTap' is a common choice for system-wide hardware events.
+		guard
+			let tap = CGEvent.tapCreate(
+				tap: .cgSessionEventTap,  // Tap into the session event stream. Others: .cgHIDEventTap, .cgAnnotatedSessionEventTap
+				place: .headInsertEventTap,  // Insert at the head of the event tap list
+				options: .defaultTap,  // Default options
+				eventsOfInterest: eventsToTap,
+				callback: { proxy, type, event, refcon -> Unmanaged<CGEvent>? in
+					// 'refcon' is the UnsafeMutableRawPointer to 'self'
+					guard let refcon else {
+						return Unmanaged.passUnretained(event)
+					}
+					let monitor = Unmanaged<GlobalHotkeyMonitor>.fromOpaque(
+						refcon
+					).takeUnretainedValue()
+					return monitor.handleEvent_Outer(
+						proxy: proxy, type: type, event: event)
+				},
+				userInfo: Unmanaged.passUnretained(self).toOpaque()  // Pass 'self' to the callback
+			)
+		else {
+			printStderr(
+				"ERROR: Failed to create event tap. This usually means AeroSpace requires Accessibility permissions. "
+					+ "Please go to System Settings > Privacy & Security > Accessibility, and ensure AeroSpace is enabled. "
+					+ "You may need to restart AeroSpace after granting permissions."
+			)
+			return
+		}
 
-        print("INFO: GlobalHotkeyMonitor started.")
-    }
+		// Create a run loop source and add it to the current run loop.
+		guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
+			printStderr("ERROR: Failed to create run loop source for event tap.")
+			return
+		}
 
-    @MainActor
-    func stop() {
-        if let tap = eventTap {
-            CGEvent.tapEnable(tap: tap, enable: false)  // Disable event delivery
+		CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+		CGEvent.tapEnable(tap: tap, enable: true)
 
-            // Invalidate the Mach port. This also removes its run loop sources.
-            // One call is sufficient.
-            CFMachPortInvalidate(tap)
+		self.eventTap = tap
+		self.runLoopSource = source
 
-            // Explicitly removing the source after invalidation is generally not needed
-            // as CFMachPortInvalidate should handle it. However, it's kept for now.
-            if let source = runLoopSource {
-                CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
-            }
+		print("INFO: GlobalHotkeyMonitor started.")
+	}
 
-            // ARC will handle the release of 'tap' and 'source' when these are set to nil.
-            self.runLoopSource = nil
-            self.eventTap = nil
-            print("INFO: GlobalHotkeyMonitor stopped.")
-        }
-        lock.lock()
-        pressedModifierKeyCodes.removeAll()
-        lock.unlock()
+	@MainActor  // Added @MainActor
+	func stop() {
+		if let tap = eventTap {
+			CGEvent.tapEnable(tap: tap, enable: false)  // Disable event delivery
 
-        // Clear optimized lookup cache
-        bindingsByKeyCode.removeAll()
-        lastKnownModeName = nil
-    }
+			// Invalidate the Mach port. This also removes its run loop sources.
+			// One call is sufficient.
+			CFMachPortInvalidate(tap)
 
-    // Entry point from C callback. Runs on event tap thread.
-    private nonisolated func handleEvent_Outer(
-        proxy: CGEventTapProxy, type cgEventType: CGEventType, event: CGEvent
-    ) -> Unmanaged<CGEvent>? {
-        var consumed = false
+			// Explicitly removing the source after invalidation is generally not needed
+			// as CFMachPortInvalidate should handle it. However, it's kept for now.
+			if let source = runLoopSource {
+				CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+			}
 
-        let keyCode = UInt16(event.getIntegerValueField(.keyboardEventKeycode))
-        let flags = event.flags  // CGEventFlags is Sendable (UInt64)
-        // CGEventType is Sendable (UInt32 wrapper)
+			// ARC will handle the release of 'tap' and 'source' when these are set to nil.
+			self.runLoopSource = nil
+			self.eventTap = nil
+			print("INFO: GlobalHotkeyMonitor stopped.")
+		}
+		stateLock.lock()  // Use lock
+		pressedModifierKeyCodes.removeAll()
+		// Clear optimized lookup cache
+		bindingsByKeyCode.removeAll()
+		lastKnownModeName = nil
+		stateLock.unlock()  // Use lock
+	}
 
-        DispatchQueue.main.sync {
-            // Pass only Sendable data to the main actor context
-            consumed = self._handleEvent_CoreLogic(
-                keyCode: keyCode, cgEventType: cgEventType, flags: flags)
-        }
-        // The original `event` is only used here to be returned if not consumed.
-        // It's not captured in the main actor closure in a way that causes data races for its content.
-        return consumed ? nil : Unmanaged.passUnretained(event)
-    }
+	// Entry point from C callback. Runs on event tap thread.
+	private nonisolated func handleEvent_Outer(
+		proxy: CGEventTapProxy, type cgEventType: CGEventType, event: CGEvent
+	) -> Unmanaged<CGEvent>? {
+		let keyCode = UInt16(event.getIntegerValueField(.keyboardEventKeycode))
+		let flags = event.flags
+		var consumed = false
 
-    // Core logic, runs on MainActor.
-    private func _handleEvent_CoreLogic(
-        keyCode: UInt16, cgEventType: CGEventType, flags: CGEventFlags
-    ) -> Bool {
-        switch cgEventType {
-            case .keyDown:
-                if isModifierKeyCode(keyCode) {
-                    pressedModifierKeyCodes.insert(keyCode)
-                } else {
-                    if checkForHotkeyMatch(nonModifierKeyCode: keyCode) {  // Pass only keyCode
-                        return true  // Consumed
-                    }
-                }
-            case .keyUp:
-                lock.lock()
-                if isModifierKeyCode(keyCode) {
-                    pressedModifierKeyCodes.remove(keyCode)
-                }
-                lock.unlock()
-            // Optionally handle keyUp for non-modifiers if needed for specific command types
-            case .flagsChanged:
-                // The keyCode in a flagsChanged event is the specific modifier key that changed.
-                let changedModifierKeyCode = keyCode
-                let newFlagsState = flags
+		switch cgEventType {
+		case .keyDown:
+			stateLock.lock()
+			if isModifierKeyCode_Raw(keyCode) {  // Use a raw checker that doesn't need self if possible, or call it on self.
+				pressedModifierKeyCodes.insert(keyCode)
+				stateLock.unlock()
+			} else {
+				stateLock.unlock()  // Unlock before calling potentially complex logic
+				if findAndExecuteHotkeyMatch_TapThread(nonModifierKeyCode: keyCode)
+				{
+					consumed = true
+				}
+			}
+		case .keyUp:
+			stateLock.lock()
+			if isModifierKeyCode_Raw(keyCode) {
+				pressedModifierKeyCodes.remove(keyCode)
+			}
+			stateLock.unlock()
+		case .flagsChanged:
+			stateLock.lock()
+			let changedModifierKeyCode = keyCode
+			// Determine if the specific modifier key that changed is now pressed or released.
+			guard
+				let physicalKey = physicalModifierKeyToKeyCode.first(where: {
+					$0.value == changedModifierKeyCode
+				})?.key
+			else {
+				print(
+					"WARN: flagsChanged event for unknown modifier keyCode: \(changedModifierKeyCode) (raw flags: \(flags))"
+				)
+				stateLock.unlock()
+				break
+			}
 
-                // Determine if the specific modifier key that changed is now pressed or released.
-                // This requires knowing which generic flag corresponds to the specific modifier key code.
-                guard
-                    let physicalKey = physicalModifierKeyToKeyCode.first(where: {
-                        $0.value == changedModifierKeyCode
-                    })?.key
-                else {
-                    // Unknown modifier key code that caused flagsChanged, should not happen if our maps are complete.
-                    print(
-                        "WARN: flagsChanged event for unknown modifier keyCode: \(changedModifierKeyCode)"
-                    )
-                    break
-                }
+			var modifierIsPressed = false
+			switch physicalKey {
+			case .leftOption, .rightOption:
+				modifierIsPressed = flags.contains(.maskAlternate)
+			case .leftCommand, .rightCommand:
+				modifierIsPressed = flags.contains(.maskCommand)
+			case .leftShift, .rightShift: modifierIsPressed = flags.contains(.maskShift)
+			case .leftControl, .rightControl:
+				modifierIsPressed = flags.contains(.maskControl)
+			case .function: modifierIsPressed = flags.contains(.maskSecondaryFn)
+			}
 
-                var modifierIsPressed = false
-                switch physicalKey {
-                    case .leftOption, .rightOption:
-                        modifierIsPressed = newFlagsState.contains(.maskAlternate)
-                    case .leftCommand, .rightCommand:
-                        modifierIsPressed = newFlagsState.contains(.maskCommand)
-                    case .leftShift, .rightShift:
-                        modifierIsPressed = newFlagsState.contains(.maskShift)
-                    case .leftControl, .rightControl:
-                        modifierIsPressed = newFlagsState.contains(.maskControl)
-                    case .function:
-                        modifierIsPressed = newFlagsState.contains(.maskSecondaryFn)
-                }
+			if modifierIsPressed {
+				pressedModifierKeyCodes.insert(changedModifierKeyCode)
+			} else {
+				pressedModifierKeyCodes.remove(changedModifierKeyCode)
+			}
+			stateLock.unlock()
+		default:
+			break
+		}
+		return consumed ? nil : Unmanaged.passUnretained(event)
+	}
 
-                lock.lock()
-                if modifierIsPressed {
-                    pressedModifierKeyCodes.insert(changedModifierKeyCode)
-                } else {
-                    pressedModifierKeyCodes.remove(changedModifierKeyCode)
-                }
-                lock.unlock()
-		// print("DEBUG: FlagsChanged: \(physicalKey) (kc: \(changedModifierKeyCode)) is now \(modifierIsPressed ? "pressed" : "released"). Current pressed: \(pressedModifierKeyCodes)")
+	// This function will be called from the tap thread (nonisolated context)
+	// It needs to handle its own synchronization for shared state.
+	private func findAndExecuteHotkeyMatch_TapThread(nonModifierKeyCode: UInt16) -> Bool {
+		stateLock.lock()  // Lock at the beginning
 
-            default:
-                break
-        }
-        return false  // Not consumed
-    }
+		// bindingsByKeyCode and lastKnownModeName are now populated by updateBindingsCache()
+		// No need to check activeMode or config directly here.
+		// The cache (self.bindingsByKeyCode) is assumed to be up-to-date for the current mode.
 
-    private func isModifierKeyCode(_ keyCode: UInt16) -> Bool {
-        physicalModifierKeyToKeyCode.values.contains(keyCode)
-    }
+		guard let candidateBindings = self.bindingsByKeyCode[nonModifierKeyCode],
+			!candidateBindings.isEmpty
+		else {
+			stateLock.unlock()
+			return false
+		}
 
-    private func checkForHotkeyMatch(nonModifierKeyCode: UInt16) -> Bool {
-        guard let currentActiveModeName = activeMode,
-              let modeConfig = config.modes[currentActiveModeName]
-        else { return false }
-        if lastKnownModeName != currentActiveModeName
-            || (bindingsByKeyCode.isEmpty && !modeConfig.bindings.isEmpty)
-        {
-            bindingsByKeyCode.removeAll()
-            for (_, binding) in modeConfig.bindings {
-                bindingsByKeyCode[binding.keyCode, default: []].append(binding)
-            }
-            lastKnownModeName = currentActiveModeName
-        }
+		let localPressedModifierKeyCodes = self.pressedModifierKeyCodes  // Copy while holding lock
 
-        guard let candidateBindings = bindingsByKeyCode[nonModifierKeyCode],
-              !candidateBindings.isEmpty
-        else {
-            return false  // No bindings for this specific non-modifier key
-        }
+		var currentPhysicalKeys = Set<PhysicalModifierKey>()
+		var activeGenericTypes = Set<GenericModifierType>()
 
-        // 1. Determine current state of pressed modifiers
-        var currentPhysicalKeys = Set<PhysicalModifierKey>()
-        var activeGenericTypes = Set<GenericModifierType>()
+		// Unlock *after* copying shared data needed for matching, but *before* iterating if possible,
+		// or keep lock if iteration logic is simple and doesn't call out.
+		// For now, keep lock for simplicity during matching as well, as it involves reading config too.
 
-        lock.lock()
-        let localPressedModifierKeyCodes = self.pressedModifierKeyCodes
-        for pressedKc in localPressedModifierKeyCodes {
-            if let physicalKey = physicalModifierKeyToKeyCode.first(where: {
-                $0.value == pressedKc
-            })?.key {
-                currentPhysicalKeys.insert(physicalKey)
-                // Determine generic type from physical key
-                switch physicalKey {
-                    case .leftOption, .rightOption: activeGenericTypes.insert(.option)
-                    case .leftCommand, .rightCommand:
-                        activeGenericTypes.insert(.command)
-                    case .leftControl, .rightControl:
-                        activeGenericTypes.insert(.control)
-                    case .leftShift, .rightShift: activeGenericTypes.insert(.shift)
-                    case .function: break  // `fn` doesn't have a generic counterpart in GenericModifierType
-                }
-            }
-        }
-        lock.unlock()
+		for pressedKc in localPressedModifierKeyCodes {
+			if let physicalKey = physicalModifierKeyToKeyCode.first(where: {
+				$0.value == pressedKc
+			})?.key {
+				currentPhysicalKeys.insert(physicalKey)
+				if let genericType = physicalKey.genericType {  // Using the extension method
+					activeGenericTypes.insert(genericType)
+				}
+			}
+		}
+		// At this point, localPressedModifierKeyCodes, currentPhysicalKeys, activeGenericTypes are derived.
+		// The candidateBindings are also from shared state (bindingsByKeyCode).
 
-        // Iterate only over bindings that match the nonModifierKeyCode
-        for binding in candidateBindings {
-            // Perform matching based on exact and generic modifiers
+		// Iterate only over bindings that match the nonModifierKeyCode
+		for binding in candidateBindings {  // candidateBindings was derived from shared state under lock
+			guard binding.exactModifiers.isSubset(of: currentPhysicalKeys) else {
+				continue
+			}
 
-            // Rule A: All exact modifiers in the binding must be currently pressed
-            guard binding.exactModifiers.isSubset(of: currentPhysicalKeys)
-            else {
-                continue  // Next binding
-            }
+			var genericMatch = true
+			for genModType in binding.genericModifiers {
+				if !activeGenericTypes.contains(genModType) {
+					genericMatch = false
+					break
+				}
+			}
+			guard genericMatch else { continue }
 
-            // Rule B: All generic modifiers in the binding must be currently active
-            // AND ensure that if a generic is specified, no specific of that type is in exactModifiers (parser should prevent this, but good for safety)
-            var genericMatch = true
-            for genModType in binding.genericModifiers {
-                if !activeGenericTypes.contains(genModType) {
-                    genericMatch = false
-                    break
-                }
-                // Parser validation should ensure exactModifiers doesn't contain specifics if generic is used for same type.
-                // e.g. if binding.genericModifiers has .option, binding.exactModifiers shouldn't have .leftOption
-            }
-            guard genericMatch else {
-                continue  // Next binding
-            }
+			let bindingEffectiveModifierCount =
+				binding.exactModifiers.count + binding.genericModifiers.count
+			if currentPhysicalKeys.count == bindingEffectiveModifierCount {
+				// Match found!
+				stateLock.unlock()  // Unlock before dispatching to main actor
 
-            // Rule C: Count check - the number of distinct physical modifiers pressed must match the number intended by the binding.
-            // Number of modifiers intended by binding:
-            // This assumes parser enforces that exactModifiers and genericModifiers are for distinct modifier *types*.
-            // e.g., can't have exact lalt AND generic alt. Only one defines the 'option' type part of the binding.
+				print("INFO: Hotkey matched: \(binding.descriptionWithKeyNotation)")
+				DispatchQueue.main.async {  // Dispatch command execution to main actor
+					Task {  // Task on MainActor to run async commands
+						try await runSession(
+							.hotkeyBinding, .checkServerIsEnabledOrDie
+						) { () throws in
+							_ = try await binding.commands.runCmdSeq(
+								.defaultEnv, .emptyStdin)
+						}
+					}
+				}
+				return true  // Consume event
+			}
+		}
 
-            // More precise count: total number of active physical keys must match what the binding implies.
-            // A binding like `alt-shift-h` implies two distinct modifier keys are involved (one option, one shift).
-            // A binding like `lalt-ralt-h` implies two distinct modifier keys are involved (left option, right option).
-            let bindingEffectiveModifierCount =
-                binding.exactModifiers.count
-                    + binding.genericModifiers.count
-            // This count must be validated by the parser: e.g. `alt-lalt-h` is invalid.
-            // If parser is correct, `binding.exactModifiers` and `binding.genericModifiers` don't specify the same base modifier type.
+		stateLock.unlock()  // Ensure unlock if no match found
+		return false
+	}
 
-            if currentPhysicalKeys.count == bindingEffectiveModifierCount {
-                // If all above checks pass, it's a match.
-                print(
-                    "INFO: Hotkey matched: \(binding.descriptionWithKeyNotation)"
-                )
-                Task {
-                    try await runSession(
-                        .hotkeyBinding, .checkServerIsEnabledOrDie
-                    ) { () throws in
-                        _ = try await binding.commands.runCmdSeq(
-                            .defaultEnv, .emptyStdin)
-                    }
-                }
-                return true  // Consume event
-            }
-        }
-        return false
-    }
+	// Helper function to check if a keycode is a modifier. Can be called with lock held or not, doesn't modify state.
+	// Renamed from isModifierKeyCode to avoid confusion with any potential @MainActor version.
+	private func isModifierKeyCode_Raw(_ keyCode: UInt16) -> Bool {
+		physicalModifierKeyToKeyCode.values.contains(keyCode)
+	}
 }
 
 // Helper extension for PhysicalModifierKey to get its generic type (if any)
 // This should ideally be in keysMap.swift or a shared location if GenericModifierType is there.
 // For now, adding it here for GlobalHotkeyMonitor's use.
-private extension PhysicalModifierKey {
-    var genericType: GenericModifierType? {
-        switch self {
-            case .leftOption, .rightOption: return .option
-            case .leftCommand, .rightCommand: return .command
-            case .leftControl, .rightControl: return .control
-            case .leftShift, .rightShift: return .shift
-            case .function: return nil  // Fn is always specific
-        }
-    }
+extension PhysicalModifierKey {
+	fileprivate var genericType: GenericModifierType? {
+		switch self {
+		case .leftOption, .rightOption: return .option
+		case .leftCommand, .rightCommand: return .command
+		case .leftControl, .rightControl: return .control
+		case .leftShift, .rightShift: return .shift
+		case .function: return nil  // Fn is always specific
+		}
+	}
 }

--- a/Sources/AppBundle/GlobalHotkeyMonitor.swift
+++ b/Sources/AppBundle/GlobalHotkeyMonitor.swift
@@ -5,275 +5,275 @@ import Common  // For Config, Command, etc.
 
 @MainActor
 class GlobalHotkeyMonitor {
-    private var eventTap: CFMachPort?
-    private var runLoopSource: CFRunLoopSource?
+	private var eventTap: CFMachPort?
+	private var runLoopSource: CFRunLoopSource?
 
-    // State to track pressed keys
-    // Using UInt16 for virtual key codes
-    private var pressedModifierKeyCodes: Set<UInt16> = []
-    // Optional: could also track all pressed keys if complex multi-non-modifier chords were needed
-    // private var pressedKeyCodes: Set<UInt16> = []
+	// State to track pressed keys
+	// Using UInt16 for virtual key codes
+	private var pressedModifierKeyCodes: Set<UInt16> = []
+	// Optional: could also track all pressed keys if complex multi-non-modifier chords were needed
+	// private var pressedKeyCodes: Set<UInt16> = []
 
-    // The mechanism is to read from global `config` and `activeMode`
-    // For now, assuming access to 'config' and 'activeMode' (defined in HotkeyBinding.swift context)
+	// The mechanism is to read from global `config` and `activeMode`
+	// For now, assuming access to 'config' and 'activeMode' (defined in HotkeyBinding.swift context)
 
-    init() {
-        // Initialization if needed
-    }
+	init() {
+		// Initialization if needed
+	}
 
-    func start() {
-        guard eventTap == nil else {
-            print("WARN: GlobalHotkeyMonitor already started.")
-            return
-        }
+	func start() {
+		guard eventTap == nil else {
+			print("WARN: GlobalHotkeyMonitor already started.")
+			return
+		}
 
-        // The types of events we want to tap.
-        // We need keyDown and keyUp to track all key states, including modifiers.
-        // flagsChanged can be supplementary or primary for modifiers if direct key up/down for them is noisy or problematic.
-        // Let's start with keyDown and keyUp.
-        let eventsToTap: CGEventMask =
-            (1 << CGEventType.keyDown.rawValue) | (1 << CGEventType.keyUp.rawValue)
-                | (1 << CGEventType.flagsChanged.rawValue)
+		// The types of events we want to tap.
+		// We need keyDown and keyUp to track all key states, including modifiers.
+		// flagsChanged can be supplementary or primary for modifiers if direct key up/down for them is noisy or problematic.
+		// Let's start with keyDown and keyUp.
+		let eventsToTap: CGEventMask =
+			(1 << CGEventType.keyDown.rawValue) | (1 << CGEventType.keyUp.rawValue)
+			| (1 << CGEventType.flagsChanged.rawValue)
 
-        // Create the event tap.
-        // '.cghidEventTap' is a common choice for system-wide hardware events.
-        guard
-            let tap = CGEvent.tapCreate(
-                tap: .cgSessionEventTap,  // Tap into the session event stream. Others: .cgHIDEventTap, .cgAnnotatedSessionEventTap
-                place: .headInsertEventTap,  // Insert at the head of the event tap list
-                options: .defaultTap,  // Default options
-                eventsOfInterest: eventsToTap,
-                callback: { proxy, type, event, refcon -> Unmanaged<CGEvent>? in
-                    // 'refcon' is the UnsafeMutableRawPointer to 'self'
-                    guard let refcon else {
-                        return Unmanaged.passUnretained(event)
-                    }
-                    let monitor = Unmanaged<GlobalHotkeyMonitor>.fromOpaque(
-                        refcon
-                    ).takeUnretainedValue()
-                    return monitor.handleEvent(
-                        proxy: proxy, type: type, event: event)
-                },
-                userInfo: Unmanaged.passUnretained(self).toOpaque()  // Pass 'self' to the callback
-            )
-        else {
-            printStderr(
-                "ERROR: Failed to create event tap. This usually means AeroSpace requires Accessibility permissions. "
-                    + "Please go to System Settings > Privacy & Security > Accessibility, and ensure AeroSpace is enabled. "
-                    + "You may need to restart AeroSpace after granting permissions."
-            )
-            // TODO: Better error handling - inform user, guide to permissions.
-            // Consider showing a user-facing alert if possible from this context,
-            // or setting a flag that the UI can pick up to show an alert.
-            // Example to open settings (use with caution, might need main thread if called from background):
-            // NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!)
-            return
-        }
+		// Create the event tap.
+		// '.cghidEventTap' is a common choice for system-wide hardware events.
+		guard
+			let tap = CGEvent.tapCreate(
+				tap: .cgSessionEventTap,  // Tap into the session event stream. Others: .cgHIDEventTap, .cgAnnotatedSessionEventTap
+				place: .headInsertEventTap,  // Insert at the head of the event tap list
+				options: .defaultTap,  // Default options
+				eventsOfInterest: eventsToTap,
+				callback: { proxy, type, event, refcon -> Unmanaged<CGEvent>? in
+					// 'refcon' is the UnsafeMutableRawPointer to 'self'
+					guard let refcon else {
+						return Unmanaged.passUnretained(event)
+					}
+					let monitor = Unmanaged<GlobalHotkeyMonitor>.fromOpaque(
+						refcon
+					).takeUnretainedValue()
+					return monitor.handleEvent(
+						proxy: proxy, type: type, event: event)
+				},
+				userInfo: Unmanaged.passUnretained(self).toOpaque()  // Pass 'self' to the callback
+			)
+		else {
+			printStderr(
+				"ERROR: Failed to create event tap. This usually means AeroSpace requires Accessibility permissions. "
+					+ "Please go to System Settings > Privacy & Security > Accessibility, and ensure AeroSpace is enabled. "
+					+ "You may need to restart AeroSpace after granting permissions."
+			)
+			// TODO: Better error handling - inform user, guide to permissions.
+			// Consider showing a user-facing alert if possible from this context,
+			// or setting a flag that the UI can pick up to show an alert.
+			// Example to open settings (use with caution, might need main thread if called from background):
+			// NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!)
+			return
+		}
 
-        // Create a run loop source and add it to the current run loop.
-        guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
-            printStderr("ERROR: Failed to create run loop source for event tap.")
-            return
-        }
+		// Create a run loop source and add it to the current run loop.
+		guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
+			printStderr("ERROR: Failed to create run loop source for event tap.")
+			return
+		}
 
-        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
-        CGEvent.tapEnable(tap: tap, enable: true)
+		CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+		CGEvent.tapEnable(tap: tap, enable: true)
 
-        self.eventTap = tap
-        self.runLoopSource = source
+		self.eventTap = tap
+		self.runLoopSource = source
 
-        print("INFO: GlobalHotkeyMonitor started.")
-    }
+		print("INFO: GlobalHotkeyMonitor started.")
+	}
 
-    func stop() {
-        if let tap = eventTap {
-            CGEvent.tapEnable(tap: tap, enable: false)
-            // CFMachPortInvalidate(tap) // Invalidating the port also removes the run loop source.
-            // However, it's often better to remove the source explicitly.
-            if let source = runLoopSource {
-                CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
-            }
-            // CFRelease(tap) // tap is a CFMachPort, managed by ARC when interacting with Swift types like CFMachPort?
-            // If directly using CFTypeRef, manual CFRelease would be needed.
-            // Swift handles this for optional CF types.
-            self.runLoopSource = nil
-            self.eventTap = nil
-            print("INFO: GlobalHotkeyMonitor stopped.")
-        }
-        pressedModifierKeyCodes.removeAll()
-    }
+	func stop() {
+		if let tap = eventTap {
+			CGEvent.tapEnable(tap: tap, enable: false)
+			// CFMachPortInvalidate(tap) // Invalidating the port also removes the run loop source.
+			// However, it's often better to remove the source explicitly.
+			if let source = runLoopSource {
+				CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+			}
+			// CFRelease(tap) // tap is a CFMachPort, managed by ARC when interacting with Swift types like CFMachPort?
+			// If directly using CFTypeRef, manual CFRelease would be needed.
+			// Swift handles this for optional CF types.
+			self.runLoopSource = nil
+			self.eventTap = nil
+			print("INFO: GlobalHotkeyMonitor stopped.")
+		}
+		pressedModifierKeyCodes.removeAll()
+	}
 
-    private func handleEvent(proxy: CGEventTapProxy, type: CGEventType, event: CGEvent)
-        -> Unmanaged<CGEvent>?
-    {
-        let keyCode = UInt16(event.getIntegerValueField(.keyboardEventKeycode))
+	private func handleEvent(proxy: CGEventTapProxy, type: CGEventType, event: CGEvent)
+		-> Unmanaged<CGEvent>?
+	{
+		let keyCode = UInt16(event.getIntegerValueField(.keyboardEventKeycode))
 
-        switch type {
-            case .keyDown:
-                if isModifierKeyCode(keyCode) {
-                    pressedModifierKeyCodes.insert(keyCode)
-                } else {
-                    if checkForHotkeyMatch(nonModifierKeyCode: keyCode, event: event) {
-                        return nil
-                    }
-                }
-            case .keyUp:
-                if isModifierKeyCode(keyCode) {
-                    pressedModifierKeyCodes.remove(keyCode)
-                } else {
-                    // Optionally handle keyUp for non-modifiers if needed for specific command types
-                }
-            case .flagsChanged:
-                // The keyCode in a flagsChanged event is the specific modifier key that changed.
-                let changedModifierKeyCode = keyCode
-                let newFlagsState = event.flags
+		switch type {
+		case .keyDown:
+			if isModifierKeyCode(keyCode) {
+				pressedModifierKeyCodes.insert(keyCode)
+			} else {
+				if checkForHotkeyMatch(nonModifierKeyCode: keyCode, event: event) {
+					return nil
+				}
+			}
+		case .keyUp:
+			if isModifierKeyCode(keyCode) {
+				pressedModifierKeyCodes.remove(keyCode)
+			} else {
+				// Optionally handle keyUp for non-modifiers if needed for specific command types
+			}
+		case .flagsChanged:
+			// The keyCode in a flagsChanged event is the specific modifier key that changed.
+			let changedModifierKeyCode = keyCode
+			let newFlagsState = event.flags
 
-                // Determine if the specific modifier key that changed is now pressed or released.
-                // This requires knowing which generic flag corresponds to the specific modifier key code.
-                guard
-                    let physicalKey = physicalModifierKeyToKeyCode.first(where: {
-                        $0.value == changedModifierKeyCode
-                    })?.key
-                else {
-                    // Unknown modifier key code that caused flagsChanged, should not happen if our maps are complete.
-                    print(
-                        "WARN: flagsChanged event for unknown modifier keyCode: \(changedModifierKeyCode)"
-                    )
-                    break
-                }
+			// Determine if the specific modifier key that changed is now pressed or released.
+			// This requires knowing which generic flag corresponds to the specific modifier key code.
+			guard
+				let physicalKey = physicalModifierKeyToKeyCode.first(where: {
+					$0.value == changedModifierKeyCode
+				})?.key
+			else {
+				// Unknown modifier key code that caused flagsChanged, should not happen if our maps are complete.
+				print(
+					"WARN: flagsChanged event for unknown modifier keyCode: \(changedModifierKeyCode)"
+				)
+				break
+			}
 
-                var modifierIsPressed = false
-                switch physicalKey {
-                    case .leftOption, .rightOption:
-                        modifierIsPressed = newFlagsState.contains(.maskAlternate)
-                    case .leftCommand, .rightCommand:
-                        modifierIsPressed = newFlagsState.contains(.maskCommand)
-                    case .leftShift, .rightShift:
-                        modifierIsPressed = newFlagsState.contains(.maskShift)
-                    case .leftControl, .rightControl:
-                        modifierIsPressed = newFlagsState.contains(.maskControl)
-                    case .function:
-                        modifierIsPressed = newFlagsState.contains(.maskSecondaryFn)
-                }
+			var modifierIsPressed = false
+			switch physicalKey {
+			case .leftOption, .rightOption:
+				modifierIsPressed = newFlagsState.contains(.maskAlternate)
+			case .leftCommand, .rightCommand:
+				modifierIsPressed = newFlagsState.contains(.maskCommand)
+			case .leftShift, .rightShift:
+				modifierIsPressed = newFlagsState.contains(.maskShift)
+			case .leftControl, .rightControl:
+				modifierIsPressed = newFlagsState.contains(.maskControl)
+			case .function:
+				modifierIsPressed = newFlagsState.contains(.maskSecondaryFn)
+			}
 
-                if modifierIsPressed {
-                    pressedModifierKeyCodes.insert(changedModifierKeyCode)
-                } else {
-                    pressedModifierKeyCodes.remove(changedModifierKeyCode)
-                }
+			if modifierIsPressed {
+				pressedModifierKeyCodes.insert(changedModifierKeyCode)
+			} else {
+				pressedModifierKeyCodes.remove(changedModifierKeyCode)
+			}
 		// print("DEBUG: FlagsChanged: \(physicalKey) (kc: \(changedModifierKeyCode)) is now \(modifierIsPressed ? "pressed" : "released"). Current pressed: \(pressedModifierKeyCodes)")
 
-            default:
-                break
-        }
+		default:
+			break
+		}
 
-        return Unmanaged.passUnretained(event)
-    }
+		return Unmanaged.passUnretained(event)
+	}
 
-    private func isModifierKeyCode(_ keyCode: UInt16) -> Bool {
-        physicalModifierKeyToKeyCode.values.contains(keyCode)
-    }
+	private func isModifierKeyCode(_ keyCode: UInt16) -> Bool {
+		physicalModifierKeyToKeyCode.values.contains(keyCode)
+	}
 
-    private func checkForHotkeyMatch(nonModifierKeyCode: UInt16, event: CGEvent) -> Bool {
-        guard let currentActiveMode = activeMode,
-              let modeConfig = config.modes[currentActiveMode]
-        else {
-            return false
-        }
+	private func checkForHotkeyMatch(nonModifierKeyCode: UInt16, event: CGEvent) -> Bool {
+		guard let currentActiveMode = activeMode,
+			let modeConfig = config.modes[currentActiveMode]
+		else {
+			return false
+		}
 
-        // 1. Determine current state of pressed modifiers
-        var currentPhysicalKeys = Set<PhysicalModifierKey>()
-        var activeGenericTypes = Set<GenericModifierType>()
+		// 1. Determine current state of pressed modifiers
+		var currentPhysicalKeys = Set<PhysicalModifierKey>()
+		var activeGenericTypes = Set<GenericModifierType>()
 
-        for pressedKc in self.pressedModifierKeyCodes {
-            if let physicalKey = physicalModifierKeyToKeyCode.first(where: {
-                $0.value == pressedKc
-            })?.key {
-                currentPhysicalKeys.insert(physicalKey)
-                // Determine generic type from physical key
-                switch physicalKey {
-                    case .leftOption, .rightOption: activeGenericTypes.insert(.option)
-                    case .leftCommand, .rightCommand:
-                        activeGenericTypes.insert(.command)
-                    case .leftControl, .rightControl:
-                        activeGenericTypes.insert(.control)
-                    case .leftShift, .rightShift: activeGenericTypes.insert(.shift)
-                    case .function: break  // `fn` doesn't have a generic counterpart in GenericModifierType
-                }
-            }
-        }
+		for pressedKc in self.pressedModifierKeyCodes {
+			if let physicalKey = physicalModifierKeyToKeyCode.first(where: {
+				$0.value == pressedKc
+			})?.key {
+				currentPhysicalKeys.insert(physicalKey)
+				// Determine generic type from physical key
+				switch physicalKey {
+				case .leftOption, .rightOption: activeGenericTypes.insert(.option)
+				case .leftCommand, .rightCommand:
+					activeGenericTypes.insert(.command)
+				case .leftControl, .rightControl:
+					activeGenericTypes.insert(.control)
+				case .leftShift, .rightShift: activeGenericTypes.insert(.shift)
+				case .function: break  // `fn` doesn't have a generic counterpart in GenericModifierType
+				}
+			}
+		}
 
-        for (_, binding) in modeConfig.bindings {
-            if binding.keyCode == nonModifierKeyCode {
-                // Perform matching based on exact and generic modifiers
+		for (_, binding) in modeConfig.bindings {
+			if binding.keyCode == nonModifierKeyCode {
+				// Perform matching based on exact and generic modifiers
 
-                // Rule A: All exact modifiers in the binding must be currently pressed
-                guard binding.exactModifiers.isSubset(of: currentPhysicalKeys)
-                else {
-                    continue  // Next binding
-                }
+				// Rule A: All exact modifiers in the binding must be currently pressed
+				guard binding.exactModifiers.isSubset(of: currentPhysicalKeys)
+				else {
+					continue  // Next binding
+				}
 
-                // Rule B: All generic modifiers in the binding must be currently active
-                // AND ensure that if a generic is specified, no specific of that type is in exactModifiers (parser should prevent this, but good for safety)
-                var genericMatch = true
-                for genModType in binding.genericModifiers {
-                    if !activeGenericTypes.contains(genModType) {
-                        genericMatch = false
-                        break
-                    }
-                    // Parser validation should ensure exactModifiers doesn't contain specifics if generic is used for same type.
-                    // e.g. if binding.genericModifiers has .option, binding.exactModifiers shouldn't have .leftOption
-                }
-                guard genericMatch else {
-                    continue  // Next binding
-                }
+				// Rule B: All generic modifiers in the binding must be currently active
+				// AND ensure that if a generic is specified, no specific of that type is in exactModifiers (parser should prevent this, but good for safety)
+				var genericMatch = true
+				for genModType in binding.genericModifiers {
+					if !activeGenericTypes.contains(genModType) {
+						genericMatch = false
+						break
+					}
+					// Parser validation should ensure exactModifiers doesn't contain specifics if generic is used for same type.
+					// e.g. if binding.genericModifiers has .option, binding.exactModifiers shouldn't have .leftOption
+				}
+				guard genericMatch else {
+					continue  // Next binding
+				}
 
-                // Rule C: Count check - the number of distinct physical modifiers pressed must match the number intended by the binding.
-                // Number of modifiers intended by binding:
-                // This assumes parser enforces that exactModifiers and genericModifiers are for distinct modifier *types*.
-                // e.g., can't have exact lalt AND generic alt. Only one defines the 'option' type part of the binding.
+				// Rule C: Count check - the number of distinct physical modifiers pressed must match the number intended by the binding.
+				// Number of modifiers intended by binding:
+				// This assumes parser enforces that exactModifiers and genericModifiers are for distinct modifier *types*.
+				// e.g., can't have exact lalt AND generic alt. Only one defines the 'option' type part of the binding.
 
-                // More precise count: total number of active physical keys must match what the binding implies.
-                // A binding like `alt-shift-h` implies two distinct modifier keys are involved (one option, one shift).
-                // A binding like `lalt-ralt-h` implies two distinct modifier keys are involved (left option, right option).
-                let bindingEffectiveModifierCount =
-                    binding.exactModifiers.count
-                        + binding.genericModifiers.count
-                // This count must be validated by the parser: e.g. `alt-lalt-h` is invalid.
-                // If parser is correct, `binding.exactModifiers` and `binding.genericModifiers` don't specify the same base modifier type.
+				// More precise count: total number of active physical keys must match what the binding implies.
+				// A binding like `alt-shift-h` implies two distinct modifier keys are involved (one option, one shift).
+				// A binding like `lalt-ralt-h` implies two distinct modifier keys are involved (left option, right option).
+				let bindingEffectiveModifierCount =
+					binding.exactModifiers.count
+					+ binding.genericModifiers.count
+				// This count must be validated by the parser: e.g. `alt-lalt-h` is invalid.
+				// If parser is correct, `binding.exactModifiers` and `binding.genericModifiers` don't specify the same base modifier type.
 
-                if currentPhysicalKeys.count == bindingEffectiveModifierCount {
-                    // If all above checks pass, it's a match.
-                    print(
-                        "INFO: Hotkey matched: \(binding.descriptionWithKeyNotation)"
-                    )
-                    Task {
-                        try await runSession(
-                            .hotkeyBinding, .checkServerIsEnabledOrDie
-                        ) { () throws in
-                            _ = try await binding.commands.runCmdSeq(
-                                .defaultEnv, .emptyStdin)
-                        }
-                    }
-                    return true  // Consume event
-                }
-            }
-        }
-        return false
-    }
+				if currentPhysicalKeys.count == bindingEffectiveModifierCount {
+					// If all above checks pass, it's a match.
+					print(
+						"INFO: Hotkey matched: \(binding.descriptionWithKeyNotation)"
+					)
+					Task {
+						try await runSession(
+							.hotkeyBinding, .checkServerIsEnabledOrDie
+						) { () throws in
+							_ = try await binding.commands.runCmdSeq(
+								.defaultEnv, .emptyStdin)
+						}
+					}
+					return true  // Consume event
+				}
+			}
+		}
+		return false
+	}
 }
 
 // Helper extension for PhysicalModifierKey to get its generic type (if any)
 // This should ideally be in keysMap.swift or a shared location if GenericModifierType is there.
 // For now, adding it here for GlobalHotkeyMonitor's use.
-private extension PhysicalModifierKey {
-    var genericType: GenericModifierType? {
-        switch self {
-            case .leftOption, .rightOption: return .option
-            case .leftCommand, .rightCommand: return .command
-            case .leftControl, .rightControl: return .control
-            case .leftShift, .rightShift: return .shift
-            case .function: return nil  // Fn is always specific
-        }
-    }
+extension PhysicalModifierKey {
+	fileprivate var genericType: GenericModifierType? {
+		switch self {
+		case .leftOption, .rightOption: return .option
+		case .leftCommand, .rightCommand: return .command
+		case .leftControl, .rightControl: return .control
+		case .leftShift, .rightShift: return .shift
+		case .function: return nil  // Fn is always specific
+		}
+	}
 }

--- a/Sources/AppBundle/GlobalHotkeyMonitor.swift
+++ b/Sources/AppBundle/GlobalHotkeyMonitor.swift
@@ -1,246 +1,279 @@
-import AppKit // For NSEvent, CGEvent
-import Common // For Config, Command, etc.
+import AppKit  // For NSEvent, CGEvent
+import Common  // For Config, Command, etc.
 
 // We will not import HotKey here as we are replacing it.
 
 @MainActor
 class GlobalHotkeyMonitor {
-    private var eventTap: CFMachPort?
-    private var runLoopSource: CFRunLoopSource?
+	private var eventTap: CFMachPort?
+	private var runLoopSource: CFRunLoopSource?
 
-    // State to track pressed keys
-    // Using UInt16 for virtual key codes
-    private var pressedModifierKeyCodes: Set<UInt16> = []
-    // Optional: could also track all pressed keys if complex multi-non-modifier chords were needed
-    // private var pressedKeyCodes: Set<UInt16> = []
+	// State to track pressed keys
+	// Using UInt16 for virtual key codes
+	private var pressedModifierKeyCodes: Set<UInt16> = []
+	// Optional: could also track all pressed keys if complex multi-non-modifier chords were needed
+	// private var pressedKeyCodes: Set<UInt16> = []
 
-    // TODO: We'll need a mechanism to get the active bindings
-    // This might be passed in or accessed via a shared context/config reference.
-    // For now, assuming access to 'config' and 'activeMode' (defined in HotkeyBinding.swift context)
+	// The mechanism is to read from global `config` and `activeMode`
+	// For now, assuming access to 'config' and 'activeMode' (defined in HotkeyBinding.swift context)
 
-    init() {
-        // Initialization if needed
-    }
+	init() {
+		// Initialization if needed
+	}
 
-    func start() {
-        guard eventTap == nil else {
-            print("WARN: GlobalHotkeyMonitor already started.")
-            return
-        }
+	func start() {
+		guard eventTap == nil else {
+			print("WARN: GlobalHotkeyMonitor already started.")
+			return
+		}
 
-        // The types of events we want to tap.
-        // We need keyDown and keyUp to track all key states, including modifiers.
-        // flagsChanged can be supplementary or primary for modifiers if direct key up/down for them is noisy or problematic.
-        // Let's start with keyDown and keyUp.
-        let eventsToTap: CGEventMask = (1 << CGEventType.keyDown.rawValue) | (1 << CGEventType.keyUp.rawValue) | (1 << CGEventType.flagsChanged.rawValue)
+		// The types of events we want to tap.
+		// We need keyDown and keyUp to track all key states, including modifiers.
+		// flagsChanged can be supplementary or primary for modifiers if direct key up/down for them is noisy or problematic.
+		// Let's start with keyDown and keyUp.
+		let eventsToTap: CGEventMask =
+			(1 << CGEventType.keyDown.rawValue) | (1 << CGEventType.keyUp.rawValue)
+			| (1 << CGEventType.flagsChanged.rawValue)
 
-        // Create the event tap.
-        // '.cghidEventTap' is a common choice for system-wide hardware events.
-        guard let tap = CGEvent.tapCreate(
-            tap: .cgSessionEventTap, // Tap into the session event stream. Others: .cgHIDEventTap, .cgAnnotatedSessionEventTap
-            place: .headInsertEventTap, // Insert at the head of the event tap list
-            options: .defaultTap,      // Default options
-            eventsOfInterest: eventsToTap,
-            callback: { proxy, type, event, refcon -> Unmanaged<CGEvent>? in
-                // 'refcon' is the UnsafeMutableRawPointer to 'self'
-                guard let refcon else { return Unmanaged.passUnretained(event) }
-                let monitor = Unmanaged<GlobalHotkeyMonitor>.fromOpaque(refcon).takeUnretainedValue()
-                return monitor.handleEvent(proxy: proxy, type: type, event: event)
-            },
-            userInfo: Unmanaged.passUnretained(self).toOpaque() // Pass 'self' to the callback
-        ) else {
-            printStderr("ERROR: Failed to create event tap. This usually means AeroSpace requires Accessibility permissions. " +
-                "Please go to System Settings > Privacy & Security > Accessibility, and ensure AeroSpace is enabled. " +
-                "You may need to restart AeroSpace after granting permissions.")
-            // TODO: Better error handling - inform user, guide to permissions.
-            // Consider showing a user-facing alert if possible from this context,
-            // or setting a flag that the UI can pick up to show an alert.
-            // Example to open settings (use with caution, might need main thread if called from background):
-            // NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!)
-            return
-        }
+		// Create the event tap.
+		// '.cghidEventTap' is a common choice for system-wide hardware events.
+		guard
+			let tap = CGEvent.tapCreate(
+				tap: .cgSessionEventTap,  // Tap into the session event stream. Others: .cgHIDEventTap, .cgAnnotatedSessionEventTap
+				place: .headInsertEventTap,  // Insert at the head of the event tap list
+				options: .defaultTap,  // Default options
+				eventsOfInterest: eventsToTap,
+				callback: { proxy, type, event, refcon -> Unmanaged<CGEvent>? in
+					// 'refcon' is the UnsafeMutableRawPointer to 'self'
+					guard let refcon else {
+						return Unmanaged.passUnretained(event)
+					}
+					let monitor = Unmanaged<GlobalHotkeyMonitor>.fromOpaque(
+						refcon
+					).takeUnretainedValue()
+					return monitor.handleEvent(
+						proxy: proxy, type: type, event: event)
+				},
+				userInfo: Unmanaged.passUnretained(self).toOpaque()  // Pass 'self' to the callback
+			)
+		else {
+			printStderr(
+				"ERROR: Failed to create event tap. This usually means AeroSpace requires Accessibility permissions. "
+					+ "Please go to System Settings > Privacy & Security > Accessibility, and ensure AeroSpace is enabled. "
+					+ "You may need to restart AeroSpace after granting permissions."
+			)
+			// TODO: Better error handling - inform user, guide to permissions.
+			// Consider showing a user-facing alert if possible from this context,
+			// or setting a flag that the UI can pick up to show an alert.
+			// Example to open settings (use with caution, might need main thread if called from background):
+			// NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!)
+			return
+		}
 
-        // Create a run loop source and add it to the current run loop.
-        guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
-            printStderr("ERROR: Failed to create run loop source for event tap.")
-            return
-        }
+		// Create a run loop source and add it to the current run loop.
+		guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
+			printStderr("ERROR: Failed to create run loop source for event tap.")
+			return
+		}
 
-        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
-        CGEvent.tapEnable(tap: tap, enable: true)
+		CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+		CGEvent.tapEnable(tap: tap, enable: true)
 
-        self.eventTap = tap
-        self.runLoopSource = source
+		self.eventTap = tap
+		self.runLoopSource = source
 
-        print("INFO: GlobalHotkeyMonitor started.")
-    }
+		print("INFO: GlobalHotkeyMonitor started.")
+	}
 
-    func stop() {
-        if let tap = eventTap {
-            CGEvent.tapEnable(tap: tap, enable: false)
-            // CFMachPortInvalidate(tap) // Invalidating the port also removes the run loop source.
-            // However, it's often better to remove the source explicitly.
-            if let source = runLoopSource {
-                CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
-            }
-            // CFRelease(tap) // tap is a CFMachPort, managed by ARC when interacting with Swift types like CFMachPort?
-            // If directly using CFTypeRef, manual CFRelease would be needed.
-            // Swift handles this for optional CF types.
-            self.runLoopSource = nil
-            self.eventTap = nil
-            print("INFO: GlobalHotkeyMonitor stopped.")
-        }
-        pressedModifierKeyCodes.removeAll()
-    }
+	func stop() {
+		if let tap = eventTap {
+			CGEvent.tapEnable(tap: tap, enable: false)
+			// CFMachPortInvalidate(tap) // Invalidating the port also removes the run loop source.
+			// However, it's often better to remove the source explicitly.
+			if let source = runLoopSource {
+				CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+			}
+			// CFRelease(tap) // tap is a CFMachPort, managed by ARC when interacting with Swift types like CFMachPort?
+			// If directly using CFTypeRef, manual CFRelease would be needed.
+			// Swift handles this for optional CF types.
+			self.runLoopSource = nil
+			self.eventTap = nil
+			print("INFO: GlobalHotkeyMonitor stopped.")
+		}
+		pressedModifierKeyCodes.removeAll()
+	}
 
-    private func handleEvent(proxy: CGEventTapProxy, type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
-        let keyCode = UInt16(event.getIntegerValueField(.keyboardEventKeycode))
+	private func handleEvent(proxy: CGEventTapProxy, type: CGEventType, event: CGEvent)
+		-> Unmanaged<CGEvent>?
+	{
+		let keyCode = UInt16(event.getIntegerValueField(.keyboardEventKeycode))
 
-        switch type {
-            case .keyDown:
-                if isModifierKeyCode(keyCode) {
-                    pressedModifierKeyCodes.insert(keyCode)
-                } else {
-                    if checkForHotkeyMatch(nonModifierKeyCode: keyCode, event: event) {
-                        return nil
-                    }
-                }
-            case .keyUp:
-                if isModifierKeyCode(keyCode) {
-                    pressedModifierKeyCodes.remove(keyCode)
-                } else {
-                    // Optionally handle keyUp for non-modifiers if needed for specific command types
-                }
-            case .flagsChanged:
-                // The keyCode in a flagsChanged event is the specific modifier key that changed.
-                let changedModifierKeyCode = keyCode
-                let newFlagsState = event.flags
+		switch type {
+		case .keyDown:
+			if isModifierKeyCode(keyCode) {
+				pressedModifierKeyCodes.insert(keyCode)
+			} else {
+				if checkForHotkeyMatch(nonModifierKeyCode: keyCode, event: event) {
+					return nil
+				}
+			}
+		case .keyUp:
+			if isModifierKeyCode(keyCode) {
+				pressedModifierKeyCodes.remove(keyCode)
+			} else {
+				// Optionally handle keyUp for non-modifiers if needed for specific command types
+			}
+		case .flagsChanged:
+			// The keyCode in a flagsChanged event is the specific modifier key that changed.
+			let changedModifierKeyCode = keyCode
+			let newFlagsState = event.flags
 
-                // Determine if the specific modifier key that changed is now pressed or released.
-                // This requires knowing which generic flag corresponds to the specific modifier key code.
-                guard let physicalKey = physicalModifierKeyToKeyCode.first(where: { $0.value == changedModifierKeyCode })?.key else {
-                    // Unknown modifier key code that caused flagsChanged, should not happen if our maps are complete.
-                    print("WARN: flagsChanged event for unknown modifier keyCode: \(changedModifierKeyCode)")
-                    break
-                }
+			// Determine if the specific modifier key that changed is now pressed or released.
+			// This requires knowing which generic flag corresponds to the specific modifier key code.
+			guard
+				let physicalKey = physicalModifierKeyToKeyCode.first(where: {
+					$0.value == changedModifierKeyCode
+				})?.key
+			else {
+				// Unknown modifier key code that caused flagsChanged, should not happen if our maps are complete.
+				print(
+					"WARN: flagsChanged event for unknown modifier keyCode: \(changedModifierKeyCode)"
+				)
+				break
+			}
 
-                var modifierIsPressed = false
-                switch physicalKey {
-                    case .leftOption, .rightOption:
-                        modifierIsPressed = newFlagsState.contains(.maskAlternate)
-                    case .leftCommand, .rightCommand:
-                        modifierIsPressed = newFlagsState.contains(.maskCommand)
-                    case .leftShift, .rightShift:
-                        modifierIsPressed = newFlagsState.contains(.maskShift)
-                    case .leftControl, .rightControl:
-                        modifierIsPressed = newFlagsState.contains(.maskControl)
-                    case .function:
-                        modifierIsPressed = newFlagsState.contains(.maskSecondaryFn)
-                }
+			var modifierIsPressed = false
+			switch physicalKey {
+			case .leftOption, .rightOption:
+				modifierIsPressed = newFlagsState.contains(.maskAlternate)
+			case .leftCommand, .rightCommand:
+				modifierIsPressed = newFlagsState.contains(.maskCommand)
+			case .leftShift, .rightShift:
+				modifierIsPressed = newFlagsState.contains(.maskShift)
+			case .leftControl, .rightControl:
+				modifierIsPressed = newFlagsState.contains(.maskControl)
+			case .function:
+				modifierIsPressed = newFlagsState.contains(.maskSecondaryFn)
+			}
 
-                if modifierIsPressed {
-                    pressedModifierKeyCodes.insert(changedModifierKeyCode)
-                } else {
-                    pressedModifierKeyCodes.remove(changedModifierKeyCode)
-                }
-            // print("DEBUG: FlagsChanged: \(physicalKey) (kc: \(changedModifierKeyCode)) is now \(modifierIsPressed ? "pressed" : "released"). Current pressed: \(pressedModifierKeyCodes)")
+			if modifierIsPressed {
+				pressedModifierKeyCodes.insert(changedModifierKeyCode)
+			} else {
+				pressedModifierKeyCodes.remove(changedModifierKeyCode)
+			}
+		// print("DEBUG: FlagsChanged: \(physicalKey) (kc: \(changedModifierKeyCode)) is now \(modifierIsPressed ? "pressed" : "released"). Current pressed: \(pressedModifierKeyCodes)")
 
-            default:
-                break
-        }
+		default:
+			break
+		}
 
-        return Unmanaged.passUnretained(event)
-    }
+		return Unmanaged.passUnretained(event)
+	}
 
-    private func isModifierKeyCode(_ keyCode: UInt16) -> Bool {
-        physicalModifierKeyToKeyCode.values.contains(keyCode)
-    }
+	private func isModifierKeyCode(_ keyCode: UInt16) -> Bool {
+		physicalModifierKeyToKeyCode.values.contains(keyCode)
+	}
 
-    private func checkForHotkeyMatch(nonModifierKeyCode: UInt16, event: CGEvent) -> Bool {
-        guard let currentActiveMode = activeMode,
-              let modeConfig = config.modes[currentActiveMode]
-        else {
-            return false
-        }
+	private func checkForHotkeyMatch(nonModifierKeyCode: UInt16, event: CGEvent) -> Bool {
+		guard let currentActiveMode = activeMode,
+			let modeConfig = config.modes[currentActiveMode]
+		else {
+			return false
+		}
 
-        for (_, binding) in modeConfig.bindings {
-            if binding.keyCode == nonModifierKeyCode {
-                let requiredModifierKeyCodes = Set(binding.specificModifiers.map { physicalModifierKeyToKeyCode[$0]! })
+		// 1. Determine current state of pressed modifiers
+		var currentPhysicalKeys = Set<PhysicalModifierKey>()
+		var activeGenericTypes = Set<GenericModifierType>()
 
-                if requiredModifierKeyCodes == self.pressedModifierKeyCodes {
-                    print("INFO: Hotkey matched: \(binding.descriptionWithKeyNotation)")
-                    Task {
-                        // Use runSession for consistent command execution and error handling
-                        // The original binding.descriptionWithKeyCode might be slightly different now if specificModifiers.toString() order changed.
-                        // However, we have the direct 'binding.commands' object here.
-                        try await runSession(.hotkeyBinding, .checkServerIsEnabledOrDie) { () throws in
-                            _ = try await binding.commands.runCmdSeq(.defaultEnv, .emptyStdin)
-                        }
-                        // TODO: Add more specific error handling for runSession if needed.
-                    }
-                    // TODO: Make event consumption configurable per binding.
-                    // For now, always consume if a binding matches and executes.
-                    return true
-                }
-            }
-        }
-        return false
-    }
+		for pressedKc in self.pressedModifierKeyCodes {
+			if let physicalKey = physicalModifierKeyToKeyCode.first(where: {
+				$0.value == pressedKc
+			})?.key {
+				currentPhysicalKeys.insert(physicalKey)
+				// Determine generic type from physical key
+				switch physicalKey {
+				case .leftOption, .rightOption: activeGenericTypes.insert(.option)
+				case .leftCommand, .rightCommand:
+					activeGenericTypes.insert(.command)
+				case .leftControl, .rightControl:
+					activeGenericTypes.insert(.control)
+				case .leftShift, .rightShift: activeGenericTypes.insert(.shift)
+				case .function: break  // `fn` doesn't have a generic counterpart in GenericModifierType
+				}
+			}
+		}
+
+		for (_, binding) in modeConfig.bindings {
+			if binding.keyCode == nonModifierKeyCode {
+				// Perform matching based on exact and generic modifiers
+
+				// Rule A: All exact modifiers in the binding must be currently pressed
+				guard binding.exactModifiers.isSubset(of: currentPhysicalKeys)
+				else {
+					continue  // Next binding
+				}
+
+				// Rule B: All generic modifiers in the binding must be currently active
+				// AND ensure that if a generic is specified, no specific of that type is in exactModifiers (parser should prevent this, but good for safety)
+				var genericMatch = true
+				for genModType in binding.genericModifiers {
+					if !activeGenericTypes.contains(genModType) {
+						genericMatch = false
+						break
+					}
+					// Parser validation should ensure exactModifiers doesn't contain specifics if generic is used for same type.
+					// e.g. if binding.genericModifiers has .option, binding.exactModifiers shouldn't have .leftOption
+				}
+				guard genericMatch else {
+					continue  // Next binding
+				}
+
+				// Rule C: Count check - the number of distinct physical modifiers pressed must match the number intended by the binding.
+				// Number of modifiers intended by binding:
+				// This assumes parser enforces that exactModifiers and genericModifiers are for distinct modifier *types*.
+				// e.g., can't have exact lalt AND generic alt. Only one defines the 'option' type part of the binding.
+
+				// More precise count: total number of active physical keys must match what the binding implies.
+				// A binding like `alt-shift-h` implies two distinct modifier keys are involved (one option, one shift).
+				// A binding like `lalt-ralt-h` implies two distinct modifier keys are involved (left option, right option).
+				let bindingEffectiveModifierCount =
+					binding.exactModifiers.count
+					+ binding.genericModifiers.count
+				// This count must be validated by the parser: e.g. `alt-lalt-h` is invalid.
+				// If parser is correct, `binding.exactModifiers` and `binding.genericModifiers` don't specify the same base modifier type.
+
+				if currentPhysicalKeys.count == bindingEffectiveModifierCount {
+					// If all above checks pass, it's a match.
+					print(
+						"INFO: Hotkey matched: \(binding.descriptionWithKeyNotation)"
+					)
+					Task {
+						try await runSession(
+							.hotkeyBinding, .checkServerIsEnabledOrDie
+						) { () throws in
+							_ = try await binding.commands.runCmdSeq(
+								.defaultEnv, .emptyStdin)
+						}
+					}
+					return true  // Consume event
+				}
+			}
+		}
+		return false
+	}
 }
 
-// Helper extension for PhysicalModifierKey (assuming it's in keysMap.swift or accessible)
+// Helper extension for PhysicalModifierKey to get its generic type (if any)
+// This should ideally be in keysMap.swift or a shared location if GenericModifierType is there.
+// For now, adding it here for GlobalHotkeyMonitor's use.
 extension PhysicalModifierKey {
-    func isPressed(in flags: CGEventFlags) -> Bool {
-        // This logic needs to map PhysicalModifierKey to the correct CGEventFlags bitmask
-        // For example, .leftOption would check for .maskAlternate and also potentially check the keycode if flags alone are not enough
-        // For CGEvent.flagsChanged, the keyCode in the event itself is the primary source of truth for *which* modifier changed.
-        // The CGEventFlags then tell the *new state* of all flags.
-
-        // A simpler approach for flagsChanged:
-        // The event's keyCode IS the modifier that changed.
-        // We check if that keyCode is now part of the 'flags'.
-        // However, CGEventFlags are like NSEvent.ModifierFlags - they don't distinguish left/right by default in the main bitmask.
-        // So, for flagsChanged, we really rely on its `keyCode` field to tell us WHICH specific modifier key triggered it,
-        // and then check if that key is "on" in the new flags state (e.g. any option key is on if .maskAlternate is set).
-        // This confirms the specific key AND its state.
-
-        // Given that our pressedModifierKeyCodes set is based on individual key codes from keyDown/Up
-        // this helper might be more for interpreting the global CGEventFlags if needed elsewhere,
-        // or if we were to *only* use flagsChanged.
-        // For the current flagsChanged logic, we iterate physicalModifierKeyToKeyCode and check against currentFlags.
-
-        // Let's assume this function helps interpret the global flags state for a *specific* modifier.
-        // This is complex because CGEventFlags themselves don't easily give left/right distinction.
-        // We are tracking left/right based on their keyCodes directly from keyDown/keyUp/flagsChanged's keyCode.
-        // So, the pressedModifierKeyCodes set is our source of truth for specific left/right keys.
-        // This function might not be directly used in the flagsChanged logic as revised.
-
-        // If we were to use it, it would look like:
-        let code = physicalModifierKeyToKeyCode[self]!
-        switch self {
-            case .leftOption, .rightOption:
-                return flags.contains(.maskAlternate) // And then check 'code' if flags.contains(.maskAlternate)
-            case .leftCommand, .rightCommand:
-                return flags.contains(.maskCommand)
-            case .leftShift, .rightShift:
-                return flags.contains(.maskShift)
-            case .leftControl, .rightControl:
-                return flags.contains(.maskControl)
-            case .function:
-                return flags.contains(.maskSecondaryFn) // Corrected for CGEventFlags
-                // default: return false
-        }
-        // This is still tricky. The most reliable way is to get key up/down for each modifier via its keycode.
-        // For flagsChanged, the keyCode of the event tells *which* modifier changed.
-        // The flags then tell the *new state* of *generic* modifiers.
-        // So, if flagsChanged says keyCode for Left Alt changed, and event.flags contains .maskAlternate, Left Alt is now on.
-
-        // Revising the flagsChanged logic: iterate known physical modifiers, check if their generic flag is set,
-        // and if the specific keycode triggered this event or is generally active.
-
-        // The revised logic in flagsChanged directly updates pressedModifierKeyCodes by checking generic flags
-        // and assuming the keyCode from flagsChanged gives the specific key.
-        // This helper will be refined if a different strategy for flagsChanged is needed.
-        return false // Placeholder as the primary logic is now directly in handleEvent
-    }
+	fileprivate var genericType: GenericModifierType? {
+		switch self {
+		case .leftOption, .rightOption: return .option
+		case .leftCommand, .rightCommand: return .command
+		case .leftControl, .rightControl: return .control
+		case .leftShift, .rightShift: return .shift
+		case .function: return nil  // Fn is always specific
+		}
+	}
 }

--- a/Sources/AppBundle/GlobalHotkeyMonitor.swift
+++ b/Sources/AppBundle/GlobalHotkeyMonitor.swift
@@ -1,0 +1,246 @@
+import AppKit // For NSEvent, CGEvent
+import Common // For Config, Command, etc.
+
+// We will not import HotKey here as we are replacing it.
+
+@MainActor
+class GlobalHotkeyMonitor {
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+
+    // State to track pressed keys
+    // Using UInt16 for virtual key codes
+    private var pressedModifierKeyCodes: Set<UInt16> = []
+    // Optional: could also track all pressed keys if complex multi-non-modifier chords were needed
+    // private var pressedKeyCodes: Set<UInt16> = []
+
+    // TODO: We'll need a mechanism to get the active bindings
+    // This might be passed in or accessed via a shared context/config reference.
+    // For now, assuming access to 'config' and 'activeMode' (defined in HotkeyBinding.swift context)
+
+    init() {
+        // Initialization if needed
+    }
+
+    func start() {
+        guard eventTap == nil else {
+            print("WARN: GlobalHotkeyMonitor already started.")
+            return
+        }
+
+        // The types of events we want to tap.
+        // We need keyDown and keyUp to track all key states, including modifiers.
+        // flagsChanged can be supplementary or primary for modifiers if direct key up/down for them is noisy or problematic.
+        // Let's start with keyDown and keyUp.
+        let eventsToTap: CGEventMask = (1 << CGEventType.keyDown.rawValue) | (1 << CGEventType.keyUp.rawValue) | (1 << CGEventType.flagsChanged.rawValue)
+
+        // Create the event tap.
+        // '.cghidEventTap' is a common choice for system-wide hardware events.
+        guard let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap, // Tap into the session event stream. Others: .cgHIDEventTap, .cgAnnotatedSessionEventTap
+            place: .headInsertEventTap, // Insert at the head of the event tap list
+            options: .defaultTap,      // Default options
+            eventsOfInterest: eventsToTap,
+            callback: { proxy, type, event, refcon -> Unmanaged<CGEvent>? in
+                // 'refcon' is the UnsafeMutableRawPointer to 'self'
+                guard let refcon else { return Unmanaged.passUnretained(event) }
+                let monitor = Unmanaged<GlobalHotkeyMonitor>.fromOpaque(refcon).takeUnretainedValue()
+                return monitor.handleEvent(proxy: proxy, type: type, event: event)
+            },
+            userInfo: Unmanaged.passUnretained(self).toOpaque() // Pass 'self' to the callback
+        ) else {
+            printStderr("ERROR: Failed to create event tap. This usually means AeroSpace requires Accessibility permissions. " +
+                "Please go to System Settings > Privacy & Security > Accessibility, and ensure AeroSpace is enabled. " +
+                "You may need to restart AeroSpace after granting permissions.")
+            // TODO: Better error handling - inform user, guide to permissions.
+            // Consider showing a user-facing alert if possible from this context,
+            // or setting a flag that the UI can pick up to show an alert.
+            // Example to open settings (use with caution, might need main thread if called from background):
+            // NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!)
+            return
+        }
+
+        // Create a run loop source and add it to the current run loop.
+        guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
+            printStderr("ERROR: Failed to create run loop source for event tap.")
+            return
+        }
+
+        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+        CGEvent.tapEnable(tap: tap, enable: true)
+
+        self.eventTap = tap
+        self.runLoopSource = source
+
+        print("INFO: GlobalHotkeyMonitor started.")
+    }
+
+    func stop() {
+        if let tap = eventTap {
+            CGEvent.tapEnable(tap: tap, enable: false)
+            // CFMachPortInvalidate(tap) // Invalidating the port also removes the run loop source.
+            // However, it's often better to remove the source explicitly.
+            if let source = runLoopSource {
+                CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+            }
+            // CFRelease(tap) // tap is a CFMachPort, managed by ARC when interacting with Swift types like CFMachPort?
+            // If directly using CFTypeRef, manual CFRelease would be needed.
+            // Swift handles this for optional CF types.
+            self.runLoopSource = nil
+            self.eventTap = nil
+            print("INFO: GlobalHotkeyMonitor stopped.")
+        }
+        pressedModifierKeyCodes.removeAll()
+    }
+
+    private func handleEvent(proxy: CGEventTapProxy, type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        let keyCode = UInt16(event.getIntegerValueField(.keyboardEventKeycode))
+
+        switch type {
+            case .keyDown:
+                if isModifierKeyCode(keyCode) {
+                    pressedModifierKeyCodes.insert(keyCode)
+                } else {
+                    if checkForHotkeyMatch(nonModifierKeyCode: keyCode, event: event) {
+                        return nil
+                    }
+                }
+            case .keyUp:
+                if isModifierKeyCode(keyCode) {
+                    pressedModifierKeyCodes.remove(keyCode)
+                } else {
+                    // Optionally handle keyUp for non-modifiers if needed for specific command types
+                }
+            case .flagsChanged:
+                // The keyCode in a flagsChanged event is the specific modifier key that changed.
+                let changedModifierKeyCode = keyCode
+                let newFlagsState = event.flags
+
+                // Determine if the specific modifier key that changed is now pressed or released.
+                // This requires knowing which generic flag corresponds to the specific modifier key code.
+                guard let physicalKey = physicalModifierKeyToKeyCode.first(where: { $0.value == changedModifierKeyCode })?.key else {
+                    // Unknown modifier key code that caused flagsChanged, should not happen if our maps are complete.
+                    print("WARN: flagsChanged event for unknown modifier keyCode: \(changedModifierKeyCode)")
+                    break
+                }
+
+                var modifierIsPressed = false
+                switch physicalKey {
+                    case .leftOption, .rightOption:
+                        modifierIsPressed = newFlagsState.contains(.maskAlternate)
+                    case .leftCommand, .rightCommand:
+                        modifierIsPressed = newFlagsState.contains(.maskCommand)
+                    case .leftShift, .rightShift:
+                        modifierIsPressed = newFlagsState.contains(.maskShift)
+                    case .leftControl, .rightControl:
+                        modifierIsPressed = newFlagsState.contains(.maskControl)
+                    case .function:
+                        modifierIsPressed = newFlagsState.contains(.maskSecondaryFn)
+                }
+
+                if modifierIsPressed {
+                    pressedModifierKeyCodes.insert(changedModifierKeyCode)
+                } else {
+                    pressedModifierKeyCodes.remove(changedModifierKeyCode)
+                }
+            // print("DEBUG: FlagsChanged: \(physicalKey) (kc: \(changedModifierKeyCode)) is now \(modifierIsPressed ? "pressed" : "released"). Current pressed: \(pressedModifierKeyCodes)")
+
+            default:
+                break
+        }
+
+        return Unmanaged.passUnretained(event)
+    }
+
+    private func isModifierKeyCode(_ keyCode: UInt16) -> Bool {
+        physicalModifierKeyToKeyCode.values.contains(keyCode)
+    }
+
+    private func checkForHotkeyMatch(nonModifierKeyCode: UInt16, event: CGEvent) -> Bool {
+        guard let currentActiveMode = activeMode,
+              let modeConfig = config.modes[currentActiveMode]
+        else {
+            return false
+        }
+
+        for (_, binding) in modeConfig.bindings {
+            if binding.keyCode == nonModifierKeyCode {
+                let requiredModifierKeyCodes = Set(binding.specificModifiers.map { physicalModifierKeyToKeyCode[$0]! })
+
+                if requiredModifierKeyCodes == self.pressedModifierKeyCodes {
+                    print("INFO: Hotkey matched: \(binding.descriptionWithKeyNotation)")
+                    Task {
+                        // Use runSession for consistent command execution and error handling
+                        // The original binding.descriptionWithKeyCode might be slightly different now if specificModifiers.toString() order changed.
+                        // However, we have the direct 'binding.commands' object here.
+                        try await runSession(.hotkeyBinding, .checkServerIsEnabledOrDie) { () throws in
+                            _ = try await binding.commands.runCmdSeq(.defaultEnv, .emptyStdin)
+                        }
+                        // TODO: Add more specific error handling for runSession if needed.
+                    }
+                    // TODO: Make event consumption configurable per binding.
+                    // For now, always consume if a binding matches and executes.
+                    return true
+                }
+            }
+        }
+        return false
+    }
+}
+
+// Helper extension for PhysicalModifierKey (assuming it's in keysMap.swift or accessible)
+extension PhysicalModifierKey {
+    func isPressed(in flags: CGEventFlags) -> Bool {
+        // This logic needs to map PhysicalModifierKey to the correct CGEventFlags bitmask
+        // For example, .leftOption would check for .maskAlternate and also potentially check the keycode if flags alone are not enough
+        // For CGEvent.flagsChanged, the keyCode in the event itself is the primary source of truth for *which* modifier changed.
+        // The CGEventFlags then tell the *new state* of all flags.
+
+        // A simpler approach for flagsChanged:
+        // The event's keyCode IS the modifier that changed.
+        // We check if that keyCode is now part of the 'flags'.
+        // However, CGEventFlags are like NSEvent.ModifierFlags - they don't distinguish left/right by default in the main bitmask.
+        // So, for flagsChanged, we really rely on its `keyCode` field to tell us WHICH specific modifier key triggered it,
+        // and then check if that key is "on" in the new flags state (e.g. any option key is on if .maskAlternate is set).
+        // This confirms the specific key AND its state.
+
+        // Given that our pressedModifierKeyCodes set is based on individual key codes from keyDown/Up
+        // this helper might be more for interpreting the global CGEventFlags if needed elsewhere,
+        // or if we were to *only* use flagsChanged.
+        // For the current flagsChanged logic, we iterate physicalModifierKeyToKeyCode and check against currentFlags.
+
+        // Let's assume this function helps interpret the global flags state for a *specific* modifier.
+        // This is complex because CGEventFlags themselves don't easily give left/right distinction.
+        // We are tracking left/right based on their keyCodes directly from keyDown/keyUp/flagsChanged's keyCode.
+        // So, the pressedModifierKeyCodes set is our source of truth for specific left/right keys.
+        // This function might not be directly used in the flagsChanged logic as revised.
+
+        // If we were to use it, it would look like:
+        let code = physicalModifierKeyToKeyCode[self]!
+        switch self {
+            case .leftOption, .rightOption:
+                return flags.contains(.maskAlternate) // And then check 'code' if flags.contains(.maskAlternate)
+            case .leftCommand, .rightCommand:
+                return flags.contains(.maskCommand)
+            case .leftShift, .rightShift:
+                return flags.contains(.maskShift)
+            case .leftControl, .rightControl:
+                return flags.contains(.maskControl)
+            case .function:
+                return flags.contains(.maskSecondaryFn) // Corrected for CGEventFlags
+                // default: return false
+        }
+        // This is still tricky. The most reliable way is to get key up/down for each modifier via its keycode.
+        // For flagsChanged, the keyCode of the event tells *which* modifier changed.
+        // The flags then tell the *new state* of *generic* modifiers.
+        // So, if flagsChanged says keyCode for Left Alt changed, and event.flags contains .maskAlternate, Left Alt is now on.
+
+        // Revising the flagsChanged logic: iterate known physical modifiers, check if their generic flag is set,
+        // and if the specific keycode triggered this event or is generally active.
+
+        // The revised logic in flagsChanged directly updates pressedModifierKeyCodes by checking generic flags
+        // and assuming the keyCode from flagsChanged gives the specific key.
+        // This helper will be refined if a different strategy for flagsChanged is needed.
+        return false // Placeholder as the primary logic is now directly in handleEvent
+    }
+}

--- a/Sources/AppBundle/GlobalHotkeyMonitor.swift
+++ b/Sources/AppBundle/GlobalHotkeyMonitor.swift
@@ -1,321 +1,329 @@
 import AppKit  // For NSEvent, CGEvent
 import Common  // For Config, Command, etc.
 
-// We will not import HotKey here as we are replacing it.
-
+@MainActor  // Class is MainActor isolated
 class GlobalHotkeyMonitor {
-	private var eventTap: CFMachPort?
-	private var runLoopSource: CFRunLoopSource?
-	private let lock = NSLock()  // Lock for protecting pressedModifierKeyCodes
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+    private let lock = NSLock()  // Lock for protecting pressedModifierKeyCodes
 
-	// State to track pressed keys
-	// Using UInt16 for virtual key codes
-	private var pressedModifierKeyCodes: Set<UInt16> = []
-	// Optional: could also track all pressed keys if complex multi-non-modifier chords were needed
-	// private var pressedKeyCodes: Set<UInt16> = []
+    // State to track pressed keys
+    // Using UInt16 for virtual key codes
+    private var pressedModifierKeyCodes: Set<UInt16> = []
+    // Optional: could also track all pressed keys if complex multi-non-modifier chords were needed
+    // private var pressedKeyCodes: Set<UInt16> = []
 
-	// For optimized hotkey lookup
-	private var bindingsByKeyCode: [UInt16: [HotkeyBinding]] = [:]
-	private var lastKnownModeName: String?  // To track when to rebuild bindingsByKeyCode
+    // For optimized hotkey lookup
+    private var bindingsByKeyCode: [UInt16: [HotkeyBinding]] = [:]
+    private var lastKnownModeName: String?  // To track when to rebuild bindingsByKeyCode
 
-	// The mechanism is to read from global `config` and `activeMode`
-	// For now, assuming access to 'config' and 'activeMode' (defined in HotkeyBinding.swift context)
+    // The mechanism is to read from global `config` and `activeMode`
+    // For now, assuming access to 'config' and 'activeMode' (defined in HotkeyBinding.swift context)
 
-	init() {
-		// Initialization if needed
-	}
+    init() {
+        // Initialization if needed
+    }
 
-	func start() {
-		guard eventTap == nil else {
-			print("WARN: GlobalHotkeyMonitor already started.")
-			return
-		}
+    func start() {
+        guard eventTap == nil else {
+            print("WARN: GlobalHotkeyMonitor already started.")
+            return
+        }
 
-		// The types of events we want to tap.
-		// We need keyDown and keyUp to track all key states, including modifiers.
-		// flagsChanged can be supplementary or primary for modifiers if direct key up/down for them is noisy or problematic.
-		// Let's start with keyDown and keyUp.
-		let eventsToTap: CGEventMask =
-			(1 << CGEventType.keyDown.rawValue) | (1 << CGEventType.keyUp.rawValue)
-			| (1 << CGEventType.flagsChanged.rawValue)
+        // The types of events we want to tap.
+        // We need keyDown and keyUp to track all key states, including modifiers.
+        // flagsChanged can be supplementary or primary for modifiers if direct key up/down for them is noisy or problematic.
+        // Let's start with keyDown and keyUp.
+        let eventsToTap: CGEventMask =
+            (1 << CGEventType.keyDown.rawValue) | (1 << CGEventType.keyUp.rawValue)
+                | (1 << CGEventType.flagsChanged.rawValue)
 
-		// Create the event tap.
-		// '.cghidEventTap' is a common choice for system-wide hardware events.
-		guard
-			let tap = CGEvent.tapCreate(
-				tap: .cgSessionEventTap,  // Tap into the session event stream. Others: .cgHIDEventTap, .cgAnnotatedSessionEventTap
-				place: .headInsertEventTap,  // Insert at the head of the event tap list
-				options: .defaultTap,  // Default options
-				eventsOfInterest: eventsToTap,
-				callback: { proxy, type, event, refcon -> Unmanaged<CGEvent>? in
-					// 'refcon' is the UnsafeMutableRawPointer to 'self'
-					guard let refcon else {
-						return Unmanaged.passUnretained(event)
-					}
-					let monitor = Unmanaged<GlobalHotkeyMonitor>.fromOpaque(
-						refcon
-					).takeUnretainedValue()
-					return monitor.handleEvent(
-						proxy: proxy, type: type, event: event)
-				},
-				userInfo: Unmanaged.passUnretained(self).toOpaque()  // Pass 'self' to the callback
-			)
-		else {
-			printStderr(
-				"ERROR: Failed to create event tap. This usually means AeroSpace requires Accessibility permissions. "
-					+ "Please go to System Settings > Privacy & Security > Accessibility, and ensure AeroSpace is enabled. "
-					+ "You may need to restart AeroSpace after granting permissions."
-			)
-			// TODO: Better error handling - inform user, guide to permissions.
-			// Consider showing a user-facing alert if possible from this context,
-			// or setting a flag that the UI can pick up to show an alert.
-			// Example to open settings (use with caution, might need main thread if called from background):
-			// NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!)
-			return
-		}
+        // Create the event tap.
+        // '.cghidEventTap' is a common choice for system-wide hardware events.
+        guard
+            let tap = CGEvent.tapCreate(
+                tap: .cgSessionEventTap,  // Tap into the session event stream. Others: .cgHIDEventTap, .cgAnnotatedSessionEventTap
+                place: .headInsertEventTap,  // Insert at the head of the event tap list
+                options: .defaultTap,  // Default options
+                eventsOfInterest: eventsToTap,
+                callback: { proxy, type, event, refcon -> Unmanaged<CGEvent>? in
+                    // 'refcon' is the UnsafeMutableRawPointer to 'self'
+                    guard let refcon else {
+                        return Unmanaged.passUnretained(event)
+                    }
+                    let monitor = Unmanaged<GlobalHotkeyMonitor>.fromOpaque(
+                        refcon
+                    ).takeUnretainedValue()
+                    return monitor.handleEvent_Outer(
+                        proxy: proxy, type: type, event: event)
+                },
+                userInfo: Unmanaged.passUnretained(self).toOpaque()  // Pass 'self' to the callback
+            )
+        else {
+            printStderr(
+                "ERROR: Failed to create event tap. This usually means AeroSpace requires Accessibility permissions. "
+                    + "Please go to System Settings > Privacy & Security > Accessibility, and ensure AeroSpace is enabled. "
+                    + "You may need to restart AeroSpace after granting permissions."
+            )
+            // TODO: Better error handling - inform user, guide to permissions.
+            // Consider showing a user-facing alert if possible from this context,
+            // or setting a flag that the UI can pick up to show an alert.
+            // Example to open settings (use with caution, might need main thread if called from background):
+            // NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!)
+            return
+        }
 
-		// Create a run loop source and add it to the current run loop.
-		guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
-			printStderr("ERROR: Failed to create run loop source for event tap.")
-			return
-		}
+        // Create a run loop source and add it to the current run loop.
+        guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
+            printStderr("ERROR: Failed to create run loop source for event tap.")
+            return
+        }
 
-		CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
-		CGEvent.tapEnable(tap: tap, enable: true)
+        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+        CGEvent.tapEnable(tap: tap, enable: true)
 
-		self.eventTap = tap
-		self.runLoopSource = source
+        self.eventTap = tap
+        self.runLoopSource = source
 
-		print("INFO: GlobalHotkeyMonitor started.")
-	}
+        print("INFO: GlobalHotkeyMonitor started.")
+    }
 
-	@MainActor
-	func stop() {
-		if let tap = eventTap {
-			CGEvent.tapEnable(tap: tap, enable: false)  // Disable event delivery
+    @MainActor
+    func stop() {
+        if let tap = eventTap {
+            CGEvent.tapEnable(tap: tap, enable: false)  // Disable event delivery
 
-			// Invalidate the Mach port. This also removes its run loop sources.
-			// One call is sufficient.
-			CFMachPortInvalidate(tap)
+            // Invalidate the Mach port. This also removes its run loop sources.
+            // One call is sufficient.
+            CFMachPortInvalidate(tap)
 
-			// Explicitly removing the source after invalidation is generally not needed
-			// as CFMachPortInvalidate should handle it. However, it's kept for now.
-			if let source = runLoopSource {
-				CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
-			}
+            // Explicitly removing the source after invalidation is generally not needed
+            // as CFMachPortInvalidate should handle it. However, it's kept for now.
+            if let source = runLoopSource {
+                CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+            }
 
-			// ARC will handle the release of 'tap' and 'source' when these are set to nil.
-			self.runLoopSource = nil
-			self.eventTap = nil
-			print("INFO: GlobalHotkeyMonitor stopped.")
-		}
-		lock.lock()
-		pressedModifierKeyCodes.removeAll()
-		lock.unlock()
+            // ARC will handle the release of 'tap' and 'source' when these are set to nil.
+            self.runLoopSource = nil
+            self.eventTap = nil
+            print("INFO: GlobalHotkeyMonitor stopped.")
+        }
+        lock.lock()
+        pressedModifierKeyCodes.removeAll()
+        lock.unlock()
 
-		// Clear optimized lookup cache
-		bindingsByKeyCode.removeAll()
-		lastKnownModeName = nil
-	}
+        // Clear optimized lookup cache
+        bindingsByKeyCode.removeAll()
+        lastKnownModeName = nil
+    }
 
-	nonisolated(unsafe) private func handleEvent(
-		proxy: CGEventTapProxy, type: CGEventType, event: CGEvent
-	)
-		-> Unmanaged<CGEvent>?
-	{
-		let keyCode = UInt16(event.getIntegerValueField(.keyboardEventKeycode))
+    // Entry point from C callback. Runs on event tap thread.
+    private nonisolated func handleEvent_Outer(
+        proxy: CGEventTapProxy, type cgEventType: CGEventType, event: CGEvent
+    ) -> Unmanaged<CGEvent>? {
+        var consumed = false
 
-		switch type {
-		case .keyDown:
-			lock.lock()
-			if isModifierKeyCode(keyCode) {
-				pressedModifierKeyCodes.insert(keyCode)
-				lock.unlock()
-			} else {
-				lock.unlock()
-				if checkForHotkeyMatch(nonModifierKeyCode: keyCode, event: event) {
-					return nil
-				}
-			}
-		case .keyUp:
-			lock.lock()
-			if isModifierKeyCode(keyCode) {
-				pressedModifierKeyCodes.remove(keyCode)
-			}
-			lock.unlock()
-		// Optionally handle keyUp for non-modifiers if needed for specific command types
-		case .flagsChanged:
-			// The keyCode in a flagsChanged event is the specific modifier key that changed.
-			let changedModifierKeyCode = keyCode
-			let newFlagsState = event.flags
+        let keyCode = UInt16(event.getIntegerValueField(.keyboardEventKeycode))
+        let flags = event.flags  // CGEventFlags is Sendable (UInt64)
+        // CGEventType is Sendable (UInt32 wrapper)
 
-			// Determine if the specific modifier key that changed is now pressed or released.
-			// This requires knowing which generic flag corresponds to the specific modifier key code.
-			guard
-				let physicalKey = physicalModifierKeyToKeyCode.first(where: {
-					$0.value == changedModifierKeyCode
-				})?.key
-			else {
-				// Unknown modifier key code that caused flagsChanged, should not happen if our maps are complete.
-				print(
-					"WARN: flagsChanged event for unknown modifier keyCode: \(changedModifierKeyCode)"
-				)
-				break
-			}
+        DispatchQueue.main.sync {
+            // Pass only Sendable data to the main actor context
+            consumed = self._handleEvent_CoreLogic(
+                keyCode: keyCode, cgEventType: cgEventType, flags: flags)
+        }
+        // The original `event` is only used here to be returned if not consumed.
+        // It's not captured in the main actor closure in a way that causes data races for its content.
+        return consumed ? nil : Unmanaged.passUnretained(event)
+    }
 
-			var modifierIsPressed = false
-			switch physicalKey {
-			case .leftOption, .rightOption:
-				modifierIsPressed = newFlagsState.contains(.maskAlternate)
-			case .leftCommand, .rightCommand:
-				modifierIsPressed = newFlagsState.contains(.maskCommand)
-			case .leftShift, .rightShift:
-				modifierIsPressed = newFlagsState.contains(.maskShift)
-			case .leftControl, .rightControl:
-				modifierIsPressed = newFlagsState.contains(.maskControl)
-			case .function:
-				modifierIsPressed = newFlagsState.contains(.maskSecondaryFn)
-			}
+    // Core logic, runs on MainActor.
+    private func _handleEvent_CoreLogic(
+        keyCode: UInt16, cgEventType: CGEventType, flags: CGEventFlags
+    ) -> Bool {
+        switch cgEventType {
+            case .keyDown:
+                if isModifierKeyCode(keyCode) {
+                    pressedModifierKeyCodes.insert(keyCode)
+                } else {
+                    if checkForHotkeyMatch(nonModifierKeyCode: keyCode) {  // Pass only keyCode
+                        return true  // Consumed
+                    }
+                }
+            case .keyUp:
+                lock.lock()
+                if isModifierKeyCode(keyCode) {
+                    pressedModifierKeyCodes.remove(keyCode)
+                }
+                lock.unlock()
+            // Optionally handle keyUp for non-modifiers if needed for specific command types
+            case .flagsChanged:
+                // The keyCode in a flagsChanged event is the specific modifier key that changed.
+                let changedModifierKeyCode = keyCode
+                let newFlagsState = flags
 
-			lock.lock()
-			if modifierIsPressed {
-				pressedModifierKeyCodes.insert(changedModifierKeyCode)
-			} else {
-				pressedModifierKeyCodes.remove(changedModifierKeyCode)
-			}
-			lock.unlock()
+                // Determine if the specific modifier key that changed is now pressed or released.
+                // This requires knowing which generic flag corresponds to the specific modifier key code.
+                guard
+                    let physicalKey = physicalModifierKeyToKeyCode.first(where: {
+                        $0.value == changedModifierKeyCode
+                    })?.key
+                else {
+                    // Unknown modifier key code that caused flagsChanged, should not happen if our maps are complete.
+                    print(
+                        "WARN: flagsChanged event for unknown modifier keyCode: \(changedModifierKeyCode)"
+                    )
+                    break
+                }
+
+                var modifierIsPressed = false
+                switch physicalKey {
+                    case .leftOption, .rightOption:
+                        modifierIsPressed = newFlagsState.contains(.maskAlternate)
+                    case .leftCommand, .rightCommand:
+                        modifierIsPressed = newFlagsState.contains(.maskCommand)
+                    case .leftShift, .rightShift:
+                        modifierIsPressed = newFlagsState.contains(.maskShift)
+                    case .leftControl, .rightControl:
+                        modifierIsPressed = newFlagsState.contains(.maskControl)
+                    case .function:
+                        modifierIsPressed = newFlagsState.contains(.maskSecondaryFn)
+                }
+
+                lock.lock()
+                if modifierIsPressed {
+                    pressedModifierKeyCodes.insert(changedModifierKeyCode)
+                } else {
+                    pressedModifierKeyCodes.remove(changedModifierKeyCode)
+                }
+                lock.unlock()
 		// print("DEBUG: FlagsChanged: \(physicalKey) (kc: \(changedModifierKeyCode)) is now \(modifierIsPressed ? "pressed" : "released"). Current pressed: \(pressedModifierKeyCodes)")
 
-		default:
-			break
-		}
+            default:
+                break
+        }
+        return false  // Not consumed
+    }
 
-		return Unmanaged.passUnretained(event)
-	}
+    private func isModifierKeyCode(_ keyCode: UInt16) -> Bool {
+        physicalModifierKeyToKeyCode.values.contains(keyCode)
+    }
 
-	private func isModifierKeyCode(_ keyCode: UInt16) -> Bool {
-		physicalModifierKeyToKeyCode.values.contains(keyCode)
-	}
+    private func checkForHotkeyMatch(nonModifierKeyCode: UInt16) -> Bool {
+        guard let currentActiveModeName = activeMode,
+              let modeConfig = config.modes[currentActiveModeName]
+        else { return false }
+        if lastKnownModeName != currentActiveModeName
+            || (bindingsByKeyCode.isEmpty && !modeConfig.bindings.isEmpty)
+        {
+            bindingsByKeyCode.removeAll()
+            for (_, binding) in modeConfig.bindings {
+                bindingsByKeyCode[binding.keyCode, default: []].append(binding)
+            }
+            lastKnownModeName = currentActiveModeName
+        }
 
-	private func checkForHotkeyMatch(nonModifierKeyCode: UInt16, event: CGEvent) -> Bool {
-		guard let currentActiveModeName = activeMode?.name,  // Assuming activeMode has a name property or similar unique ID
-			let modeConfig = config.modes[currentActiveModeName]
-		else {
-			return false
-		}
+        guard let candidateBindings = bindingsByKeyCode[nonModifierKeyCode],
+              !candidateBindings.isEmpty
+        else {
+            return false  // No bindings for this specific non-modifier key
+        }
 
-		// Rebuild bindingsByKeyCode if mode changed or not initialized for current mode
-		if lastKnownModeName != currentActiveModeName
-			|| bindingsByKeyCode.isEmpty && !modeConfig.bindings.isEmpty
-		{
-			bindingsByKeyCode.removeAll()
-			for (_, binding) in modeConfig.bindings {
-				bindingsByKeyCode[binding.keyCode, default: []].append(binding)
-			}
-			lastKnownModeName = currentActiveModeName
-		}
+        // 1. Determine current state of pressed modifiers
+        var currentPhysicalKeys = Set<PhysicalModifierKey>()
+        var activeGenericTypes = Set<GenericModifierType>()
 
-		guard let candidateBindings = bindingsByKeyCode[nonModifierKeyCode],
-			!candidateBindings.isEmpty
-		else {
-			return false  // No bindings for this specific non-modifier key
-		}
+        lock.lock()
+        let localPressedModifierKeyCodes = self.pressedModifierKeyCodes
+        for pressedKc in localPressedModifierKeyCodes {
+            if let physicalKey = physicalModifierKeyToKeyCode.first(where: {
+                $0.value == pressedKc
+            })?.key {
+                currentPhysicalKeys.insert(physicalKey)
+                // Determine generic type from physical key
+                switch physicalKey {
+                    case .leftOption, .rightOption: activeGenericTypes.insert(.option)
+                    case .leftCommand, .rightCommand:
+                        activeGenericTypes.insert(.command)
+                    case .leftControl, .rightControl:
+                        activeGenericTypes.insert(.control)
+                    case .leftShift, .rightShift: activeGenericTypes.insert(.shift)
+                    case .function: break  // `fn` doesn't have a generic counterpart in GenericModifierType
+                }
+            }
+        }
+        lock.unlock()
 
-		// 1. Determine current state of pressed modifiers
-		var currentPhysicalKeys = Set<PhysicalModifierKey>()
-		var activeGenericTypes = Set<GenericModifierType>()
+        // Iterate only over bindings that match the nonModifierKeyCode
+        for binding in candidateBindings {
+            // Perform matching based on exact and generic modifiers
 
-		lock.lock()
-		let localPressedModifierKeyCodes = self.pressedModifierKeyCodes
-		for pressedKc in localPressedModifierKeyCodes {
-			if let physicalKey = physicalModifierKeyToKeyCode.first(where: {
-				$0.value == pressedKc
-			})?.key {
-				currentPhysicalKeys.insert(physicalKey)
-				// Determine generic type from physical key
-				switch physicalKey {
-				case .leftOption, .rightOption: activeGenericTypes.insert(.option)
-				case .leftCommand, .rightCommand:
-					activeGenericTypes.insert(.command)
-				case .leftControl, .rightControl:
-					activeGenericTypes.insert(.control)
-				case .leftShift, .rightShift: activeGenericTypes.insert(.shift)
-				case .function: break  // `fn` doesn't have a generic counterpart in GenericModifierType
-				}
-			}
-		}
-		lock.unlock()
+            // Rule A: All exact modifiers in the binding must be currently pressed
+            guard binding.exactModifiers.isSubset(of: currentPhysicalKeys)
+            else {
+                continue  // Next binding
+            }
 
-		// Iterate only over bindings that match the nonModifierKeyCode
-		for binding in candidateBindings {
-			// Perform matching based on exact and generic modifiers
+            // Rule B: All generic modifiers in the binding must be currently active
+            // AND ensure that if a generic is specified, no specific of that type is in exactModifiers (parser should prevent this, but good for safety)
+            var genericMatch = true
+            for genModType in binding.genericModifiers {
+                if !activeGenericTypes.contains(genModType) {
+                    genericMatch = false
+                    break
+                }
+                // Parser validation should ensure exactModifiers doesn't contain specifics if generic is used for same type.
+                // e.g. if binding.genericModifiers has .option, binding.exactModifiers shouldn't have .leftOption
+            }
+            guard genericMatch else {
+                continue  // Next binding
+            }
 
-			// Rule A: All exact modifiers in the binding must be currently pressed
-			guard binding.exactModifiers.isSubset(of: currentPhysicalKeys)
-			else {
-				continue  // Next binding
-			}
+            // Rule C: Count check - the number of distinct physical modifiers pressed must match the number intended by the binding.
+            // Number of modifiers intended by binding:
+            // This assumes parser enforces that exactModifiers and genericModifiers are for distinct modifier *types*.
+            // e.g., can't have exact lalt AND generic alt. Only one defines the 'option' type part of the binding.
 
-			// Rule B: All generic modifiers in the binding must be currently active
-			// AND ensure that if a generic is specified, no specific of that type is in exactModifiers (parser should prevent this, but good for safety)
-			var genericMatch = true
-			for genModType in binding.genericModifiers {
-				if !activeGenericTypes.contains(genModType) {
-					genericMatch = false
-					break
-				}
-				// Parser validation should ensure exactModifiers doesn't contain specifics if generic is used for same type.
-				// e.g. if binding.genericModifiers has .option, binding.exactModifiers shouldn't have .leftOption
-			}
-			guard genericMatch else {
-				continue  // Next binding
-			}
+            // More precise count: total number of active physical keys must match what the binding implies.
+            // A binding like `alt-shift-h` implies two distinct modifier keys are involved (one option, one shift).
+            // A binding like `lalt-ralt-h` implies two distinct modifier keys are involved (left option, right option).
+            let bindingEffectiveModifierCount =
+                binding.exactModifiers.count
+                    + binding.genericModifiers.count
+            // This count must be validated by the parser: e.g. `alt-lalt-h` is invalid.
+            // If parser is correct, `binding.exactModifiers` and `binding.genericModifiers` don't specify the same base modifier type.
 
-			// Rule C: Count check - the number of distinct physical modifiers pressed must match the number intended by the binding.
-			// Number of modifiers intended by binding:
-			// This assumes parser enforces that exactModifiers and genericModifiers are for distinct modifier *types*.
-			// e.g., can't have exact lalt AND generic alt. Only one defines the 'option' type part of the binding.
-
-			// More precise count: total number of active physical keys must match what the binding implies.
-			// A binding like `alt-shift-h` implies two distinct modifier keys are involved (one option, one shift).
-			// A binding like `lalt-ralt-h` implies two distinct modifier keys are involved (left option, right option).
-			let bindingEffectiveModifierCount =
-				binding.exactModifiers.count
-				+ binding.genericModifiers.count
-			// This count must be validated by the parser: e.g. `alt-lalt-h` is invalid.
-			// If parser is correct, `binding.exactModifiers` and `binding.genericModifiers` don't specify the same base modifier type.
-
-			if currentPhysicalKeys.count == bindingEffectiveModifierCount {
-				// If all above checks pass, it's a match.
-				print(
-					"INFO: Hotkey matched: \(binding.descriptionWithKeyNotation)"
-				)
-				Task {
-					try await runSession(
-						.hotkeyBinding, .checkServerIsEnabledOrDie
-					) { () throws in
-						_ = try await binding.commands.runCmdSeq(
-							.defaultEnv, .emptyStdin)
-					}
-				}
-				return true  // Consume event
-			}
-		}
-		return false
-	}
+            if currentPhysicalKeys.count == bindingEffectiveModifierCount {
+                // If all above checks pass, it's a match.
+                print(
+                    "INFO: Hotkey matched: \(binding.descriptionWithKeyNotation)"
+                )
+                Task {
+                    try await runSession(
+                        .hotkeyBinding, .checkServerIsEnabledOrDie
+                    ) { () throws in
+                        _ = try await binding.commands.runCmdSeq(
+                            .defaultEnv, .emptyStdin)
+                    }
+                }
+                return true  // Consume event
+            }
+        }
+        return false
+    }
 }
 
 // Helper extension for PhysicalModifierKey to get its generic type (if any)
 // This should ideally be in keysMap.swift or a shared location if GenericModifierType is there.
 // For now, adding it here for GlobalHotkeyMonitor's use.
-extension PhysicalModifierKey {
-	fileprivate var genericType: GenericModifierType? {
-		switch self {
-		case .leftOption, .rightOption: return .option
-		case .leftCommand, .rightCommand: return .command
-		case .leftControl, .rightControl: return .control
-		case .leftShift, .rightShift: return .shift
-		case .function: return nil  // Fn is always specific
-		}
-	}
+private extension PhysicalModifierKey {
+    var genericType: GenericModifierType? {
+        switch self {
+            case .leftOption, .rightOption: return .option
+            case .leftCommand, .rightCommand: return .command
+            case .leftControl, .rightControl: return .control
+            case .leftShift, .rightShift: return .shift
+            case .function: return nil  // Fn is always specific
+        }
+    }
 }

--- a/Sources/AppBundle/command/cmdManifest.swift
+++ b/Sources/AppBundle/command/cmdManifest.swift
@@ -9,7 +9,8 @@ extension CmdArgs {
             case .close:
                 command = CloseCommand(args: self as! CloseCmdArgs)
             case .closeAllWindowsButCurrent:
-                command = CloseAllWindowsButCurrentCommand(args: self as! CloseAllWindowsButCurrentCmdArgs)
+                command = CloseAllWindowsButCurrentCommand(
+                    args: self as! CloseAllWindowsButCurrentCmdArgs)
             case .config:
                 command = ConfigCommand(args: self as! ConfigCmdArgs)
             case .debugWindows:
@@ -60,6 +61,8 @@ extension CmdArgs {
                 command = MoveNodeToWorkspaceCommand(args: self as! MoveNodeToWorkspaceCmdArgs)
             case .moveWorkspaceToMonitor:
                 command = MoveWorkspaceToMonitorCommand(args: self as! MoveWorkspaceToMonitorCmdArgs)
+            case .noop:
+                command = NoopCommand(args: self as! NoopCmdArgs)
             case .reloadConfig:
                 command = ReloadConfigCommand(args: self as! ReloadConfigCmdArgs)
             case .resize:

--- a/Sources/AppBundle/command/impl/NoopCommand.swift
+++ b/Sources/AppBundle/command/impl/NoopCommand.swift
@@ -1,0 +1,11 @@
+import Common
+
+struct NoopCommand: Command {
+    let args: NoopCmdArgs
+
+    @MainActor
+    func run(_ env: CmdEnv, _ io: CmdIo) async throws -> Bool {
+        // No operation, so we indicate success.
+        return true
+    }
+}

--- a/Sources/AppBundle/command/impl/ReloadConfigCommand.swift
+++ b/Sources/AppBundle/command/impl/ReloadConfigCommand.swift
@@ -27,7 +27,6 @@ struct ReloadConfigCommand: Command {
     switch readConfig(forceConfigUrl: forceConfigUrl) {
         case .success(let (parsedConfig, url)):
             if !args.dryRun {
-                resetHotKeys()
                 config = parsedConfig
                 configUrl = url
                 activateMode(activeMode)

--- a/Sources/AppBundle/config/Config.swift
+++ b/Sources/AppBundle/config/Config.swift
@@ -1,6 +1,5 @@
 import AppKit
 import Common
-import HotKey
 
 func getDefaultConfigUrlFromProject() -> URL {
     var url = URL(filePath: #file)

--- a/Sources/AppBundle/config/HotkeyBinding.swift
+++ b/Sources/AppBundle/config/HotkeyBinding.swift
@@ -1,21 +1,12 @@
 import AppKit
 import Common
-
-// import Foundation // Common already imports Foundation
-// REMOVED: import HotKey // REMOVE: No longer using HotKey.Key or HotKey objects here
 import TOMLKit
-
-// Block of TODOs and old comments removed.
 
 @MainActor var activeMode: String? = mainModeId
 @MainActor func activateMode(_ targetMode: String?) {
     activeMode = targetMode
     GlobalHotkeyMonitor.shared.updateBindingsCache()
 }
-
-// Define GenericModifierType here if not accessible from keysMap.swift or for clarity
-// For now, assuming it's available from keysMap.swift via `import Common` or similar in consuming files
-// If not, it should be defined here or in a shared Common place.
 
 struct HotkeyBinding: Equatable, Sendable {
     let exactModifiers: Set<PhysicalModifierKey>
@@ -55,8 +46,6 @@ struct HotkeyBinding: Equatable, Sendable {
                 ? virtualKeyCodeToString(keyCode)
                 : sortedModifierString + "-" + virtualKeyCodeToString(keyCode)
     }
-
-    // REMOVED commented-out convenience init
 
     static func == (lhs: HotkeyBinding, rhs: HotkeyBinding) -> Bool {
         // Equality should primarily depend on the effective modifiers, keycode, and commands.

--- a/Sources/AppBundle/config/HotkeyBinding.swift
+++ b/Sources/AppBundle/config/HotkeyBinding.swift
@@ -1,6 +1,5 @@
 import AppKit
 import Common
-
 // import Foundation // Common already imports Foundation
 // import HotKey // REMOVE: No longer using HotKey.Key or HotKey objects here
 import TOMLKit
@@ -59,8 +58,8 @@ struct HotkeyBinding: Equatable, Sendable {
 
         self.descriptionWithKeyCode =
             sortedModifierString.isEmpty
-                ? virtualKeyCodeToString(keyCode)
-                : sortedModifierString + "-" + virtualKeyCodeToString(keyCode)
+            ? virtualKeyCodeToString(keyCode)
+            : sortedModifierString + "-" + virtualKeyCodeToString(keyCode)
     }
 
     // Convenience init for old structure, will be removed or refactored by parseBinding
@@ -78,6 +77,7 @@ struct HotkeyBinding: Equatable, Sendable {
             && lhs.keyCode == rhs.keyCode  // keyCode is part of descriptionWithKeyCode, but good to be explicit
             && lhs.exactModifiers == rhs.exactModifiers  // Explicit check
             && lhs.genericModifiers == rhs.genericModifiers  // Explicit check
+            && lhs.commands.count == rhs.commands.count  // Add count check
             && zip(lhs.commands, rhs.commands).allSatisfy { $0.equals($1) }  // Command equality
     }
 }
@@ -136,11 +136,9 @@ func parseBinding(_ raw: String, _ backtrace: TomlBacktrace, _ mapping: [String:
 
     var exactModifiers = Set<PhysicalModifierKey>()
     var genericModifiers = Set<GenericModifierType>()
-    var parsedModifierTokens: [String] = []
 
     for token in rawKeys.dropLast() {
         let tokenString = String(token)
-        parsedModifierTokens.append(tokenString)
         if let physicalMod = specificModifiersMap[tokenString] {
             guard !exactModifiers.contains(physicalMod) else {
                 return .failure(
@@ -171,10 +169,10 @@ func parseBinding(_ raw: String, _ backtrace: TomlBacktrace, _ mapping: [String:
     for genModType in genericModifiers {
         let specificCounterparts: Set<PhysicalModifierKey> =
             switch genModType {
-                case .option: [.leftOption, .rightOption]
-                case .command: [.leftCommand, .rightCommand]
-                case .control: [.leftControl, .rightControl]
-                case .shift: [.leftShift, .rightShift]
+            case .option: [.leftOption, .rightOption]
+            case .command: [.leftCommand, .rightCommand]
+            case .control: [.leftControl, .rightControl]
+            case .shift: [.leftShift, .rightShift]
             }
         if !exactModifiers.isDisjoint(with: specificCounterparts) {
             return .failure(
@@ -210,9 +208,9 @@ func parseBinding(_ raw: String, _ backtrace: TomlBacktrace, _ mapping: [String:
 private func exampleGenericToken(for type: GenericModifierType) -> String {
     // Return a common token for the generic type
     switch type {
-        case .option: return "alt"
-        case .command: return "cmd"
-        case .control: return "ctrl"
-        case .shift: return "shift"
+    case .option: return "alt"
+    case .command: return "cmd"
+    case .control: return "ctrl"
+    case .shift: return "shift"
     }
 }

--- a/Sources/AppBundle/config/HotkeyBinding.swift
+++ b/Sources/AppBundle/config/HotkeyBinding.swift
@@ -1,23 +1,15 @@
 import AppKit
 import Common
-
 // import Foundation // Common already imports Foundation
-// import HotKey // REMOVE: No longer using HotKey.Key or HotKey objects here
+// REMOVED: import HotKey // REMOVE: No longer using HotKey.Key or HotKey objects here
 import TOMLKit
 
-// TODO: Refactor hotkey management. This will be replaced by CGEventTap logic.
-// @MainActor private var hotkeys: [String: HotKey] = [:]
-
-// @MainActor func resetHotKeys() { // REMOVE THIS FUNCTION
-//     // TODO: Refactor hotkey management.
-//     print("TODO: resetHotKeys needs to be refactored for CGEventTap")
-// }
-
-// TODO: Refactor: HotKey extension will likely be removed.
+// Block of TODOs and old comments removed.
 
 @MainActor var activeMode: String? = mainModeId
 @MainActor func activateMode(_ targetMode: String?) {
     activeMode = targetMode
+    GlobalHotkeyMonitor.shared.updateBindingsCache()
 }
 
 // Define GenericModifierType here if not accessible from keysMap.swift or for clarity
@@ -59,17 +51,11 @@ struct HotkeyBinding: Equatable, Sendable {
 
         self.descriptionWithKeyCode =
             sortedModifierString.isEmpty
-                ? virtualKeyCodeToString(keyCode)
-                : sortedModifierString + "-" + virtualKeyCodeToString(keyCode)
+            ? virtualKeyCodeToString(keyCode)
+            : sortedModifierString + "-" + virtualKeyCodeToString(keyCode)
     }
 
-    // Convenience init for old structure, will be removed or refactored by parseBinding
-    // init(
-    //     _ specificModifiers: Set<PhysicalModifierKey>, _ keyCode: UInt16, _ commands: [any Command],
-    //     descriptionWithKeyNotation: String
-    // ) {
-    //     self.init(exactModifiers: specificModifiers, genericModifiers: [], keyCode: keyCode, commands: commands, descriptionWithKeyNotation: descriptionWithKeyNotation)
-    // }
+    // REMOVED commented-out convenience init
 
     static func == (lhs: HotkeyBinding, rhs: HotkeyBinding) -> Bool {
         // Equality should primarily depend on the effective modifiers, keycode, and commands.
@@ -170,10 +156,10 @@ func parseBinding(_ raw: String, _ backtrace: TomlBacktrace, _ mapping: [String:
     for genModType in genericModifiers {
         let specificCounterparts: Set<PhysicalModifierKey> =
             switch genModType {
-                case .option: [.leftOption, .rightOption]
-                case .command: [.leftCommand, .rightCommand]
-                case .control: [.leftControl, .rightControl]
-                case .shift: [.leftShift, .rightShift]
+            case .option: [.leftOption, .rightOption]
+            case .command: [.leftCommand, .rightCommand]
+            case .control: [.leftControl, .rightControl]
+            case .shift: [.leftShift, .rightShift]
             }
         if !exactModifiers.isDisjoint(with: specificCounterparts) {
             return .failure(
@@ -209,9 +195,9 @@ func parseBinding(_ raw: String, _ backtrace: TomlBacktrace, _ mapping: [String:
 private func exampleGenericToken(for type: GenericModifierType) -> String {
     // Return a common token for the generic type
     switch type {
-        case .option: return "alt"
-        case .command: return "cmd"
-        case .control: return "ctrl"
-        case .shift: return "shift"
+    case .option: return "alt"
+    case .command: return "cmd"
+    case .control: return "ctrl"
+    case .shift: return "shift"
     }
 }

--- a/Sources/AppBundle/config/HotkeyBinding.swift
+++ b/Sources/AppBundle/config/HotkeyBinding.swift
@@ -1,6 +1,5 @@
 import AppKit
 import Common
-
 // import Foundation // Common already imports Foundation
 // import HotKey // REMOVE: No longer using HotKey.Key or HotKey objects here
 import TOMLKit
@@ -59,8 +58,8 @@ struct HotkeyBinding: Equatable, Sendable {
 
         self.descriptionWithKeyCode =
             sortedModifierString.isEmpty
-                ? virtualKeyCodeToString(keyCode)
-                : sortedModifierString + "-" + virtualKeyCodeToString(keyCode)
+            ? virtualKeyCodeToString(keyCode)
+            : sortedModifierString + "-" + virtualKeyCodeToString(keyCode)
     }
 
     // Convenience init for old structure, will be removed or refactored by parseBinding
@@ -171,10 +170,10 @@ func parseBinding(_ raw: String, _ backtrace: TomlBacktrace, _ mapping: [String:
     for genModType in genericModifiers {
         let specificCounterparts: Set<PhysicalModifierKey> =
             switch genModType {
-                case .option: [.leftOption, .rightOption]
-                case .command: [.leftCommand, .rightCommand]
-                case .control: [.leftControl, .rightControl]
-                case .shift: [.leftShift, .rightShift]
+            case .option: [.leftOption, .rightOption]
+            case .command: [.leftCommand, .rightCommand]
+            case .control: [.leftControl, .rightControl]
+            case .shift: [.leftShift, .rightShift]
             }
         if !exactModifiers.isDisjoint(with: specificCounterparts) {
             return .failure(
@@ -210,9 +209,9 @@ func parseBinding(_ raw: String, _ backtrace: TomlBacktrace, _ mapping: [String:
 private func exampleGenericToken(for type: GenericModifierType) -> String {
     // Return a common token for the generic type
     switch type {
-        case .option: return "alt"
-        case .command: return "cmd"
-        case .control: return "ctrl"
-        case .shift: return "shift"
+    case .option: return "alt"
+    case .command: return "cmd"
+    case .control: return "ctrl"
+    case .shift: return "shift"
     }
 }

--- a/Sources/AppBundle/config/HotkeyBinding.swift
+++ b/Sources/AppBundle/config/HotkeyBinding.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Common
+
 // import Foundation // Common already imports Foundation
 // import HotKey // REMOVE: No longer using HotKey.Key or HotKey objects here
 import TOMLKit
@@ -58,8 +59,8 @@ struct HotkeyBinding: Equatable, Sendable {
 
         self.descriptionWithKeyCode =
             sortedModifierString.isEmpty
-            ? virtualKeyCodeToString(keyCode)
-            : sortedModifierString + "-" + virtualKeyCodeToString(keyCode)
+                ? virtualKeyCodeToString(keyCode)
+                : sortedModifierString + "-" + virtualKeyCodeToString(keyCode)
     }
 
     // Convenience init for old structure, will be removed or refactored by parseBinding
@@ -169,10 +170,10 @@ func parseBinding(_ raw: String, _ backtrace: TomlBacktrace, _ mapping: [String:
     for genModType in genericModifiers {
         let specificCounterparts: Set<PhysicalModifierKey> =
             switch genModType {
-            case .option: [.leftOption, .rightOption]
-            case .command: [.leftCommand, .rightCommand]
-            case .control: [.leftControl, .rightControl]
-            case .shift: [.leftShift, .rightShift]
+                case .option: [.leftOption, .rightOption]
+                case .command: [.leftCommand, .rightCommand]
+                case .control: [.leftControl, .rightControl]
+                case .shift: [.leftShift, .rightShift]
             }
         if !exactModifiers.isDisjoint(with: specificCounterparts) {
             return .failure(
@@ -208,9 +209,9 @@ func parseBinding(_ raw: String, _ backtrace: TomlBacktrace, _ mapping: [String:
 private func exampleGenericToken(for type: GenericModifierType) -> String {
     // Return a common token for the generic type
     switch type {
-    case .option: return "alt"
-    case .command: return "cmd"
-    case .control: return "ctrl"
-    case .shift: return "shift"
+        case .option: return "alt"
+        case .command: return "cmd"
+        case .control: return "ctrl"
+        case .shift: return "shift"
     }
 }

--- a/Sources/AppBundle/config/HotkeyBinding.swift
+++ b/Sources/AppBundle/config/HotkeyBinding.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Common
+
 // import Foundation // Common already imports Foundation
 // import HotKey // REMOVE: No longer using HotKey.Key or HotKey objects here
 import TOMLKit
@@ -58,8 +59,8 @@ struct HotkeyBinding: Equatable, Sendable {
 
         self.descriptionWithKeyCode =
             sortedModifierString.isEmpty
-            ? virtualKeyCodeToString(keyCode)
-            : sortedModifierString + "-" + virtualKeyCodeToString(keyCode)
+                ? virtualKeyCodeToString(keyCode)
+                : sortedModifierString + "-" + virtualKeyCodeToString(keyCode)
     }
 
     // Convenience init for old structure, will be removed or refactored by parseBinding
@@ -170,10 +171,10 @@ func parseBinding(_ raw: String, _ backtrace: TomlBacktrace, _ mapping: [String:
     for genModType in genericModifiers {
         let specificCounterparts: Set<PhysicalModifierKey> =
             switch genModType {
-            case .option: [.leftOption, .rightOption]
-            case .command: [.leftCommand, .rightCommand]
-            case .control: [.leftControl, .rightControl]
-            case .shift: [.leftShift, .rightShift]
+                case .option: [.leftOption, .rightOption]
+                case .command: [.leftCommand, .rightCommand]
+                case .control: [.leftControl, .rightControl]
+                case .shift: [.leftShift, .rightShift]
             }
         if !exactModifiers.isDisjoint(with: specificCounterparts) {
             return .failure(
@@ -209,9 +210,9 @@ func parseBinding(_ raw: String, _ backtrace: TomlBacktrace, _ mapping: [String:
 private func exampleGenericToken(for type: GenericModifierType) -> String {
     // Return a common token for the generic type
     switch type {
-    case .option: return "alt"
-    case .command: return "cmd"
-    case .control: return "ctrl"
-    case .shift: return "shift"
+        case .option: return "alt"
+        case .command: return "cmd"
+        case .control: return "ctrl"
+        case .shift: return "shift"
     }
 }

--- a/Sources/AppBundle/config/HotkeyBinding.swift
+++ b/Sources/AppBundle/config/HotkeyBinding.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Common
+
 // import Foundation // Common already imports Foundation
 // REMOVED: import HotKey // REMOVE: No longer using HotKey.Key or HotKey objects here
 import TOMLKit
@@ -51,8 +52,8 @@ struct HotkeyBinding: Equatable, Sendable {
 
         self.descriptionWithKeyCode =
             sortedModifierString.isEmpty
-            ? virtualKeyCodeToString(keyCode)
-            : sortedModifierString + "-" + virtualKeyCodeToString(keyCode)
+                ? virtualKeyCodeToString(keyCode)
+                : sortedModifierString + "-" + virtualKeyCodeToString(keyCode)
     }
 
     // REMOVED commented-out convenience init
@@ -156,10 +157,10 @@ func parseBinding(_ raw: String, _ backtrace: TomlBacktrace, _ mapping: [String:
     for genModType in genericModifiers {
         let specificCounterparts: Set<PhysicalModifierKey> =
             switch genModType {
-            case .option: [.leftOption, .rightOption]
-            case .command: [.leftCommand, .rightCommand]
-            case .control: [.leftControl, .rightControl]
-            case .shift: [.leftShift, .rightShift]
+                case .option: [.leftOption, .rightOption]
+                case .command: [.leftCommand, .rightCommand]
+                case .control: [.leftControl, .rightControl]
+                case .shift: [.leftShift, .rightShift]
             }
         if !exactModifiers.isDisjoint(with: specificCounterparts) {
             return .failure(
@@ -195,9 +196,9 @@ func parseBinding(_ raw: String, _ backtrace: TomlBacktrace, _ mapping: [String:
 private func exampleGenericToken(for type: GenericModifierType) -> String {
     // Return a common token for the generic type
     switch type {
-    case .option: return "alt"
-    case .command: return "cmd"
-    case .control: return "ctrl"
-    case .shift: return "shift"
+        case .option: return "alt"
+        case .command: return "cmd"
+        case .control: return "ctrl"
+        case .shift: return "shift"
     }
 }

--- a/Sources/AppBundle/config/Mode.swift
+++ b/Sources/AppBundle/config/Mode.swift
@@ -1,5 +1,6 @@
 import Common
-import HotKey
+
+// import HotKey // REMOVE
 import TOMLKit
 
 struct Mode: ConvenienceCopyable, Equatable, Sendable {
@@ -10,7 +11,7 @@ struct Mode: ConvenienceCopyable, Equatable, Sendable {
     static let zero = Mode(name: nil, bindings: [:])
 }
 
-func parseModes(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError], _ mapping: [String: Key]) -> [String: Mode] {
+func parseModes(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError], _ mapping: [String: UInt16]) -> [String: Mode] {
     guard let rawTable = raw.table else {
         errors += [expectedActualTypeError(expected: .table, actual: raw.type, backtrace)]
         return [:]
@@ -25,7 +26,7 @@ func parseModes(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ error
     return result
 }
 
-func parseMode(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError], _ mapping: [String: Key]) -> Mode {
+func parseMode(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError], _ mapping: [String: UInt16]) -> Mode {
     guard let rawTable: TOMLTable = raw.table else {
         errors += [expectedActualTypeError(expected: .table, actual: raw.type, backtrace)]
         return .zero

--- a/Sources/AppBundle/config/Mode.swift
+++ b/Sources/AppBundle/config/Mode.swift
@@ -1,6 +1,4 @@
 import Common
-
-// import HotKey // REMOVE
 import TOMLKit
 
 struct Mode: ConvenienceCopyable, Equatable, Sendable {
@@ -11,7 +9,10 @@ struct Mode: ConvenienceCopyable, Equatable, Sendable {
     static let zero = Mode(name: nil, bindings: [:])
 }
 
-func parseModes(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError], _ mapping: [String: UInt16]) -> [String: Mode] {
+func parseModes(
+    _ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError],
+    _ mapping: [String: UInt16]
+) -> [String: Mode] {
     guard let rawTable = raw.table else {
         errors += [expectedActualTypeError(expected: .table, actual: raw.type, backtrace)]
         return [:]
@@ -26,7 +27,10 @@ func parseModes(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ error
     return result
 }
 
-func parseMode(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError], _ mapping: [String: UInt16]) -> Mode {
+func parseMode(
+    _ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError],
+    _ mapping: [String: UInt16]
+) -> Mode {
     guard let rawTable: TOMLTable = raw.table else {
         errors += [expectedActualTypeError(expected: .table, actual: raw.type, backtrace)]
         return .zero

--- a/Sources/AppBundle/config/keysMap.swift
+++ b/Sources/AppBundle/config/keysMap.swift
@@ -161,10 +161,10 @@ enum VirtualKeyCodes {  // Using an enum namespace for clarity
 // func getKeysPreset(_ layout: KeyMapping.Preset) -> [String: Key] { // OLD
 func getKeysPreset(_ layout: KeyMapping.Preset) -> [String: UInt16] {  // NEW
     return switch layout {
-        // case .qwerty: keyNotationToKeyCode // OLD
-        case .qwerty: keyNotationToVirtualKeyCode  // NEW
-        case .dvorak: dvorakMap
-        case .colemak: colemakMap
+    // case .qwerty: keyNotationToKeyCode // OLD
+    case .qwerty: keyNotationToVirtualKeyCode  // NEW
+    case .dvorak: dvorakMap
+    case .colemak: colemakMap
     }
 }
 
@@ -351,30 +351,32 @@ private let colemakMap: [String: UInt16] =
         k: VirtualKeyCodes.n,
     ]
 
-let modifiersMap: [String: NSEvent.ModifierFlags] = [
-    "shift": .shift,
-    "alt": .option,
-    "ctrl": .control,
-    "cmd": .command,
-]
+// Dead code - this map was for the old NSEvent.ModifierFlags based system.
+// The new system uses PhysicalModifierKey and GenericModifierType.
+// let modifiersMap: [String: NSEvent.ModifierFlags] = [
+//     "shift": .shift,
+//     "alt": .option,
+//     "ctrl": .control,
+//     "cmd": .command,
+// ]
 
 // Added for specific modifier key handling
 enum PhysicalModifierKey: String, CaseIterable, Hashable, Sendable {
     case leftShift, rightShift, leftControl, rightControl, leftOption, rightOption, leftCommand,
-         rightCommand, function
+        rightCommand, function
 
     // Helper to get the string representation used in config files
     var configKey: String {
         switch self {
-            case .leftShift: "lshift"
-            case .rightShift: "rshift"
-            case .leftControl: "lctrl"
-            case .rightControl: "rctrl"
-            case .leftOption: "lalt"
-            case .rightOption: "ralt"
-            case .leftCommand: "lcmd"
-            case .rightCommand: "rcmd"
-            case .function: "fn"
+        case .leftShift: "lshift"
+        case .rightShift: "rshift"
+        case .leftControl: "lctrl"
+        case .rightControl: "rctrl"
+        case .leftOption: "lalt"
+        case .rightOption: "ralt"
+        case .leftCommand: "lcmd"
+        case .rightCommand: "rcmd"
+        case .function: "fn"
         }
     }
 }
@@ -427,7 +429,7 @@ extension NSEvent.ModifierFlags {
 extension Set<PhysicalModifierKey> {
     func toString() -> String {
         // Sort to ensure consistent order for descriptions, e.g., cmd-ctrl-shift
-        self.sorted(by: { $0.rawValue < $1.rawValue }).map { $0.configKey }.joined(separator: "-")
+        self.sorted(by: { $0.configKey < $1.configKey }).map { $0.configKey }.joined(separator: "-")
     }
 }
 
@@ -441,8 +443,8 @@ func virtualKeyCodeToString(_ keyCode: UInt16) -> String {
     }
     // Fallback for less common keys or if not in the map
     switch keyCode {
-        case VirtualKeyCodes.a: return "a"
-        // ... add more cases as needed for complete coverage for descriptions
-        default: return "keyCode_0x" + String(keyCode, radix: 16)
+    case VirtualKeyCodes.a: return "a"
+    // ... add more cases as needed for complete coverage for descriptions
+    default: return "keyCode_0x" + String(keyCode, radix: 16)
     }
 }

--- a/Sources/AppBundle/config/keysMap.swift
+++ b/Sources/AppBundle/config/keysMap.swift
@@ -1,8 +1,6 @@
 import AppKit
 import Common
 
-// import HotKey // Will be removed if Key type is fully replaced
-
 private let minus = "minus"
 private let equal = "equal"
 
@@ -158,22 +156,16 @@ enum VirtualKeyCodes {  // Using an enum namespace for clarity
     // Help/Insert is 0x72, but often remapped
 }
 
-// func getKeysPreset(_ layout: KeyMapping.Preset) -> [String: Key] { // OLD
-func getKeysPreset(_ layout: KeyMapping.Preset) -> [String: UInt16] {  // NEW
+func getKeysPreset(_ layout: KeyMapping.Preset) -> [String: UInt16] {
     return switch layout {
-        // case .qwerty: keyNotationToKeyCode // OLD
-        case .qwerty: keyNotationToVirtualKeyCode  // NEW
+        case .qwerty: keyNotationToVirtualKeyCode
         case .dvorak: dvorakMap
         case .colemak: colemakMap
     }
 }
 
-// extension Key: @unchecked @retroactive Sendable {} // This comes from HotKey, remove if HotKey is fully removed
-
-// let keyNotationToKeyCode: [String: Key] = [ // OLD
-let keyNotationToVirtualKeyCode: [String: UInt16] = [  // NEW
-    // sectionSign: .section, // OLD Key enum
-    sectionSign: VirtualKeyCodes.section,  // NEW UInt16
+let keyNotationToVirtualKeyCode: [String: UInt16] = [
+    sectionSign: VirtualKeyCodes.section,
     "0": VirtualKeyCodes._0,
     "1": VirtualKeyCodes._1,
     "2": VirtualKeyCodes._2,
@@ -286,9 +278,8 @@ let keyNotationToVirtualKeyCode: [String: UInt16] = [  // NEW
     "right": VirtualKeyCodes.rightArrow,
 ]
 
-// private let dvorakMap: [String: Key] = keyNotationToKeyCode + [ // OLD
 private let dvorakMap: [String: UInt16] =
-    keyNotationToVirtualKeyCode + [  // NEW
+    keyNotationToVirtualKeyCode + [
         leftSquareBracket: VirtualKeyCodes.minus,
         rightSquareBracket: VirtualKeyCodes.equal,
 
@@ -329,9 +320,8 @@ private let dvorakMap: [String: UInt16] =
         z: VirtualKeyCodes.slash,
     ]
 
-// private let colemakMap: [String: Key] = keyNotationToKeyCode + [ // OLD
 private let colemakMap: [String: UInt16] =
-    keyNotationToVirtualKeyCode + [  // NEW
+    keyNotationToVirtualKeyCode + [
         f: VirtualKeyCodes.e,
         p: VirtualKeyCodes.r,
         g: VirtualKeyCodes.t,

--- a/Sources/AppBundle/config/keysMap.swift
+++ b/Sources/AppBundle/config/keysMap.swift
@@ -161,10 +161,10 @@ enum VirtualKeyCodes {  // Using an enum namespace for clarity
 // func getKeysPreset(_ layout: KeyMapping.Preset) -> [String: Key] { // OLD
 func getKeysPreset(_ layout: KeyMapping.Preset) -> [String: UInt16] {  // NEW
     return switch layout {
-    // case .qwerty: keyNotationToKeyCode // OLD
-    case .qwerty: keyNotationToVirtualKeyCode  // NEW
-    case .dvorak: dvorakMap
-    case .colemak: colemakMap
+        // case .qwerty: keyNotationToKeyCode // OLD
+        case .qwerty: keyNotationToVirtualKeyCode  // NEW
+        case .dvorak: dvorakMap
+        case .colemak: colemakMap
     }
 }
 
@@ -363,20 +363,20 @@ private let colemakMap: [String: UInt16] =
 // Added for specific modifier key handling
 enum PhysicalModifierKey: String, CaseIterable, Hashable, Sendable {
     case leftShift, rightShift, leftControl, rightControl, leftOption, rightOption, leftCommand,
-        rightCommand, function
+         rightCommand, function
 
     // Helper to get the string representation used in config files
     var configKey: String {
         switch self {
-        case .leftShift: "lshift"
-        case .rightShift: "rshift"
-        case .leftControl: "lctrl"
-        case .rightControl: "rctrl"
-        case .leftOption: "lalt"
-        case .rightOption: "ralt"
-        case .leftCommand: "lcmd"
-        case .rightCommand: "rcmd"
-        case .function: "fn"
+            case .leftShift: "lshift"
+            case .rightShift: "rshift"
+            case .leftControl: "lctrl"
+            case .rightControl: "rctrl"
+            case .leftOption: "lalt"
+            case .rightOption: "ralt"
+            case .leftCommand: "lcmd"
+            case .rightCommand: "rcmd"
+            case .function: "fn"
         }
     }
 }
@@ -443,8 +443,8 @@ func virtualKeyCodeToString(_ keyCode: UInt16) -> String {
     }
     // Fallback for less common keys or if not in the map
     switch keyCode {
-    case VirtualKeyCodes.a: return "a"
-    // ... add more cases as needed for complete coverage for descriptions
-    default: return "keyCode_0x" + String(keyCode, radix: 16)
+        case VirtualKeyCodes.a: return "a"
+        // ... add more cases as needed for complete coverage for descriptions
+        default: return "keyCode_0x" + String(keyCode, radix: 16)
     }
 }

--- a/Sources/AppBundle/config/keysMap.swift
+++ b/Sources/AppBundle/config/keysMap.swift
@@ -45,7 +45,7 @@ private let period = "period"
 private let slash = "slash"
 
 // Define virtual key codes (subset, expand as needed based on keyNotationToKeyCode)
-enum VirtualKeyCodes { // Using an enum namespace for clarity
+enum VirtualKeyCodes {  // Using an enum namespace for clarity
     static let a: UInt16 = 0x00
     static let s: UInt16 = 0x01
     static let d: UInt16 = 0x02
@@ -57,7 +57,7 @@ enum VirtualKeyCodes { // Using an enum namespace for clarity
     static let c: UInt16 = 0x08
     static let v: UInt16 = 0x09
     // sectionSign for ISO layout
-    static let section: UInt16 = 0x0A // Or grave for ANSI on some mappings
+    static let section: UInt16 = 0x0A  // Or grave for ANSI on some mappings
     static let b: UInt16 = 0x0B
     static let q: UInt16 = 0x0C
     static let w: UInt16 = 0x0D
@@ -77,30 +77,30 @@ enum VirtualKeyCodes { // Using an enum namespace for clarity
     static let minus: UInt16 = 0x1B
     static let _8: UInt16 = 0x1C
     static let _0: UInt16 = 0x1D
-    static let rightBracket: UInt16 = 0x1E // ]
+    static let rightBracket: UInt16 = 0x1E  // ]
     static let o: UInt16 = 0x1F
     static let u: UInt16 = 0x20
     static let leftBracket: UInt16 = 0x21  // [
     static let i: UInt16 = 0x22
     static let p: UInt16 = 0x23
-    static let enter: UInt16 = 0x24       // Primary Enter/Return
+    static let enter: UInt16 = 0x24  // Primary Enter/Return
     static let l: UInt16 = 0x25
     static let j: UInt16 = 0x26
-    static let quote: UInt16 = 0x27       // '
+    static let quote: UInt16 = 0x27  // '
     static let k: UInt16 = 0x28
-    static let semicolon: UInt16 = 0x29   // ;
-    static let backslash: UInt16 = 0x2A   // \
-    static let comma: UInt16 = 0x2B       // ,
-    static let slash: UInt16 = 0x2C       // /
+    static let semicolon: UInt16 = 0x29  // ;
+    static let backslash: UInt16 = 0x2A  // \
+    static let comma: UInt16 = 0x2B  // ,
+    static let slash: UInt16 = 0x2C  // /
     static let n: UInt16 = 0x2D
     static let m: UInt16 = 0x2E
-    static let period: UInt16 = 0x2F      // .
+    static let period: UInt16 = 0x2F  // .
     static let tab: UInt16 = 0x30
     static let space: UInt16 = 0x31
-    static let grave: UInt16 = 0x32       // ` / ~ (ANSI) , or § / ± (ISO)
+    static let grave: UInt16 = 0x32  // ` / ~ (ANSI) , or § / ± (ISO)
     // For sectionSign, some use 0x0A. Let's stick to 0x32 for grave/backtick common on ANSI
     // and handle sectionSign separately if needed via specific mapping.
-    static let backspace: UInt16 = 0x33   // Delete (Backspace)
+    static let backspace: UInt16 = 0x33  // Delete (Backspace)
     // static let enterPowerbook: UInt16 = 0x34 // Less common
     static let escape: UInt16 = 0x35
     // Modifier key codes are handled by physicalModifierKeyToKeyCode
@@ -108,7 +108,7 @@ enum VirtualKeyCodes { // Using an enum namespace for clarity
     static let keypadDecimal: UInt16 = 0x41
     static let keypadMultiply: UInt16 = 0x43
     static let keypadPlus: UInt16 = 0x45
-    static let keypadClear: UInt16 = 0x47    // Num Lock on some
+    static let keypadClear: UInt16 = 0x47  // Num Lock on some
     static let keypadDivide: UInt16 = 0x4B
     static let keypadEnter: UInt16 = 0x4C
     static let keypadMinus: UInt16 = 0x4E
@@ -147,7 +147,7 @@ enum VirtualKeyCodes { // Using an enum namespace for clarity
 
     static let home: UInt16 = 0x73
     static let pageUp: UInt16 = 0x74
-    static let forwardDelete: UInt16 = 0x75 // Del key below Help
+    static let forwardDelete: UInt16 = 0x75  // Del key below Help
     static let end: UInt16 = 0x77
     static let pageDown: UInt16 = 0x79
 
@@ -159,10 +159,10 @@ enum VirtualKeyCodes { // Using an enum namespace for clarity
 }
 
 // func getKeysPreset(_ layout: KeyMapping.Preset) -> [String: Key] { // OLD
-func getKeysPreset(_ layout: KeyMapping.Preset) -> [String: UInt16] { // NEW
+func getKeysPreset(_ layout: KeyMapping.Preset) -> [String: UInt16] {  // NEW
     return switch layout {
         // case .qwerty: keyNotationToKeyCode // OLD
-        case .qwerty: keyNotationToVirtualKeyCode // NEW
+        case .qwerty: keyNotationToVirtualKeyCode  // NEW
         case .dvorak: dvorakMap
         case .colemak: colemakMap
     }
@@ -171,9 +171,9 @@ func getKeysPreset(_ layout: KeyMapping.Preset) -> [String: UInt16] { // NEW
 // extension Key: @unchecked @retroactive Sendable {} // This comes from HotKey, remove if HotKey is fully removed
 
 // let keyNotationToKeyCode: [String: Key] = [ // OLD
-let keyNotationToVirtualKeyCode: [String: UInt16] = [ // NEW
+let keyNotationToVirtualKeyCode: [String: UInt16] = [  // NEW
     // sectionSign: .section, // OLD Key enum
-    sectionSign: VirtualKeyCodes.section, // NEW UInt16
+    sectionSign: VirtualKeyCodes.section,  // NEW UInt16
     "0": VirtualKeyCodes._0,
     "1": VirtualKeyCodes._1,
     "2": VirtualKeyCodes._2,
@@ -270,7 +270,7 @@ let keyNotationToVirtualKeyCode: [String: UInt16] = [ // NEW
     "f19": VirtualKeyCodes.f19,
     "f20": VirtualKeyCodes.f20,
 
-    "backtick": VirtualKeyCodes.grave, // For ANSI layout, grave is 0x32. Section sign is 0x0A for ISO.
+    "backtick": VirtualKeyCodes.grave,  // For ANSI layout, grave is 0x32. Section sign is 0x0A for ISO.
     // The original HotKey.Key.grave might map to 0x32 (kVK_ANSI_Grave)
     // HotKey.Key.section maps to 0x0A (kVK_ISO_Section)
     // For simplicity, "backtick" maps to ANSI grave. "sectionSign" handles ISO.
@@ -287,67 +287,69 @@ let keyNotationToVirtualKeyCode: [String: UInt16] = [ // NEW
 ]
 
 // private let dvorakMap: [String: Key] = keyNotationToKeyCode + [ // OLD
-private let dvorakMap: [String: UInt16] = keyNotationToVirtualKeyCode + [ // NEW
-    leftSquareBracket: VirtualKeyCodes.minus,
-    rightSquareBracket: VirtualKeyCodes.equal,
+private let dvorakMap: [String: UInt16] =
+    keyNotationToVirtualKeyCode + [  // NEW
+        leftSquareBracket: VirtualKeyCodes.minus,
+        rightSquareBracket: VirtualKeyCodes.equal,
 
-    quote: VirtualKeyCodes.q,
-    comma: VirtualKeyCodes.w,
-    period: VirtualKeyCodes.e,
-    p: VirtualKeyCodes.r,
-    y: VirtualKeyCodes.t,
-    f: VirtualKeyCodes.y,
-    g: VirtualKeyCodes.u,
-    c: VirtualKeyCodes.i,
-    r: VirtualKeyCodes.o,
-    l: VirtualKeyCodes.p,
-    slash: VirtualKeyCodes.leftBracket,
-    equal: VirtualKeyCodes.rightBracket,
-    backslash: VirtualKeyCodes.backslash,
+        quote: VirtualKeyCodes.q,
+        comma: VirtualKeyCodes.w,
+        period: VirtualKeyCodes.e,
+        p: VirtualKeyCodes.r,
+        y: VirtualKeyCodes.t,
+        f: VirtualKeyCodes.y,
+        g: VirtualKeyCodes.u,
+        c: VirtualKeyCodes.i,
+        r: VirtualKeyCodes.o,
+        l: VirtualKeyCodes.p,
+        slash: VirtualKeyCodes.leftBracket,
+        equal: VirtualKeyCodes.rightBracket,
+        backslash: VirtualKeyCodes.backslash,
 
-    a: VirtualKeyCodes.a,
-    o: VirtualKeyCodes.s,
-    e: VirtualKeyCodes.d,
-    u: VirtualKeyCodes.f,
-    i: VirtualKeyCodes.g,
-    d: VirtualKeyCodes.h,
-    h: VirtualKeyCodes.j,
-    t: VirtualKeyCodes.k,
-    n: VirtualKeyCodes.l,
-    s: VirtualKeyCodes.semicolon,
-    minus: VirtualKeyCodes.quote,
+        a: VirtualKeyCodes.a,
+        o: VirtualKeyCodes.s,
+        e: VirtualKeyCodes.d,
+        u: VirtualKeyCodes.f,
+        i: VirtualKeyCodes.g,
+        d: VirtualKeyCodes.h,
+        h: VirtualKeyCodes.j,
+        t: VirtualKeyCodes.k,
+        n: VirtualKeyCodes.l,
+        s: VirtualKeyCodes.semicolon,
+        minus: VirtualKeyCodes.quote,
 
-    semicolon: VirtualKeyCodes.z,
-    q: VirtualKeyCodes.x,
-    j: VirtualKeyCodes.c,
-    k: VirtualKeyCodes.v,
-    x: VirtualKeyCodes.b,
-    b: VirtualKeyCodes.n,
-    w: VirtualKeyCodes.comma,
-    v: VirtualKeyCodes.period,
-    z: VirtualKeyCodes.slash,
-]
+        semicolon: VirtualKeyCodes.z,
+        q: VirtualKeyCodes.x,
+        j: VirtualKeyCodes.c,
+        k: VirtualKeyCodes.v,
+        x: VirtualKeyCodes.b,
+        b: VirtualKeyCodes.n,
+        w: VirtualKeyCodes.comma,
+        v: VirtualKeyCodes.period,
+        z: VirtualKeyCodes.slash,
+    ]
 
 // private let colemakMap: [String: Key] = keyNotationToKeyCode + [ // OLD
-private let colemakMap: [String: UInt16] = keyNotationToVirtualKeyCode + [ // NEW
-    f: VirtualKeyCodes.e,
-    p: VirtualKeyCodes.r,
-    g: VirtualKeyCodes.t,
-    j: VirtualKeyCodes.y,
-    l: VirtualKeyCodes.u,
-    u: VirtualKeyCodes.i,
-    y: VirtualKeyCodes.o,
-    semicolon: VirtualKeyCodes.p,
-    r: VirtualKeyCodes.s,
-    s: VirtualKeyCodes.d,
-    t: VirtualKeyCodes.f,
-    d: VirtualKeyCodes.g,
-    n: VirtualKeyCodes.j,
-    e: VirtualKeyCodes.k,
-    i: VirtualKeyCodes.l,
-    o: VirtualKeyCodes.semicolon,
-    k: VirtualKeyCodes.n,
-]
+private let colemakMap: [String: UInt16] =
+    keyNotationToVirtualKeyCode + [  // NEW
+        f: VirtualKeyCodes.e,
+        p: VirtualKeyCodes.r,
+        g: VirtualKeyCodes.t,
+        j: VirtualKeyCodes.y,
+        l: VirtualKeyCodes.u,
+        u: VirtualKeyCodes.i,
+        y: VirtualKeyCodes.o,
+        semicolon: VirtualKeyCodes.p,
+        r: VirtualKeyCodes.s,
+        s: VirtualKeyCodes.d,
+        t: VirtualKeyCodes.f,
+        d: VirtualKeyCodes.g,
+        n: VirtualKeyCodes.j,
+        e: VirtualKeyCodes.k,
+        i: VirtualKeyCodes.l,
+        o: VirtualKeyCodes.semicolon,
+        k: VirtualKeyCodes.n,
+    ]
 
 let modifiersMap: [String: NSEvent.ModifierFlags] = [
     "shift": .shift,
@@ -358,7 +360,8 @@ let modifiersMap: [String: NSEvent.ModifierFlags] = [
 
 // Added for specific modifier key handling
 enum PhysicalModifierKey: String, CaseIterable, Hashable, Sendable {
-    case leftShift, rightShift, leftControl, rightControl, leftOption, rightOption, leftCommand, rightCommand, function
+    case leftShift, rightShift, leftControl, rightControl, leftOption, rightOption, leftCommand,
+         rightCommand, function
 
     // Helper to get the string representation used in config files
     var configKey: String {
@@ -376,13 +379,31 @@ enum PhysicalModifierKey: String, CaseIterable, Hashable, Sendable {
     }
 }
 
-let specificModifiersMap: [String: PhysicalModifierKey] = PhysicalModifierKey.allCases.reduce(into: [:]) { result, key in
-    result[key.configKey] = key
-    // Add alternative generic keys if desired, e.g., map "alt" to LeftOption as a default or a special "either" type
-    // For now, keeping it strict to specific modifiers.
-    // Example for also allowing generic "alt":
-    // if key == .leftOption { result["alt"] = key } // Or handle "alt" to mean "leftOption OR rightOption"
+// Explicitly define the map with all keys for robustness, especially in test environments
+let specificModifiersMap: [String: PhysicalModifierKey] = [
+    // Specific left/right
+    PhysicalModifierKey.leftShift.configKey: .leftShift,
+    PhysicalModifierKey.rightShift.configKey: .rightShift,
+    PhysicalModifierKey.leftControl.configKey: .leftControl,
+    PhysicalModifierKey.rightControl.configKey: .rightControl,
+    PhysicalModifierKey.leftOption.configKey: .leftOption,
+    PhysicalModifierKey.rightOption.configKey: .rightOption,
+    PhysicalModifierKey.leftCommand.configKey: .leftCommand,
+    PhysicalModifierKey.rightCommand.configKey: .rightCommand,
+    PhysicalModifierKey.function.configKey: .function,
+]
+
+// New: For generic modifier parsing
+enum GenericModifierType: String, CaseIterable, Hashable, Sendable {
+    case option, command, control, shift
 }
+
+let genericModifiersMap: [String: GenericModifierType] = [
+    "alt": .option, "option": .option,
+    "cmd": .command, "command": .command,
+    "ctrl": .control, "control": .control,
+    "shift": .shift,
+]
 
 let physicalModifierKeyToKeyCode: [PhysicalModifierKey: UInt16] = [
     .leftShift: 0x38, .rightShift: 0x3C,

--- a/Sources/AppBundle/config/keysMap.swift
+++ b/Sources/AppBundle/config/keysMap.swift
@@ -161,10 +161,10 @@ enum VirtualKeyCodes {  // Using an enum namespace for clarity
 // func getKeysPreset(_ layout: KeyMapping.Preset) -> [String: Key] { // OLD
 func getKeysPreset(_ layout: KeyMapping.Preset) -> [String: UInt16] {  // NEW
     return switch layout {
-    // case .qwerty: keyNotationToKeyCode // OLD
-    case .qwerty: keyNotationToVirtualKeyCode  // NEW
-    case .dvorak: dvorakMap
-    case .colemak: colemakMap
+        // case .qwerty: keyNotationToKeyCode // OLD
+        case .qwerty: keyNotationToVirtualKeyCode  // NEW
+        case .dvorak: dvorakMap
+        case .colemak: colemakMap
     }
 }
 
@@ -361,20 +361,20 @@ let modifiersMap: [String: NSEvent.ModifierFlags] = [
 // Added for specific modifier key handling
 enum PhysicalModifierKey: String, CaseIterable, Hashable, Sendable {
     case leftShift, rightShift, leftControl, rightControl, leftOption, rightOption, leftCommand,
-        rightCommand, function
+         rightCommand, function
 
     // Helper to get the string representation used in config files
     var configKey: String {
         switch self {
-        case .leftShift: "lshift"
-        case .rightShift: "rshift"
-        case .leftControl: "lctrl"
-        case .rightControl: "rctrl"
-        case .leftOption: "lalt"
-        case .rightOption: "ralt"
-        case .leftCommand: "lcmd"
-        case .rightCommand: "rcmd"
-        case .function: "fn"
+            case .leftShift: "lshift"
+            case .rightShift: "rshift"
+            case .leftControl: "lctrl"
+            case .rightControl: "rctrl"
+            case .leftOption: "lalt"
+            case .rightOption: "ralt"
+            case .leftCommand: "lcmd"
+            case .rightCommand: "rcmd"
+            case .function: "fn"
         }
     }
 }
@@ -441,8 +441,8 @@ func virtualKeyCodeToString(_ keyCode: UInt16) -> String {
     }
     // Fallback for less common keys or if not in the map
     switch keyCode {
-    case VirtualKeyCodes.a: return "a"
-    // ... add more cases as needed for complete coverage for descriptions
-    default: return "keyCode_0x" + String(keyCode, radix: 16)
+        case VirtualKeyCodes.a: return "a"
+        // ... add more cases as needed for complete coverage for descriptions
+        default: return "keyCode_0x" + String(keyCode, radix: 16)
     }
 }

--- a/Sources/AppBundle/config/keysMap.swift
+++ b/Sources/AppBundle/config/keysMap.swift
@@ -438,3 +438,17 @@ func virtualKeyCodeToString(_ keyCode: UInt16) -> String {
         default: return "keyCode_0x" + String(keyCode, radix: 16)
     }
 }
+
+// Extension moved from GlobalHotkeyMonitor.swift
+// This makes the utility available to any other component that needs it.
+extension PhysicalModifierKey {
+    var genericType: GenericModifierType? {
+        switch self {
+            case .leftOption, .rightOption: return .option
+            case .leftCommand, .rightCommand: return .command
+            case .leftControl, .rightControl: return .control
+            case .leftShift, .rightShift: return .shift
+            case .function: return nil  // Fn is always specific
+        }
+    }
+}

--- a/Sources/AppBundle/config/keysMap.swift
+++ b/Sources/AppBundle/config/keysMap.swift
@@ -161,10 +161,10 @@ enum VirtualKeyCodes {  // Using an enum namespace for clarity
 // func getKeysPreset(_ layout: KeyMapping.Preset) -> [String: Key] { // OLD
 func getKeysPreset(_ layout: KeyMapping.Preset) -> [String: UInt16] {  // NEW
     return switch layout {
-        // case .qwerty: keyNotationToKeyCode // OLD
-        case .qwerty: keyNotationToVirtualKeyCode  // NEW
-        case .dvorak: dvorakMap
-        case .colemak: colemakMap
+    // case .qwerty: keyNotationToKeyCode // OLD
+    case .qwerty: keyNotationToVirtualKeyCode  // NEW
+    case .dvorak: dvorakMap
+    case .colemak: colemakMap
     }
 }
 
@@ -361,20 +361,20 @@ let modifiersMap: [String: NSEvent.ModifierFlags] = [
 // Added for specific modifier key handling
 enum PhysicalModifierKey: String, CaseIterable, Hashable, Sendable {
     case leftShift, rightShift, leftControl, rightControl, leftOption, rightOption, leftCommand,
-         rightCommand, function
+        rightCommand, function
 
     // Helper to get the string representation used in config files
     var configKey: String {
         switch self {
-            case .leftShift: "lshift"
-            case .rightShift: "rshift"
-            case .leftControl: "lctrl"
-            case .rightControl: "rctrl"
-            case .leftOption: "lalt"
-            case .rightOption: "ralt"
-            case .leftCommand: "lcmd"
-            case .rightCommand: "rcmd"
-            case .function: "fn"
+        case .leftShift: "lshift"
+        case .rightShift: "rshift"
+        case .leftControl: "lctrl"
+        case .rightControl: "rctrl"
+        case .leftOption: "lalt"
+        case .rightOption: "ralt"
+        case .leftCommand: "lcmd"
+        case .rightCommand: "rcmd"
+        case .function: "fn"
         }
     }
 }
@@ -441,8 +441,8 @@ func virtualKeyCodeToString(_ keyCode: UInt16) -> String {
     }
     // Fallback for less common keys or if not in the map
     switch keyCode {
-        case VirtualKeyCodes.a: return "a"
-        // ... add more cases as needed for complete coverage for descriptions
-        default: return "keyCode_0x" + String(keyCode, radix: 16)
+    case VirtualKeyCodes.a: return "a"
+    // ... add more cases as needed for complete coverage for descriptions
+    default: return "keyCode_0x" + String(keyCode, radix: 16)
     }
 }

--- a/Sources/AppBundle/config/keysMap.swift
+++ b/Sources/AppBundle/config/keysMap.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Common
-import HotKey
+
+// import HotKey // Will be removed if Key type is fully replaced
 
 private let minus = "minus"
 private let equal = "equal"
@@ -43,206 +44,309 @@ private let comma = "comma"
 private let period = "period"
 private let slash = "slash"
 
-func getKeysPreset(_ layout: KeyMapping.Preset) -> [String: Key] {
+// Define virtual key codes (subset, expand as needed based on keyNotationToKeyCode)
+enum VirtualKeyCodes { // Using an enum namespace for clarity
+    static let a: UInt16 = 0x00
+    static let s: UInt16 = 0x01
+    static let d: UInt16 = 0x02
+    static let f: UInt16 = 0x03
+    static let h: UInt16 = 0x04
+    static let g: UInt16 = 0x05
+    static let z: UInt16 = 0x06
+    static let x: UInt16 = 0x07
+    static let c: UInt16 = 0x08
+    static let v: UInt16 = 0x09
+    // sectionSign for ISO layout
+    static let section: UInt16 = 0x0A // Or grave for ANSI on some mappings
+    static let b: UInt16 = 0x0B
+    static let q: UInt16 = 0x0C
+    static let w: UInt16 = 0x0D
+    static let e: UInt16 = 0x0E
+    static let r: UInt16 = 0x0F
+    static let y: UInt16 = 0x10
+    static let t: UInt16 = 0x11
+    static let _1: UInt16 = 0x12
+    static let _2: UInt16 = 0x13
+    static let _3: UInt16 = 0x14
+    static let _4: UInt16 = 0x15
+    static let _6: UInt16 = 0x16
+    static let _5: UInt16 = 0x17
+    static let equal: UInt16 = 0x18
+    static let _9: UInt16 = 0x19
+    static let _7: UInt16 = 0x1A
+    static let minus: UInt16 = 0x1B
+    static let _8: UInt16 = 0x1C
+    static let _0: UInt16 = 0x1D
+    static let rightBracket: UInt16 = 0x1E // ]
+    static let o: UInt16 = 0x1F
+    static let u: UInt16 = 0x20
+    static let leftBracket: UInt16 = 0x21  // [
+    static let i: UInt16 = 0x22
+    static let p: UInt16 = 0x23
+    static let enter: UInt16 = 0x24       // Primary Enter/Return
+    static let l: UInt16 = 0x25
+    static let j: UInt16 = 0x26
+    static let quote: UInt16 = 0x27       // '
+    static let k: UInt16 = 0x28
+    static let semicolon: UInt16 = 0x29   // ;
+    static let backslash: UInt16 = 0x2A   // \
+    static let comma: UInt16 = 0x2B       // ,
+    static let slash: UInt16 = 0x2C       // /
+    static let n: UInt16 = 0x2D
+    static let m: UInt16 = 0x2E
+    static let period: UInt16 = 0x2F      // .
+    static let tab: UInt16 = 0x30
+    static let space: UInt16 = 0x31
+    static let grave: UInt16 = 0x32       // ` / ~ (ANSI) , or § / ± (ISO)
+    // For sectionSign, some use 0x0A. Let's stick to 0x32 for grave/backtick common on ANSI
+    // and handle sectionSign separately if needed via specific mapping.
+    static let backspace: UInt16 = 0x33   // Delete (Backspace)
+    // static let enterPowerbook: UInt16 = 0x34 // Less common
+    static let escape: UInt16 = 0x35
+    // Modifier key codes are handled by physicalModifierKeyToKeyCode
+
+    static let keypadDecimal: UInt16 = 0x41
+    static let keypadMultiply: UInt16 = 0x43
+    static let keypadPlus: UInt16 = 0x45
+    static let keypadClear: UInt16 = 0x47    // Num Lock on some
+    static let keypadDivide: UInt16 = 0x4B
+    static let keypadEnter: UInt16 = 0x4C
+    static let keypadMinus: UInt16 = 0x4E
+    static let keypadEquals: UInt16 = 0x51
+    static let keypad0: UInt16 = 0x52
+    static let keypad1: UInt16 = 0x53
+    static let keypad2: UInt16 = 0x54
+    static let keypad3: UInt16 = 0x55
+    static let keypad4: UInt16 = 0x56
+    static let keypad5: UInt16 = 0x57
+    static let keypad6: UInt16 = 0x58
+    static let keypad7: UInt16 = 0x59
+    static let keypad8: UInt16 = 0x5B
+    static let keypad9: UInt16 = 0x5C
+
+    static let f1: UInt16 = 0x7A
+    static let f2: UInt16 = 0x78
+    static let f3: UInt16 = 0x63
+    static let f4: UInt16 = 0x76
+    static let f5: UInt16 = 0x60
+    static let f6: UInt16 = 0x61
+    static let f7: UInt16 = 0x62
+    static let f8: UInt16 = 0x64
+    static let f9: UInt16 = 0x65
+    static let f10: UInt16 = 0x6D
+    static let f11: UInt16 = 0x67
+    static let f12: UInt16 = 0x6F
+    static let f13: UInt16 = 0x69
+    static let f14: UInt16 = 0x6B
+    static let f15: UInt16 = 0x71
+    static let f16: UInt16 = 0x6A
+    static let f17: UInt16 = 0x40
+    static let f18: UInt16 = 0x4F
+    static let f19: UInt16 = 0x50
+    static let f20: UInt16 = 0x5A
+
+    static let home: UInt16 = 0x73
+    static let pageUp: UInt16 = 0x74
+    static let forwardDelete: UInt16 = 0x75 // Del key below Help
+    static let end: UInt16 = 0x77
+    static let pageDown: UInt16 = 0x79
+
+    static let leftArrow: UInt16 = 0x7B
+    static let rightArrow: UInt16 = 0x7C
+    static let downArrow: UInt16 = 0x7D
+    static let upArrow: UInt16 = 0x7E
+    // Help/Insert is 0x72, but often remapped
+}
+
+// func getKeysPreset(_ layout: KeyMapping.Preset) -> [String: Key] { // OLD
+func getKeysPreset(_ layout: KeyMapping.Preset) -> [String: UInt16] { // NEW
     return switch layout {
-        case .qwerty: keyNotationToKeyCode
+        // case .qwerty: keyNotationToKeyCode // OLD
+        case .qwerty: keyNotationToVirtualKeyCode // NEW
         case .dvorak: dvorakMap
         case .colemak: colemakMap
     }
 }
 
-extension Key: @unchecked @retroactive Sendable {}
+// extension Key: @unchecked @retroactive Sendable {} // This comes from HotKey, remove if HotKey is fully removed
 
-let keyNotationToKeyCode: [String: Key] = [
-    sectionSign: .section,
-    "0": .zero,
-    "1": .one,
-    "2": .two,
-    "3": .three,
-    "4": .four,
-    "5": .five,
-    "6": .six,
-    "7": .seven,
-    "8": .eight,
-    "9": .nine,
-    minus: .minus,
-    equal: .equal,
+// let keyNotationToKeyCode: [String: Key] = [ // OLD
+let keyNotationToVirtualKeyCode: [String: UInt16] = [ // NEW
+    // sectionSign: .section, // OLD Key enum
+    sectionSign: VirtualKeyCodes.section, // NEW UInt16
+    "0": VirtualKeyCodes._0,
+    "1": VirtualKeyCodes._1,
+    "2": VirtualKeyCodes._2,
+    "3": VirtualKeyCodes._3,
+    "4": VirtualKeyCodes._4,
+    "5": VirtualKeyCodes._5,
+    "6": VirtualKeyCodes._6,
+    "7": VirtualKeyCodes._7,
+    "8": VirtualKeyCodes._8,
+    "9": VirtualKeyCodes._9,
+    minus: VirtualKeyCodes.minus,
+    equal: VirtualKeyCodes.equal,
 
-    q: .q,
-    w: .w,
-    e: .e,
-    r: .r,
-    t: .t,
-    y: .y,
-    u: .u,
-    i: .i,
-    o: .o,
-    p: .p,
-    leftSquareBracket: .leftBracket,
-    rightSquareBracket: .rightBracket,
-    backslash: .backslash,
+    q: VirtualKeyCodes.q,
+    w: VirtualKeyCodes.w,
+    e: VirtualKeyCodes.e,
+    r: VirtualKeyCodes.r,
+    t: VirtualKeyCodes.t,
+    y: VirtualKeyCodes.y,
+    u: VirtualKeyCodes.u,
+    i: VirtualKeyCodes.i,
+    o: VirtualKeyCodes.o,
+    p: VirtualKeyCodes.p,
+    leftSquareBracket: VirtualKeyCodes.leftBracket,
+    rightSquareBracket: VirtualKeyCodes.rightBracket,
+    backslash: VirtualKeyCodes.backslash,
 
-    a: .a,
-    s: .s,
-    d: .d,
-    f: .f,
-    g: .g,
-    h: .h,
-    j: .j,
-    k: .k,
-    l: .l,
-    semicolon: .semicolon,
-    quote: .quote,
+    a: VirtualKeyCodes.a,
+    s: VirtualKeyCodes.s,
+    d: VirtualKeyCodes.d,
+    f: VirtualKeyCodes.f,
+    g: VirtualKeyCodes.g,
+    h: VirtualKeyCodes.h,
+    j: VirtualKeyCodes.j,
+    k: VirtualKeyCodes.k,
+    l: VirtualKeyCodes.l,
+    semicolon: VirtualKeyCodes.semicolon,
+    quote: VirtualKeyCodes.quote,
 
-    z: .z,
-    x: .x,
-    c: .c,
-    v: .v,
-    b: .b,
-    n: .n,
-    m: .m,
-    comma: .comma,
-    period: .period,
-    slash: .slash,
+    z: VirtualKeyCodes.z,
+    x: VirtualKeyCodes.x,
+    c: VirtualKeyCodes.c,
+    v: VirtualKeyCodes.v,
+    b: VirtualKeyCodes.b,
+    n: VirtualKeyCodes.n,
+    m: VirtualKeyCodes.m,
+    comma: VirtualKeyCodes.comma,
+    period: VirtualKeyCodes.period,
+    slash: VirtualKeyCodes.slash,
 
-    "keypad0": .keypad0,
-    "keypad1": .keypad1,
-    "keypad2": .keypad2,
-    "keypad3": .keypad3,
-    "keypad4": .keypad4,
-    "keypad5": .keypad5,
-    "keypad6": .keypad6,
-    "keypad7": .keypad7,
-    "keypad8": .keypad8,
-    "keypad9": .keypad9,
-    "keypadClear": .keypadClear,
-    "keypadDecimalMark": .keypadDecimal,
-    "keypadDivide": .keypadDivide,
-    "keypadEnter": .keypadEnter,
-    "keypadEqual": .keypadEquals,
-    "keypadMinus": .keypadMinus,
-    "keypadMultiply": .keypadMultiply,
-    "keypadPlus": .keypadPlus,
+    "keypad0": VirtualKeyCodes.keypad0,
+    "keypad1": VirtualKeyCodes.keypad1,
+    "keypad2": VirtualKeyCodes.keypad2,
+    "keypad3": VirtualKeyCodes.keypad3,
+    "keypad4": VirtualKeyCodes.keypad4,
+    "keypad5": VirtualKeyCodes.keypad5,
+    "keypad6": VirtualKeyCodes.keypad6,
+    "keypad7": VirtualKeyCodes.keypad7,
+    "keypad8": VirtualKeyCodes.keypad8,
+    "keypad9": VirtualKeyCodes.keypad9,
+    "keypadClear": VirtualKeyCodes.keypadClear,
+    "keypadDecimalMark": VirtualKeyCodes.keypadDecimal,
+    "keypadDivide": VirtualKeyCodes.keypadDivide,
+    "keypadEnter": VirtualKeyCodes.keypadEnter,
+    "keypadEqual": VirtualKeyCodes.keypadEquals,
+    "keypadMinus": VirtualKeyCodes.keypadMinus,
+    "keypadMultiply": VirtualKeyCodes.keypadMultiply,
+    "keypadPlus": VirtualKeyCodes.keypadPlus,
 
-    "pageUp": .pageUp,
-    "pageDown": .pageDown,
-    "home": .home,
-    "end": .end,
-    "forwardDelete": .forwardDelete,
+    "pageUp": VirtualKeyCodes.pageUp,
+    "pageDown": VirtualKeyCodes.pageDown,
+    "home": VirtualKeyCodes.home,
+    "end": VirtualKeyCodes.end,
+    "forwardDelete": VirtualKeyCodes.forwardDelete,
 
-    "f1": .f1,
-    "f2": .f2,
-    "f3": .f3,
-    "f4": .f4,
-    "f5": .f5,
-    "f6": .f6,
-    "f7": .f7,
-    "f8": .f8,
-    "f9": .f9,
-    "f10": .f10,
-    "f11": .f11,
-    "f12": .f12,
-    "f13": .f13,
-    "f14": .f14,
-    "f15": .f15,
-    "f16": .f16,
-    "f17": .f17,
-    "f18": .f18,
-    "f19": .f19,
-    "f20": .f20,
+    "f1": VirtualKeyCodes.f1,
+    "f2": VirtualKeyCodes.f2,
+    "f3": VirtualKeyCodes.f3,
+    "f4": VirtualKeyCodes.f4,
+    "f5": VirtualKeyCodes.f5,
+    "f6": VirtualKeyCodes.f6,
+    "f7": VirtualKeyCodes.f7,
+    "f8": VirtualKeyCodes.f8,
+    "f9": VirtualKeyCodes.f9,
+    "f10": VirtualKeyCodes.f10,
+    "f11": VirtualKeyCodes.f11,
+    "f12": VirtualKeyCodes.f12,
+    "f13": VirtualKeyCodes.f13,
+    "f14": VirtualKeyCodes.f14,
+    "f15": VirtualKeyCodes.f15,
+    "f16": VirtualKeyCodes.f16,
+    "f17": VirtualKeyCodes.f17,
+    "f18": VirtualKeyCodes.f18,
+    "f19": VirtualKeyCodes.f19,
+    "f20": VirtualKeyCodes.f20,
 
-    "backtick": .grave,
-    "space": .space,
-    "enter": .return,
-    "esc": .escape,
-    "backspace": .delete,
-    "tab": .tab,
+    "backtick": VirtualKeyCodes.grave, // For ANSI layout, grave is 0x32. Section sign is 0x0A for ISO.
+    // The original HotKey.Key.grave might map to 0x32 (kVK_ANSI_Grave)
+    // HotKey.Key.section maps to 0x0A (kVK_ISO_Section)
+    // For simplicity, "backtick" maps to ANSI grave. "sectionSign" handles ISO.
+    "space": VirtualKeyCodes.space,
+    "enter": VirtualKeyCodes.enter,
+    "esc": VirtualKeyCodes.escape,
+    "backspace": VirtualKeyCodes.backspace,
+    "tab": VirtualKeyCodes.tab,
 
-    "left": .leftArrow,
-    "down": .downArrow,
-    "up": .upArrow,
-    "right": .rightArrow,
+    "left": VirtualKeyCodes.leftArrow,
+    "down": VirtualKeyCodes.downArrow,
+    "up": VirtualKeyCodes.upArrow,
+    "right": VirtualKeyCodes.rightArrow,
 ]
 
-private let dvorakMap: [String: Key] = keyNotationToKeyCode + [
-    leftSquareBracket: .minus,
-    rightSquareBracket: .equal,
+// private let dvorakMap: [String: Key] = keyNotationToKeyCode + [ // OLD
+private let dvorakMap: [String: UInt16] = keyNotationToVirtualKeyCode + [ // NEW
+    leftSquareBracket: VirtualKeyCodes.minus,
+    rightSquareBracket: VirtualKeyCodes.equal,
 
-    quote: .q,
-    comma: .w,
-    period: .e,
-    p: .r,
-    y: .t,
-    f: .y,
-    g: .u,
-    c: .i,
-    r: .o,
-    l: .p,
-    slash: .leftBracket, // leftBracket -> leftSquareBracket
-    equal: .rightBracket, // rightBracket -> rightSquareBracket
-    backslash: .backslash,
+    quote: VirtualKeyCodes.q,
+    comma: VirtualKeyCodes.w,
+    period: VirtualKeyCodes.e,
+    p: VirtualKeyCodes.r,
+    y: VirtualKeyCodes.t,
+    f: VirtualKeyCodes.y,
+    g: VirtualKeyCodes.u,
+    c: VirtualKeyCodes.i,
+    r: VirtualKeyCodes.o,
+    l: VirtualKeyCodes.p,
+    slash: VirtualKeyCodes.leftBracket,
+    equal: VirtualKeyCodes.rightBracket,
+    backslash: VirtualKeyCodes.backslash,
 
-    a: .a,
-    o: .s,
-    e: .d,
-    u: .f,
-    i: .g,
-    d: .h,
-    h: .j,
-    t: .k,
-    n: .l,
-    s: .semicolon,
-    minus: .quote,
+    a: VirtualKeyCodes.a,
+    o: VirtualKeyCodes.s,
+    e: VirtualKeyCodes.d,
+    u: VirtualKeyCodes.f,
+    i: VirtualKeyCodes.g,
+    d: VirtualKeyCodes.h,
+    h: VirtualKeyCodes.j,
+    t: VirtualKeyCodes.k,
+    n: VirtualKeyCodes.l,
+    s: VirtualKeyCodes.semicolon,
+    minus: VirtualKeyCodes.quote,
 
-    semicolon: .z,
-    q: .x,
-    j: .c,
-    k: .v,
-    x: .b,
-    b: .n,
-    m: .m,
-    w: .comma,
-    v: .period,
-    z: .slash,
+    semicolon: VirtualKeyCodes.z,
+    q: VirtualKeyCodes.x,
+    j: VirtualKeyCodes.c,
+    k: VirtualKeyCodes.v,
+    x: VirtualKeyCodes.b,
+    b: VirtualKeyCodes.n,
+    w: VirtualKeyCodes.comma,
+    v: VirtualKeyCodes.period,
+    z: VirtualKeyCodes.slash,
 ]
 
-private let colemakMap: [String: Key] = keyNotationToKeyCode + [
-    q: .q,
-    w: .w,
-    f: .e,
-    p: .r,
-    g: .t,
-    j: .y,
-    l: .u,
-    u: .i,
-    y: .o,
-    semicolon: .p,
-    leftSquareBracket: .leftBracket,
-    rightSquareBracket: .rightBracket,
-    backslash: .backslash,
-
-    a: .a,
-    r: .s,
-    s: .d,
-    t: .f,
-    d: .g,
-    h: .h,
-    n: .j,
-    e: .k,
-    i: .l,
-    o: .semicolon,
-    quote: .quote,
-
-    z: .z,
-    x: .x,
-    c: .c,
-    v: .v,
-    b: .b,
-    k: .n,
-    m: .m,
-    comma: .comma,
-    period: .period,
-    slash: .slash,
+// private let colemakMap: [String: Key] = keyNotationToKeyCode + [ // OLD
+private let colemakMap: [String: UInt16] = keyNotationToVirtualKeyCode + [ // NEW
+    f: VirtualKeyCodes.e,
+    p: VirtualKeyCodes.r,
+    g: VirtualKeyCodes.t,
+    j: VirtualKeyCodes.y,
+    l: VirtualKeyCodes.u,
+    u: VirtualKeyCodes.i,
+    y: VirtualKeyCodes.o,
+    semicolon: VirtualKeyCodes.p,
+    r: VirtualKeyCodes.s,
+    s: VirtualKeyCodes.d,
+    t: VirtualKeyCodes.f,
+    d: VirtualKeyCodes.g,
+    n: VirtualKeyCodes.j,
+    e: VirtualKeyCodes.k,
+    i: VirtualKeyCodes.l,
+    o: VirtualKeyCodes.semicolon,
+    k: VirtualKeyCodes.n,
 ]
 
 let modifiersMap: [String: NSEvent.ModifierFlags] = [
@@ -250,6 +354,42 @@ let modifiersMap: [String: NSEvent.ModifierFlags] = [
     "alt": .option,
     "ctrl": .control,
     "cmd": .command,
+]
+
+// Added for specific modifier key handling
+enum PhysicalModifierKey: String, CaseIterable, Hashable, Sendable {
+    case leftShift, rightShift, leftControl, rightControl, leftOption, rightOption, leftCommand, rightCommand, function
+
+    // Helper to get the string representation used in config files
+    var configKey: String {
+        switch self {
+            case .leftShift: "lshift"
+            case .rightShift: "rshift"
+            case .leftControl: "lctrl"
+            case .rightControl: "rctrl"
+            case .leftOption: "lalt"
+            case .rightOption: "ralt"
+            case .leftCommand: "lcmd"
+            case .rightCommand: "rcmd"
+            case .function: "fn"
+        }
+    }
+}
+
+let specificModifiersMap: [String: PhysicalModifierKey] = PhysicalModifierKey.allCases.reduce(into: [:]) { result, key in
+    result[key.configKey] = key
+    // Add alternative generic keys if desired, e.g., map "alt" to LeftOption as a default or a special "either" type
+    // For now, keeping it strict to specific modifiers.
+    // Example for also allowing generic "alt":
+    // if key == .leftOption { result["alt"] = key } // Or handle "alt" to mean "leftOption OR rightOption"
+}
+
+let physicalModifierKeyToKeyCode: [PhysicalModifierKey: UInt16] = [
+    .leftShift: 0x38, .rightShift: 0x3C,
+    .leftControl: 0x3B, .rightControl: 0x3E,
+    .leftOption: 0x3A, .rightOption: 0x3D,
+    .leftCommand: 0x37, .rightCommand: 0x36,
+    .function: 0x3F,
 ]
 
 extension NSEvent.ModifierFlags {
@@ -263,145 +403,25 @@ extension NSEvent.ModifierFlags {
     }
 }
 
-extension Key {
+extension Set<PhysicalModifierKey> {
     func toString() -> String {
-        switch self {
-            case .a: "a"
-            case .b: "b"
-            case .c: "c"
-            case .d: "d"
-            case .e: "e"
-            case .f: "f"
-            case .g: "g"
-            case .h: "h"
-            case .i: "i"
-            case .j: "j"
-            case .k: "k"
-            case .l: "l"
-            case .m: "m"
-            case .n: "n"
-            case .o: "o"
-            case .p: "p"
-            case .q: "q"
-            case .r: "r"
-            case .s: "s"
-            case .t: "t"
-            case .u: "u"
-            case .v: "v"
-            case .w: "w"
-            case .x: "x"
-            case .y: "y"
-            case .z: "z"
-
-            case .zero: "0"
-            case .one: "1"
-            case .two: "2"
-            case .three: "3"
-            case .four: "4"
-            case .five: "5"
-            case .six: "6"
-            case .seven: "7"
-            case .eight: "8"
-            case .nine: "9"
-
-            case .period: "period"
-            case .quote: "quote"
-            case .leftBracket: "leftSquareBracket"
-            case .rightBracket: "rightSquareBracket"
-            case .semicolon: "semicolon"
-            case .slash: "slash"
-            case .backslash: "backslash"
-            case .comma: "comma"
-            case .equal: "equal"
-            case .grave: "backtick"
-            case .minus: "minus"
-            case .space: "space"
-            case .tab: "tab"
-            case .return: "enter"
-            case .pageUp: "pageUp"
-            case .pageDown: "pageDown"
-            case .home: "home"
-            case .end: "end"
-            case .leftArrow: "left"
-            case .downArrow: "down"
-            case .upArrow: "up"
-            case .rightArrow: "right"
-            case .escape: "esc"
-            case .delete: "backspace"
-            case .section: "sectionSign"
-
-            case .f1: "f1"
-            case .f2: "f2"
-            case .f3: "f3"
-            case .f4: "f4"
-            case .f5: "f5"
-            case .f6: "f6"
-            case .f7: "f7"
-            case .f8: "f8"
-            case .f9: "f9"
-            case .f10: "f10"
-            case .f11: "f11"
-            case .f12: "f12"
-            case .f13: "f13"
-            case .f14: "f14"
-            case .f15: "f15"
-            case .f16: "f16"
-            case .f17: "f17"
-            case .f18: "f18"
-            case .f19: "f19"
-            case .f20: "f20"
-
-            case .keypad0: "keypad0"
-            case .keypad1: "keypad1"
-            case .keypad2: "keypad2"
-            case .keypad3: "keypad3"
-            case .keypad4: "keypad4"
-            case .keypad5: "keypad5"
-            case .keypad6: "keypad6"
-            case .keypad7: "keypad7"
-            case .keypad8: "keypad8"
-            case .keypad9: "keypad9"
-            case .keypadClear: "keypadClear"
-            case .keypadDecimal: "keypadDecimalMark"
-            case .keypadDivide: "keypadDivide"
-            case .keypadEnter: "keypadEnter"
-            case .keypadEquals: "keypadEqual"
-            case .keypadMinus: "keypadMinus"
-            case .keypadMultiply: "keypadMultiply"
-            case .keypadPlus: "keypadPlus"
-
-            // wtf
-            case .command: "cmd"
-            case .rightCommand: "rCmd"
-            case .option: "alt"
-            case .rightOption: "rAlt"
-            case .control: "ctrl"
-            case .rightControl: "rCtrl"
-            case .shift: "shift"
-            case .rightShift: "rShift"
-            case .function: "function"
-            case .capsLock: "capsLock"
-            case .forwardDelete: "forwardDelete"
-            case .help: "help"
-            case .volumeUp: "volumeUp"
-            case .volumeDown: "volumeDown"
-            case .mute: "mute"
-        }
+        // Sort to ensure consistent order for descriptions, e.g., cmd-ctrl-shift
+        self.sorted(by: { $0.rawValue < $1.rawValue }).map { $0.configKey }.joined(separator: "-")
     }
 }
 
-// doesn't work :(
-//extension NSEvent.ModifierFlags {
-//    static let lOption = NSEvent.ModifierFlags(rawValue: 1 << 1)
-//    static let rOption = NSEvent.ModifierFlags(rawValue: 1 << 2)
-//    static let lShift = NSEvent.ModifierFlags(rawValue: 0x00000002)
-//    static let rShift = NSEvent.ModifierFlags(rawValue: 0x00000004)
-//    static let lCommand = NSEvent.ModifierFlags(rawValue: 1 << 7)
-//    static let rCommand = NSEvent.ModifierFlags(rawValue: 0x00000010)
-//}
-
-// NSEvent.ModifierFlags.command.rawValue // 1 << 20
-// NSEvent.ModifierFlags.option.rawValue // 1 << 19
-// NSEvent.ModifierFlags.control.rawValue // 1 << 18
-// NSEvent.ModifierFlags.shift.rawValue // 1 << 17
-// https://github.com/koekeishiya/skhd/blob/master/src/hotkey.h
+// New: Map virtual key code back to string for descriptions (optional, can be expanded)
+func virtualKeyCodeToString(_ keyCode: UInt16) -> String {
+    // This is the reverse of keyNotationToVirtualKeyCode for common keys
+    // Could be generated or manually maintained for important keys
+    // For simplicity, we can find the first key in keyNotationToVirtualKeyCode that maps to this keyCode
+    if let keyName = keyNotationToVirtualKeyCode.first(where: { $0.value == keyCode })?.key {
+        return keyName
+    }
+    // Fallback for less common keys or if not in the map
+    switch keyCode {
+        case VirtualKeyCodes.a: return "a"
+        // ... add more cases as needed for complete coverage for descriptions
+        default: return "keyCode_0x" + String(keyCode, radix: 16)
+    }
+}

--- a/Sources/AppBundle/config/parseConfig.swift
+++ b/Sources/AppBundle/config/parseConfig.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Common
-import HotKey
+
+// import HotKey
 import TOMLKit
 
 @MainActor

--- a/Sources/AppBundle/config/parseKeyMapping.swift
+++ b/Sources/AppBundle/config/parseKeyMapping.swift
@@ -1,6 +1,4 @@
 import Common
-
-// import HotKey // REMOVE
 import TOMLKit
 
 private let keyMappingParser: [String: any ParserProtocol<KeyMapping>] = [

--- a/Sources/AppBundle/config/parseKeyMapping.swift
+++ b/Sources/AppBundle/config/parseKeyMapping.swift
@@ -1,11 +1,11 @@
 import Common
-
 // import HotKey // REMOVE
 import TOMLKit
 
 private let keyMappingParser: [String: any ParserProtocol<KeyMapping>] = [
     "preset": Parser(\.preset, parsePreset),
-    "key-notation-to-key-code": Parser(\.rawKeyNotationToVirtualKeyCode, parseKeyNotationToVirtualKeyCode),
+    "key-notation-to-key-code": Parser(
+        \.rawKeyNotationToVirtualKeyCode, parseKeyNotationToVirtualKeyCode),
 ]
 
 struct KeyMapping: ConvenienceCopyable, Equatable, Sendable {
@@ -29,37 +29,67 @@ struct KeyMapping: ConvenienceCopyable, Equatable, Sendable {
     }
 }
 
-func parseKeyMapping(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError]) -> KeyMapping {
+func parseKeyMapping(
+    _ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError]
+) -> KeyMapping {
     parseTable(raw, KeyMapping(), keyMappingParser, backtrace, &errors)
 }
 
-private func parsePreset(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace) -> ParsedToml<KeyMapping.Preset> {
-    parseString(raw, backtrace).flatMap { parseEnum($0, KeyMapping.Preset.self).toParsedToml(backtrace) }
+private func parsePreset(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace) -> ParsedToml<
+    KeyMapping.Preset
+> {
+    parseString(raw, backtrace).flatMap {
+        parseEnum($0, KeyMapping.Preset.self).toParsedToml(backtrace)
+    }
 }
 
-private func parseKeyNotationToVirtualKeyCode(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError]) -> [String: UInt16] {
+private func parseKeyNotationToVirtualKeyCode(
+    _ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError]
+) -> [String: UInt16] {
     var result: [String: UInt16] = [:]
     guard let table = raw.table else {
         errors.append(expectedActualTypeError(expected: .table, actual: raw.type, backtrace))
         return result
     }
     for (customKeyNotation, keyCodeStringValue): (String, TOMLValueConvertible) in table {
-        if isValidKeyNotation(customKeyNotation) {
-            let itemBacktrace = backtrace + .key(customKeyNotation)
-            if let keyCodeString = parseString(keyCodeStringValue, itemBacktrace).getOrNil(appendErrorTo: &errors) {
+        let normalizedKey = customKeyNotation.lowercased()
+        let itemBacktrace = backtrace + .key(customKeyNotation)
+
+        if isValidKeyNotation(normalizedKey) {
+            if let keyCodeString = parseString(keyCodeStringValue, itemBacktrace).getOrNil(
+                appendErrorTo: &errors)
+            {
                 if let virtualKeyCode = keyNotationToVirtualKeyCode[keyCodeString.lowercased()] {
-                    result[customKeyNotation] = virtualKeyCode
+                    if result[normalizedKey] != nil {
+                        errors.append(
+                            .semantic(
+                                itemBacktrace,
+                                "Duplicate definition for custom key notation '\(customKeyNotation)' (normalizes to '\(normalizedKey)')"
+                            ))
+                    } else {
+                        result[normalizedKey] = virtualKeyCode
+                    }
                 } else {
-                    errors.append(.semantic(itemBacktrace, "'\(keyCodeString)' is an invalid key string. It does not map to a known virtual key code. Check keysMap.swift for available keys."))
+                    errors.append(
+                        .semantic(
+                            itemBacktrace,
+                            "'\(keyCodeString)' is an invalid key string. It does not map to a known virtual key code. Check keysMap.swift for available keys."
+                        ))
                 }
             }
         } else {
-            errors.append(.semantic(backtrace + .key(customKeyNotation), "'\(customKeyNotation)' is invalid as a custom key notation string. It must not contain spaces or '-'."))
+            errors.append(
+                .semantic(
+                    itemBacktrace,
+                    "'\(customKeyNotation)' is invalid as a custom key notation string. It must not be empty and must not contain spaces or '-'."
+                ))
         }
     }
     return result
 }
 
 private func isValidKeyNotation(_ str: String) -> Bool {
-    str.rangeOfCharacter(from: .whitespacesAndNewlines) == nil && !str.contains("-")
+    !str.isEmpty
+        && str.rangeOfCharacter(from: .whitespacesAndNewlines) == nil
+        && !str.contains("-")
 }

--- a/Sources/AppBundle/config/parseKeyMapping.swift
+++ b/Sources/AppBundle/config/parseKeyMapping.swift
@@ -1,4 +1,5 @@
 import Common
+
 // import HotKey // REMOVE
 import TOMLKit
 

--- a/Sources/AppBundle/initAppBundle.swift
+++ b/Sources/AppBundle/initAppBundle.swift
@@ -2,10 +2,6 @@ import AppKit
 import Common
 import Foundation
 
-// Create a global instance of the hotkey monitor - This will be removed, using GlobalHotkeyMonitor.shared instead
-// @MainActor  // Ensure it's created on the main thread if it interacts with UI/AppKit later
-// let globalHotkeyMonitor = GlobalHotkeyMonitor() // Remove this line
-
 @MainActor public func initAppBundle() {
     initTerminationHandler()
     setupMonitorTermination()  // Register for graceful shutdown of the monitor

--- a/Sources/AppBundle/initAppBundle.swift
+++ b/Sources/AppBundle/initAppBundle.swift
@@ -3,12 +3,12 @@ import Common
 import Foundation
 
 // Create a global instance of the hotkey monitor
-@MainActor // Ensure it's created on the main thread if it interacts with UI/AppKit later
+@MainActor  // Ensure it's created on the main thread if it interacts with UI/AppKit later
 let globalHotkeyMonitor = GlobalHotkeyMonitor()
 
 @MainActor public func initAppBundle() {
     initTerminationHandler()
-    setupMonitorTermination() // Register for graceful shutdown of the monitor
+    setupMonitorTermination()  // Register for graceful shutdown of the monitor
     isCli = false
     initServerArgs()
     if isDebug {
@@ -20,7 +20,9 @@ let globalHotkeyMonitor = GlobalHotkeyMonitor()
         check(reloadConfig(forceConfigUrl: defaultConfigUrl))
     }
     if serverArgs.startedAtLogin && !config.startAtLogin {
-        printStderr("--started-at-login is passed but 'started-at-login = false' in the config. Terminating...")
+        printStderr(
+            "--started-at-login is passed but 'started-at-login = false' in the config. Terminating..."
+        )
         terminateApp()
     }
 
@@ -32,7 +34,7 @@ let globalHotkeyMonitor = GlobalHotkeyMonitor()
     startUnixSocketServer()
     GlobalObserver.initObserver()
     Task {
-        Workspace.garbageCollectUnusedWorkspaces() // init workspaces
+        Workspace.garbageCollectUnusedWorkspaces()  // init workspaces
         _ = Workspace.all.first?.focusWorkspace()
         try await runRefreshSessionBlocking(.startup, layoutWorkspaces: false)
         try await runSession(.startup, .checkServerIsEnabledOrDie) {
@@ -51,10 +53,10 @@ private func setupMonitorTermination() {
     NotificationCenter.default.addObserver(
         forName: NSApplication.willTerminateNotification,
         object: nil,
-        queue: .main // .main queue helps, but explicit Task @MainActor is safer for actor-isolated calls
+        queue: .main  // .main queue helps, but explicit Task @MainActor is safer for actor-isolated calls
     ) { _ in
         print("INFO: Application is terminating. Stopping GlobalHotkeyMonitor.")
-        Task { @MainActor in // Explicitly dispatch to main actor
+        Task { @MainActor in  // Explicitly dispatch to main actor
             globalHotkeyMonitor.stop()
         }
     }
@@ -116,7 +118,9 @@ private func initServerArgs() {
                 _serverArgs.startedAtLogin = true
                 args = Array(args.dropFirst())
             case "-NSDocumentRevisionsDebugMode":
-                cliError("Xcode -> Edit Scheme ... -> Options -> Document Versions -> Allow debugging when browsing versions -> false")
+                cliError(
+                    "Xcode -> Edit Scheme ... -> Options -> Document Versions -> Allow debugging when browsing versions -> false"
+                )
             default:
                 cliError("Unrecognized flag '\(args.first!)'")
         }

--- a/Sources/AppBundle/initAppBundle.swift
+++ b/Sources/AppBundle/initAppBundle.swift
@@ -104,25 +104,25 @@ private func initServerArgs() {
     }
     while !args.isEmpty {
         switch args.first {
-        case "--version", "-v":
-            print("\(aeroSpaceAppVersion) \(gitHash)")
-            exit(0)
-        case "--config-path":
-            if let arg = args.getOrNil(atIndex: 1) {
-                _serverArgs.configLocation = arg
-            } else {
-                cliError("Missing <path> in --config-path flag")
-            }
-            args = Array(args.dropFirst(2))
-        case "--started-at-login":
-            _serverArgs.startedAtLogin = true
-            args = Array(args.dropFirst())
-        case "-NSDocumentRevisionsDebugMode":
-            cliError(
-                "Xcode -> Edit Scheme ... -> Options -> Document Versions -> Allow debugging when browsing versions -> false"
-            )
-        default:
-            cliError("Unrecognized flag '\(args.first!)'")
+            case "--version", "-v":
+                print("\(aeroSpaceAppVersion) \(gitHash)")
+                exit(0)
+            case "--config-path":
+                if let arg = args.getOrNil(atIndex: 1) {
+                    _serverArgs.configLocation = arg
+                } else {
+                    cliError("Missing <path> in --config-path flag")
+                }
+                args = Array(args.dropFirst(2))
+            case "--started-at-login":
+                _serverArgs.startedAtLogin = true
+                args = Array(args.dropFirst())
+            case "-NSDocumentRevisionsDebugMode":
+                cliError(
+                    "Xcode -> Edit Scheme ... -> Options -> Document Versions -> Allow debugging when browsing versions -> false"
+                )
+            default:
+                cliError("Unrecognized flag '\(args.first!)'")
         }
     }
     if let path = serverArgs.configLocation, !FileManager.default.fileExists(atPath: path) {

--- a/Sources/AppBundleTests/config/ConfigTest.swift
+++ b/Sources/AppBundleTests/config/ConfigTest.swift
@@ -183,7 +183,7 @@ final class ConfigTest: XCTestCase {
         assertEquals(
             errors.descriptions,
             [
-                "enable-normalization-flatten-containers: Expected type is \'bool\'. But actual type is \'string\'",
+                "enable-normalization-flatten-containers: Expected type is \'bool\'. But actual type is \'string\'"
             ]
         )
     }
@@ -236,7 +236,7 @@ final class ConfigTest: XCTestCase {
                 These two settings don't play nicely together. 'split' command has no effect when enable-normalization-flatten-containers is disabled.
 
                 My recommendation: keep the normalizations enabled, and prefer 'join-with' over 'split'.
-                """,
+                """
             ],
             errors.descriptions
         )
@@ -443,13 +443,13 @@ final class ConfigTest: XCTestCase {
                 ]), additionalMsg: "Parsed KeyMapping does not match expected.")
 
         let binding = HotkeyBinding(
-            specificModifiers: [PhysicalModifierKey.leftOption],
+            exactModifiers: [PhysicalModifierKey.leftOption],
             keyCode: VirtualKeyCodes.u,
             commands: [
                 WorkspaceCommand(
-                    args: WorkspaceCmdArgs(target: .direct(.parse("unicorn").getOrDie()))),
+                    args: WorkspaceCmdArgs(target: .direct(.parse("unicorn").getOrDie())))
             ],
-            "alt-u"
+            descriptionWithKeyNotation: "alt-u"
         )
         assertEquals(binding.descriptionWithKeyCode, "lalt-u")
         assertEquals(binding.descriptionWithKeyNotation, "alt-u")
@@ -509,7 +509,7 @@ final class ConfigTest: XCTestCase {
         assertEquals(
             errors.descriptions, [],
             additionalMsg:
-            "Parsing specific modifiers produced errors: \(errors.descriptions.joined(separator: "\n"))"
+                "Parsing specific modifiers produced errors: \(errors.descriptions.joined(separator: "\n"))"
         )
 
         let bindings = config.modes[mainModeId]?.bindings
@@ -524,7 +524,7 @@ final class ConfigTest: XCTestCase {
         ) {
             let keyForMap =
                 (expectedModifiers.isEmpty ? "" : expectedModifiers.toString() + "-")
-                    + virtualKeyCodeToString(expectedKeyCode)
+                + virtualKeyCodeToString(expectedKeyCode)
 
             // DEBUG: Print available binding keys
             // print(
@@ -574,70 +574,70 @@ final class ConfigTest: XCTestCase {
         let testCases: [(config: String, expectedErrorSubstring: String, description: String)] = [
             (
                 config: """
-                    [mode.main.binding]
-                        alt-lalt-h = 'noop'
-                    """,
+                [mode.main.binding]
+                    alt-lalt-h = 'noop'
+                """,
                 expectedErrorSubstring:
-                "cannot specify both a generic modifier for 'option' (e.g., 'alt') and a specific one (e.g., 'lalt', 'ralt')",
+                    "cannot specify both a generic modifier for 'option' (e.g., 'alt') and a specific one (e.g., 'lalt', 'ralt')",
                 description: "Generic 'alt' and specific 'lalt' for option type conflict"
             ),
             (
                 config: """
-                    [mode.main.binding]
-                        cmd-rcmd-h = 'noop'
-                    """,
+                [mode.main.binding]
+                    cmd-rcmd-h = 'noop'
+                """,
                 expectedErrorSubstring:
-                "cannot specify both a generic modifier for 'command' (e.g., 'cmd') and a specific one",
+                    "cannot specify both a generic modifier for 'command' (e.g., 'cmd') and a specific one",
                 description: "Generic 'cmd' and specific 'rcmd' for command type conflict"
             ),
             (
                 config: """
-                    [mode.main.binding]
-                        shift-lshift-h = 'noop'
-                    """,
+                [mode.main.binding]
+                    shift-lshift-h = 'noop'
+                """,
                 expectedErrorSubstring:
-                "cannot specify both a generic modifier for 'shift' (e.g., 'shift') and a specific one",
+                    "cannot specify both a generic modifier for 'shift' (e.g., 'shift') and a specific one",
                 description: "Generic 'shift' and specific 'lshift' for shift type conflict"
             ),
             (
                 config: """
-                    [mode.main.binding]
-                        ctrl-rctrl-h = 'noop'
-                    """,
+                [mode.main.binding]
+                    ctrl-rctrl-h = 'noop'
+                """,
                 expectedErrorSubstring:
-                "cannot specify both a generic modifier for 'control' (e.g., 'ctrl') and a specific one",
+                    "cannot specify both a generic modifier for 'control' (e.g., 'ctrl') and a specific one",
                 description: "Generic 'ctrl' and specific 'rctrl' for control type conflict"
             ),
             (
                 config: """
-                    [mode.main.binding]
-                        alt-alt-h = 'noop'
-                    """,
+                [mode.main.binding]
+                    alt-alt-h = 'noop'
+                """,
                 expectedErrorSubstring: "Duplicate generic modifier 'alt'",
                 description: "Duplicate generic modifier 'alt-alt'"
             ),
             (
                 config: """
-                    [mode.main.binding]
-                        lalt-lalt-h = 'noop'
-                    """,
+                [mode.main.binding]
+                    lalt-lalt-h = 'noop'
+                """,
                 expectedErrorSubstring: "Duplicate specific modifier 'lalt'",
                 description: "Duplicate specific modifier 'lalt-lalt'"
             ),
             // Add more cases if needed, e.g. for cmd, ctrl, shift duplicates
             (
                 config: """
-                    [mode.main.binding]
-                        cmd-cmd-h = 'noop'
-                    """,
+                [mode.main.binding]
+                    cmd-cmd-h = 'noop'
+                """,
                 expectedErrorSubstring: "Duplicate generic modifier 'cmd'",
                 description: "Duplicate generic modifier 'cmd-cmd'"
             ),
             (
                 config: """
-                    [mode.main.binding]
-                        lcmd-lcmd-h = 'noop'
-                    """,
+                [mode.main.binding]
+                    lcmd-lcmd-h = 'noop'
+                """,
                 expectedErrorSubstring: "Duplicate specific modifier 'lcmd'",
                 description: "Duplicate specific modifier 'lcmd-lcmd'"
             ),

--- a/Sources/AppBundleTests/config/ConfigTest.swift
+++ b/Sources/AppBundleTests/config/ConfigTest.swift
@@ -183,7 +183,7 @@ final class ConfigTest: XCTestCase {
         assertEquals(
             errors.descriptions,
             [
-                "enable-normalization-flatten-containers: Expected type is \'bool\'. But actual type is \'string\'"
+                "enable-normalization-flatten-containers: Expected type is \'bool\'. But actual type is \'string\'",
             ]
         )
     }
@@ -236,7 +236,7 @@ final class ConfigTest: XCTestCase {
                 These two settings don't play nicely together. 'split' command has no effect when enable-normalization-flatten-containers is disabled.
 
                 My recommendation: keep the normalizations enabled, and prefer 'join-with' over 'split'.
-                """
+                """,
             ],
             errors.descriptions
         )
@@ -447,7 +447,7 @@ final class ConfigTest: XCTestCase {
             keyCode: VirtualKeyCodes.u,
             commands: [
                 WorkspaceCommand(
-                    args: WorkspaceCmdArgs(target: .direct(.parse("unicorn").getOrDie())))
+                    args: WorkspaceCmdArgs(target: .direct(.parse("unicorn").getOrDie()))),
             ],
             "alt-u"
         )
@@ -509,7 +509,7 @@ final class ConfigTest: XCTestCase {
         assertEquals(
             errors.descriptions, [],
             additionalMsg:
-                "Parsing specific modifiers produced errors: \(errors.descriptions.joined(separator: "\n"))"
+            "Parsing specific modifiers produced errors: \(errors.descriptions.joined(separator: "\n"))"
         )
 
         let bindings = config.modes[mainModeId]?.bindings
@@ -524,7 +524,7 @@ final class ConfigTest: XCTestCase {
         ) {
             let keyForMap =
                 (expectedModifiers.isEmpty ? "" : expectedModifiers.toString() + "-")
-                + virtualKeyCodeToString(expectedKeyCode)
+                    + virtualKeyCodeToString(expectedKeyCode)
 
             // DEBUG: Print available binding keys
             // print(
@@ -574,70 +574,70 @@ final class ConfigTest: XCTestCase {
         let testCases: [(config: String, expectedErrorSubstring: String, description: String)] = [
             (
                 config: """
-                [mode.main.binding]
-                    alt-lalt-h = 'noop'
-                """,
+                    [mode.main.binding]
+                        alt-lalt-h = 'noop'
+                    """,
                 expectedErrorSubstring:
-                    "cannot specify both a generic modifier for 'option' (e.g., 'alt') and a specific one (e.g., 'lalt', 'ralt')",
+                "cannot specify both a generic modifier for 'option' (e.g., 'alt') and a specific one (e.g., 'lalt', 'ralt')",
                 description: "Generic 'alt' and specific 'lalt' for option type conflict"
             ),
             (
                 config: """
-                [mode.main.binding]
-                    cmd-rcmd-h = 'noop'
-                """,
+                    [mode.main.binding]
+                        cmd-rcmd-h = 'noop'
+                    """,
                 expectedErrorSubstring:
-                    "cannot specify both a generic modifier for 'command' (e.g., 'cmd') and a specific one",
+                "cannot specify both a generic modifier for 'command' (e.g., 'cmd') and a specific one",
                 description: "Generic 'cmd' and specific 'rcmd' for command type conflict"
             ),
             (
                 config: """
-                [mode.main.binding]
-                    shift-lshift-h = 'noop'
-                """,
+                    [mode.main.binding]
+                        shift-lshift-h = 'noop'
+                    """,
                 expectedErrorSubstring:
-                    "cannot specify both a generic modifier for 'shift' (e.g., 'shift') and a specific one",
+                "cannot specify both a generic modifier for 'shift' (e.g., 'shift') and a specific one",
                 description: "Generic 'shift' and specific 'lshift' for shift type conflict"
             ),
             (
                 config: """
-                [mode.main.binding]
-                    ctrl-rctrl-h = 'noop'
-                """,
+                    [mode.main.binding]
+                        ctrl-rctrl-h = 'noop'
+                    """,
                 expectedErrorSubstring:
-                    "cannot specify both a generic modifier for 'control' (e.g., 'ctrl') and a specific one",
+                "cannot specify both a generic modifier for 'control' (e.g., 'ctrl') and a specific one",
                 description: "Generic 'ctrl' and specific 'rctrl' for control type conflict"
             ),
             (
                 config: """
-                [mode.main.binding]
-                    alt-alt-h = 'noop'
-                """,
+                    [mode.main.binding]
+                        alt-alt-h = 'noop'
+                    """,
                 expectedErrorSubstring: "Duplicate generic modifier 'alt'",
                 description: "Duplicate generic modifier 'alt-alt'"
             ),
             (
                 config: """
-                [mode.main.binding]
-                    lalt-lalt-h = 'noop'
-                """,
+                    [mode.main.binding]
+                        lalt-lalt-h = 'noop'
+                    """,
                 expectedErrorSubstring: "Duplicate specific modifier 'lalt'",
                 description: "Duplicate specific modifier 'lalt-lalt'"
             ),
             // Add more cases if needed, e.g. for cmd, ctrl, shift duplicates
             (
                 config: """
-                [mode.main.binding]
-                    cmd-cmd-h = 'noop'
-                """,
+                    [mode.main.binding]
+                        cmd-cmd-h = 'noop'
+                    """,
                 expectedErrorSubstring: "Duplicate generic modifier 'cmd'",
                 description: "Duplicate generic modifier 'cmd-cmd'"
             ),
             (
                 config: """
-                [mode.main.binding]
-                    lcmd-lcmd-h = 'noop'
-                """,
+                    [mode.main.binding]
+                        lcmd-lcmd-h = 'noop'
+                    """,
                 expectedErrorSubstring: "Duplicate specific modifier 'lcmd'",
                 description: "Duplicate specific modifier 'lcmd-lcmd'"
             ),

--- a/Sources/AppBundleTests/config/ConfigTest.swift
+++ b/Sources/AppBundleTests/config/ConfigTest.swift
@@ -183,7 +183,7 @@ final class ConfigTest: XCTestCase {
         assertEquals(
             errors.descriptions,
             [
-                "enable-normalization-flatten-containers: Expected type is \'bool\'. But actual type is \'string\'"
+                "enable-normalization-flatten-containers: Expected type is \'bool\'. But actual type is \'string\'",
             ]
         )
     }
@@ -236,7 +236,7 @@ final class ConfigTest: XCTestCase {
                 These two settings don't play nicely together. 'split' command has no effect when enable-normalization-flatten-containers is disabled.
 
                 My recommendation: keep the normalizations enabled, and prefer 'join-with' over 'split'.
-                """
+                """,
             ],
             errors.descriptions
         )
@@ -447,7 +447,7 @@ final class ConfigTest: XCTestCase {
             keyCode: VirtualKeyCodes.u,
             commands: [
                 WorkspaceCommand(
-                    args: WorkspaceCmdArgs(target: .direct(.parse("unicorn").getOrDie())))
+                    args: WorkspaceCmdArgs(target: .direct(.parse("unicorn").getOrDie()))),
             ],
             descriptionWithKeyNotation: "alt-u"
         )
@@ -509,7 +509,7 @@ final class ConfigTest: XCTestCase {
         assertEquals(
             errors.descriptions, [],
             additionalMsg:
-                "Parsing specific modifiers produced errors: \(errors.descriptions.joined(separator: "\n"))"
+            "Parsing specific modifiers produced errors: \(errors.descriptions.joined(separator: "\n"))"
         )
 
         let bindings = config.modes[mainModeId]?.bindings
@@ -524,7 +524,7 @@ final class ConfigTest: XCTestCase {
         ) {
             let keyForMap =
                 (expectedModifiers.isEmpty ? "" : expectedModifiers.toString() + "-")
-                + virtualKeyCodeToString(expectedKeyCode)
+                    + virtualKeyCodeToString(expectedKeyCode)
 
             // DEBUG: Print available binding keys
             // print(
@@ -574,70 +574,70 @@ final class ConfigTest: XCTestCase {
         let testCases: [(config: String, expectedErrorSubstring: String, description: String)] = [
             (
                 config: """
-                [mode.main.binding]
-                    alt-lalt-h = 'noop'
-                """,
+                    [mode.main.binding]
+                        alt-lalt-h = 'noop'
+                    """,
                 expectedErrorSubstring:
-                    "cannot specify both a generic modifier for 'option' (e.g., 'alt') and a specific one (e.g., 'lalt', 'ralt')",
+                "cannot specify both a generic modifier for 'option' (e.g., 'alt') and a specific one (e.g., 'lalt', 'ralt')",
                 description: "Generic 'alt' and specific 'lalt' for option type conflict"
             ),
             (
                 config: """
-                [mode.main.binding]
-                    cmd-rcmd-h = 'noop'
-                """,
+                    [mode.main.binding]
+                        cmd-rcmd-h = 'noop'
+                    """,
                 expectedErrorSubstring:
-                    "cannot specify both a generic modifier for 'command' (e.g., 'cmd') and a specific one",
+                "cannot specify both a generic modifier for 'command' (e.g., 'cmd') and a specific one",
                 description: "Generic 'cmd' and specific 'rcmd' for command type conflict"
             ),
             (
                 config: """
-                [mode.main.binding]
-                    shift-lshift-h = 'noop'
-                """,
+                    [mode.main.binding]
+                        shift-lshift-h = 'noop'
+                    """,
                 expectedErrorSubstring:
-                    "cannot specify both a generic modifier for 'shift' (e.g., 'shift') and a specific one",
+                "cannot specify both a generic modifier for 'shift' (e.g., 'shift') and a specific one",
                 description: "Generic 'shift' and specific 'lshift' for shift type conflict"
             ),
             (
                 config: """
-                [mode.main.binding]
-                    ctrl-rctrl-h = 'noop'
-                """,
+                    [mode.main.binding]
+                        ctrl-rctrl-h = 'noop'
+                    """,
                 expectedErrorSubstring:
-                    "cannot specify both a generic modifier for 'control' (e.g., 'ctrl') and a specific one",
+                "cannot specify both a generic modifier for 'control' (e.g., 'ctrl') and a specific one",
                 description: "Generic 'ctrl' and specific 'rctrl' for control type conflict"
             ),
             (
                 config: """
-                [mode.main.binding]
-                    alt-alt-h = 'noop'
-                """,
+                    [mode.main.binding]
+                        alt-alt-h = 'noop'
+                    """,
                 expectedErrorSubstring: "Duplicate generic modifier 'alt'",
                 description: "Duplicate generic modifier 'alt-alt'"
             ),
             (
                 config: """
-                [mode.main.binding]
-                    lalt-lalt-h = 'noop'
-                """,
+                    [mode.main.binding]
+                        lalt-lalt-h = 'noop'
+                    """,
                 expectedErrorSubstring: "Duplicate specific modifier 'lalt'",
                 description: "Duplicate specific modifier 'lalt-lalt'"
             ),
             // Add more cases if needed, e.g. for cmd, ctrl, shift duplicates
             (
                 config: """
-                [mode.main.binding]
-                    cmd-cmd-h = 'noop'
-                """,
+                    [mode.main.binding]
+                        cmd-cmd-h = 'noop'
+                    """,
                 expectedErrorSubstring: "Duplicate generic modifier 'cmd'",
                 description: "Duplicate generic modifier 'cmd-cmd'"
             ),
             (
                 config: """
-                [mode.main.binding]
-                    lcmd-lcmd-h = 'noop'
-                """,
+                    [mode.main.binding]
+                        lcmd-lcmd-h = 'noop'
+                    """,
                 expectedErrorSubstring: "Duplicate specific modifier 'lcmd'",
                 description: "Duplicate specific modifier 'lcmd-lcmd'"
             ),

--- a/Sources/AppBundleTests/config/ConfigTest.swift
+++ b/Sources/AppBundleTests/config/ConfigTest.swift
@@ -183,7 +183,7 @@ final class ConfigTest: XCTestCase {
         assertEquals(
             errors.descriptions,
             [
-                "enable-normalization-flatten-containers: Expected type is \'bool\'. But actual type is \'string\'",
+                "enable-normalization-flatten-containers: Expected type is \'bool\'. But actual type is \'string\'"
             ]
         )
     }
@@ -236,7 +236,7 @@ final class ConfigTest: XCTestCase {
                 These two settings don't play nicely together. 'split' command has no effect when enable-normalization-flatten-containers is disabled.
 
                 My recommendation: keep the normalizations enabled, and prefer 'join-with' over 'split'.
-                """,
+                """
             ],
             errors.descriptions
         )
@@ -447,7 +447,7 @@ final class ConfigTest: XCTestCase {
             keyCode: VirtualKeyCodes.u,
             commands: [
                 WorkspaceCommand(
-                    args: WorkspaceCmdArgs(target: .direct(.parse("unicorn").getOrDie()))),
+                    args: WorkspaceCmdArgs(target: .direct(.parse("unicorn").getOrDie())))
             ],
             "alt-u"
         )
@@ -509,7 +509,7 @@ final class ConfigTest: XCTestCase {
         assertEquals(
             errors.descriptions, [],
             additionalMsg:
-            "Parsing specific modifiers produced errors: \(errors.descriptions.joined(separator: "\n"))"
+                "Parsing specific modifiers produced errors: \(errors.descriptions.joined(separator: "\n"))"
         )
 
         let bindings = config.modes[mainModeId]?.bindings
@@ -524,7 +524,7 @@ final class ConfigTest: XCTestCase {
         ) {
             let keyForMap =
                 (expectedModifiers.isEmpty ? "" : expectedModifiers.toString() + "-")
-                    + virtualKeyCodeToString(expectedKeyCode)
+                + virtualKeyCodeToString(expectedKeyCode)
 
             // DEBUG: Print available binding keys
             // print(
@@ -574,70 +574,70 @@ final class ConfigTest: XCTestCase {
         let testCases: [(config: String, expectedErrorSubstring: String, description: String)] = [
             (
                 config: """
-                    [mode.main.binding]
-                        alt-lalt-h = 'noop'
-                    """,
+                [mode.main.binding]
+                    alt-lalt-h = 'noop'
+                """,
                 expectedErrorSubstring:
-                "cannot specify both a generic modifier for 'option' (e.g., 'alt') and a specific one (e.g., 'lalt', 'ralt')",
+                    "cannot specify both a generic modifier for 'option' (e.g., 'alt') and a specific one (e.g., 'lalt', 'ralt')",
                 description: "Generic 'alt' and specific 'lalt' for option type conflict"
             ),
             (
                 config: """
-                    [mode.main.binding]
-                        cmd-rcmd-h = 'noop'
-                    """,
+                [mode.main.binding]
+                    cmd-rcmd-h = 'noop'
+                """,
                 expectedErrorSubstring:
-                "cannot specify both a generic modifier for 'command' (e.g., 'cmd') and a specific one",
+                    "cannot specify both a generic modifier for 'command' (e.g., 'cmd') and a specific one",
                 description: "Generic 'cmd' and specific 'rcmd' for command type conflict"
             ),
             (
                 config: """
-                    [mode.main.binding]
-                        shift-lshift-h = 'noop'
-                    """,
+                [mode.main.binding]
+                    shift-lshift-h = 'noop'
+                """,
                 expectedErrorSubstring:
-                "cannot specify both a generic modifier for 'shift' (e.g., 'shift') and a specific one",
+                    "cannot specify both a generic modifier for 'shift' (e.g., 'shift') and a specific one",
                 description: "Generic 'shift' and specific 'lshift' for shift type conflict"
             ),
             (
                 config: """
-                    [mode.main.binding]
-                        ctrl-rctrl-h = 'noop'
-                    """,
+                [mode.main.binding]
+                    ctrl-rctrl-h = 'noop'
+                """,
                 expectedErrorSubstring:
-                "cannot specify both a generic modifier for 'control' (e.g., 'ctrl') and a specific one",
+                    "cannot specify both a generic modifier for 'control' (e.g., 'ctrl') and a specific one",
                 description: "Generic 'ctrl' and specific 'rctrl' for control type conflict"
             ),
             (
                 config: """
-                    [mode.main.binding]
-                        alt-alt-h = 'noop'
-                    """,
+                [mode.main.binding]
+                    alt-alt-h = 'noop'
+                """,
                 expectedErrorSubstring: "Duplicate generic modifier 'alt'",
                 description: "Duplicate generic modifier 'alt-alt'"
             ),
             (
                 config: """
-                    [mode.main.binding]
-                        lalt-lalt-h = 'noop'
-                    """,
+                [mode.main.binding]
+                    lalt-lalt-h = 'noop'
+                """,
                 expectedErrorSubstring: "Duplicate specific modifier 'lalt'",
                 description: "Duplicate specific modifier 'lalt-lalt'"
             ),
             // Add more cases if needed, e.g. for cmd, ctrl, shift duplicates
             (
                 config: """
-                    [mode.main.binding]
-                        cmd-cmd-h = 'noop'
-                    """,
+                [mode.main.binding]
+                    cmd-cmd-h = 'noop'
+                """,
                 expectedErrorSubstring: "Duplicate generic modifier 'cmd'",
                 description: "Duplicate generic modifier 'cmd-cmd'"
             ),
             (
                 config: """
-                    [mode.main.binding]
-                        lcmd-lcmd-h = 'noop'
-                    """,
+                [mode.main.binding]
+                    lcmd-lcmd-h = 'noop'
+                """,
                 expectedErrorSubstring: "Duplicate specific modifier 'lcmd'",
                 description: "Duplicate specific modifier 'lcmd-lcmd'"
             ),

--- a/Sources/AppBundleTests/testUtil.swift
+++ b/Sources/AppBundleTests/testUtil.swift
@@ -1,10 +1,7 @@
+@testable import AppBundle
 import Common
 import Foundation
-
-// import HotKey // REMOVE
 import XCTest
-
-@testable import AppBundle
 
 let projectRoot: URL = {
     var url = URL(filePath: #filePath).absoluteURL

--- a/Sources/AppBundleTests/testUtil.swift
+++ b/Sources/AppBundleTests/testUtil.swift
@@ -1,5 +1,6 @@
 import Common
 import Foundation
+
 // import HotKey // REMOVE
 import XCTest
 
@@ -46,11 +47,11 @@ func setUpWorkspacesForTests() {
 func testParseCommandSucc(_ command: String, _ expected: any CmdArgs) {
     let parsed = parseCommand(command)
     switch parsed {
-    case .cmd(let command):
-        XCTAssertTrue(
-            command.args.equals(expected), "actual: \(command.args) expected: \(expected)")
-    case .help: die()  // todo test help
-    case .failure(let msg): XCTFail(msg)
+        case .cmd(let command):
+            XCTAssertTrue(
+                command.args.equals(expected), "actual: \(command.args) expected: \(expected)")
+        case .help: die()  // todo test help
+        case .failure(let msg): XCTFail(msg)
     }
 }
 
@@ -83,9 +84,9 @@ extension ParsedCmd {
 func testParseCommandFail(_ command: String, msg expected: String) {
     let parsed = parseCommand(command)
     switch parsed {
-    case .cmd(let command): XCTFail("\(command) isn't supposed to be parcelable")
-    case .failure(let msg): assertEquals(msg, expected)
-    case .help: die()  // todo test help
+        case .cmd(let command): XCTFail("\(command) isn't supposed to be parcelable")
+        case .failure(let msg): assertEquals(msg, expected)
+        case .help: die()  // todo test help
     }
 }
 
@@ -123,8 +124,8 @@ extension HotkeyBinding {
     ) {
         let constructedDescription =
             exactModifiers.isEmpty
-            ? virtualKeyCodeToString(keyCode)
-            : exactModifiers.toString() + "-" + virtualKeyCodeToString(keyCode)
+                ? virtualKeyCodeToString(keyCode)
+                : exactModifiers.toString() + "-" + virtualKeyCodeToString(keyCode)
 
         // The main HotkeyBinding init takes descriptionWithKeyNotation, which is the raw binding string.
         // For tests, if descriptionForTests is nil, we use the constructed one.

--- a/Sources/AppBundleTests/testUtil.swift
+++ b/Sources/AppBundleTests/testUtil.swift
@@ -1,9 +1,10 @@
-@testable import AppBundle
 import Common
 import Foundation
 
 // import HotKey // REMOVE
 import XCTest
+
+@testable import AppBundle
 
 let projectRoot: URL = {
     var url = URL(filePath: #filePath).absoluteURL
@@ -18,9 +19,9 @@ let projectRoot: URL = {
 func setUpWorkspacesForTests() {
     config = defaultConfig
     configUrl = defaultConfigUrl
-    config.enableNormalizationFlattenContainers = false // Make layout tests more predictable
-    config.enableNormalizationOppositeOrientationForNestedContainers = false // Make layout tests more predictable
-    config.defaultRootContainerOrientation = .horizontal // Make default layout predictable
+    config.enableNormalizationFlattenContainers = false  // Make layout tests more predictable
+    config.enableNormalizationOppositeOrientationForNestedContainers = false  // Make layout tests more predictable
+    config.defaultRootContainerOrientation = .horizontal  // Make default layout predictable
 
     // Don't create any bindings and workspaces for tests
     config.modes = [mainModeId: Mode(name: nil, bindings: [:])]
@@ -34,7 +35,9 @@ func setUpWorkspacesForTests() {
     check(Workspace.get(byName: "setUpWorkspacesForTests").focusWorkspace())
     Workspace.garbageCollectUnusedWorkspaces()
     check(focus.workspace.isEffectivelyEmpty)
-    check(focus.workspace === Workspace.all.singleOrNil(), Workspace.all.map(\.description).joined(separator: ", "))
+    check(
+        focus.workspace === Workspace.all.singleOrNil(),
+        Workspace.all.map(\.description).joined(separator: ", "))
     check(mainMonitor.setActiveWorkspace(focus.workspace))
 
     TestApp.shared.focusedWindow = nil
@@ -44,8 +47,10 @@ func setUpWorkspacesForTests() {
 func testParseCommandSucc(_ command: String, _ expected: any CmdArgs) {
     let parsed = parseCommand(command)
     switch parsed {
-        case .cmd(let command): XCTAssertTrue(command.args.equals(expected), "actual: \(command.args) expected: \(expected)")
-        case .help: die() // todo test help
+        case .cmd(let command):
+            XCTAssertTrue(
+                command.args.equals(expected), "actual: \(command.args) expected: \(expected)")
+        case .help: die()  // todo test help
         case .failure(let msg): XCTFail(msg)
     }
 }
@@ -81,7 +86,7 @@ func testParseCommandFail(_ command: String, msg expected: String) {
     switch parsed {
         case .cmd(let command): XCTFail("\(command) isn't supposed to be parcelable")
         case .failure(let msg): assertEquals(msg, expected)
-        case .help: die() // todo test help
+        case .help: die()  // todo test help
     }
 }
 
@@ -117,17 +122,19 @@ extension HotkeyBinding {
         // for tests, we either pass it or construct a similar representation.
         _ descriptionForTests: String? = nil
     ) {
-        let constructedDescription = specificModifiers.isEmpty
-            ? virtualKeyCodeToString(keyCode)
-            : specificModifiers.toString() + "-" + virtualKeyCodeToString(keyCode)
+        let constructedDescription =
+            specificModifiers.isEmpty
+                ? virtualKeyCodeToString(keyCode)
+                : specificModifiers.toString() + "-" + virtualKeyCodeToString(keyCode)
 
         // The main HotkeyBinding init takes descriptionWithKeyNotation, which is the raw binding string.
         // For tests, if descriptionForTests is nil, we use the constructed one.
         // This matches how descriptionWithKeyCode is generated.
         self.init(
-            specificModifiers,
-            keyCode,
-            commands,
+            exactModifiers: specificModifiers,
+            genericModifiers: [],
+            keyCode: keyCode,
+            commands: commands,
             descriptionWithKeyNotation: descriptionForTests ?? constructedDescription
         )
     }

--- a/Sources/AppBundleTests/testUtil.swift
+++ b/Sources/AppBundleTests/testUtil.swift
@@ -1,6 +1,5 @@
 import Common
 import Foundation
-
 // import HotKey // REMOVE
 import XCTest
 
@@ -47,11 +46,11 @@ func setUpWorkspacesForTests() {
 func testParseCommandSucc(_ command: String, _ expected: any CmdArgs) {
     let parsed = parseCommand(command)
     switch parsed {
-        case .cmd(let command):
-            XCTAssertTrue(
-                command.args.equals(expected), "actual: \(command.args) expected: \(expected)")
-        case .help: die()  // todo test help
-        case .failure(let msg): XCTFail(msg)
+    case .cmd(let command):
+        XCTAssertTrue(
+            command.args.equals(expected), "actual: \(command.args) expected: \(expected)")
+    case .help: die()  // todo test help
+    case .failure(let msg): XCTFail(msg)
     }
 }
 
@@ -84,9 +83,9 @@ extension ParsedCmd {
 func testParseCommandFail(_ command: String, msg expected: String) {
     let parsed = parseCommand(command)
     switch parsed {
-        case .cmd(let command): XCTFail("\(command) isn't supposed to be parcelable")
-        case .failure(let msg): assertEquals(msg, expected)
-        case .help: die()  // todo test help
+    case .cmd(let command): XCTFail("\(command) isn't supposed to be parcelable")
+    case .failure(let msg): assertEquals(msg, expected)
+    case .help: die()  // todo test help
     }
 }
 
@@ -113,9 +112,9 @@ extension MoveNodeToWorkspaceCmdArgs {
 }
 
 extension HotkeyBinding {
-    // Convenience init for tests using specific modifiers and UInt16 keycode
+    // Convenience init for tests using exact modifiers and UInt16 keycode
     init(
-        specificModifiers: Set<PhysicalModifierKey>,
+        exactModifiers: Set<PhysicalModifierKey>,
         keyCode: UInt16,
         commands: [any Command],
         // descriptionWithKeyNotation is the raw string from config,
@@ -123,39 +122,19 @@ extension HotkeyBinding {
         _ descriptionForTests: String? = nil
     ) {
         let constructedDescription =
-            specificModifiers.isEmpty
-                ? virtualKeyCodeToString(keyCode)
-                : specificModifiers.toString() + "-" + virtualKeyCodeToString(keyCode)
+            exactModifiers.isEmpty
+            ? virtualKeyCodeToString(keyCode)
+            : exactModifiers.toString() + "-" + virtualKeyCodeToString(keyCode)
 
         // The main HotkeyBinding init takes descriptionWithKeyNotation, which is the raw binding string.
         // For tests, if descriptionForTests is nil, we use the constructed one.
         // This matches how descriptionWithKeyCode is generated.
         self.init(
-            exactModifiers: specificModifiers,
+            exactModifiers: exactModifiers,
             genericModifiers: [],
             keyCode: keyCode,
             commands: commands,
             descriptionWithKeyNotation: descriptionForTests ?? constructedDescription
         )
     }
-
-    // Example of how a test might call it, assuming default NSEvent.ModifierFlags map to left versions for simplicity in old tests
-    // This is a helper and might need adjustment based on how tests want to represent generic modifiers.
-    // For now, tests should be updated to use the above initializer with Set<PhysicalModifierKey>.
-    /*
-     init(_ modifiers: NSEvent.ModifierFlags, _ virtualKeyCode: UInt16, _ commands: [any Command]) {
-         var specificMods: Set<PhysicalModifierKey> = []
-         if modifiers.contains(.command) { specificMods.insert(.leftCommand) } // Default to left for tests
-         if modifiers.contains(.option) { specificMods.insert(.leftOption) }
-         if modifiers.contains(.control) { specificMods.insert(.leftControl) }
-         if modifiers.contains(.shift) { specificMods.insert(.leftShift) }
-         // FN key isn't typically in NSEvent.ModifierFlags in the same way for old HotKey lib.
-
-         let constructedDescription = specificMods.isEmpty
-             ? virtualKeyCodeToString(virtualKeyCode)
-             : specificMods.toString() + "-" + virtualKeyCodeToString(virtualKeyCode)
-
-         self.init(specificMods, virtualKeyCode, commands, descriptionWithKeyNotation: constructedDescription)
-     }
-     */
 }

--- a/Sources/Common/cmdArgs/cmdArgsManifest.swift
+++ b/Sources/Common/cmdArgs/cmdArgsManifest.swift
@@ -29,6 +29,7 @@ public enum CmdKind: String, CaseIterable, Equatable, Sendable {
     case moveNodeToMonitor = "move-node-to-monitor"
     case moveNodeToWorkspace = "move-node-to-workspace"
     case moveWorkspaceToMonitor = "move-workspace-to-monitor"
+    case noop
     case reloadConfig = "reload-config"
     case resize
     case split
@@ -56,7 +57,7 @@ func initSubcommands() -> [String: any SubCommandParserProtocol] {
             case .enable:
                 result[kind.rawValue] = SubCommandParser(parseEnableCmdArgs)
             case .execAndForget:
-                break // exec-and-forget is parsed separately
+                break  // exec-and-forget is parsed separately
             case .flattenWorkspaceTree:
                 result[kind.rawValue] = SubCommandParser(FlattenWorkspaceTreeCmdArgs.init)
             case .focus:
@@ -102,7 +103,10 @@ func initSubcommands() -> [String: any SubCommandParserProtocol] {
             case .moveWorkspaceToMonitor:
                 result[kind.rawValue] = SubCommandParser(parseWorkspaceToMonitorCmdArgs)
                 // deprecated
-                result["move-workspace-to-display"] = SubCommandParser(MoveWorkspaceToMonitorCmdArgs.init)
+                result["move-workspace-to-display"] = SubCommandParser(
+                    MoveWorkspaceToMonitorCmdArgs.init)
+            case .noop:
+                result[kind.rawValue] = SubCommandParser(NoopCmdArgs.init)
             case .reloadConfig:
                 result[kind.rawValue] = SubCommandParser(ReloadConfigCmdArgs.init)
             case .resize:

--- a/Sources/Common/cmdArgs/impl/NoopCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/NoopCmdArgs.swift
@@ -1,16 +1,16 @@
 public struct NoopCmdArgs: CmdArgs {
-    public let rawArgs: EquatableNoop<[String]>
-    public init(rawArgs: [String]) { self.rawArgs = .init(rawArgs) }
-    public static let parser: CmdParser<Self> = cmdParser(
-        kind: .noop,  // This will require adding .noop to CmdKind
-        allowInConfig: true,
-        help: "Does nothing. Useful for clearing a previously bound hotkey or for testing.",
-        options: [:],
-        arguments: []
-    )
+	public let rawArgs: EquatableNoop<[String]>
+	public init(rawArgs: [String]) { self.rawArgs = .init(rawArgs) }
+	public static let parser: CmdParser<Self> = cmdParser(
+		kind: .noop,  // This will require adding .noop to CmdKind
+		allowInConfig: true,
+		help: "Does nothing. Useful for clearing a previously bound hotkey or for testing.",
+		options: [:],
+		arguments: []
+	)
 
-    public var windowId: UInt32?
-    public var workspaceName: WorkspaceName?
+	public var windowId: UInt32?
+	public var workspaceName: WorkspaceName?
 }
 
 // We might not need a custom parse function if the default behavior of parseSpecificCmdArgs is sufficient

--- a/Sources/Common/cmdArgs/impl/NoopCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/NoopCmdArgs.swift
@@ -1,14 +1,14 @@
 public struct NoopCmdArgs: CmdArgs {
-	public let rawArgs: EquatableNoop<[String]>
-	public init(rawArgs: [String]) { self.rawArgs = .init(rawArgs) }
-	public static let parser: CmdParser<Self> = cmdParser(
-		kind: .noop,  // This will require adding .noop to CmdKind
-		allowInConfig: true,
-		help: "Does nothing. Useful for clearing a previously bound hotkey or for testing.",
-		options: [:],
-		arguments: []
-	)
+    public let rawArgs: EquatableNoop<[String]>
+    public init(rawArgs: [String]) { self.rawArgs = .init(rawArgs) }
+    public static let parser: CmdParser<Self> = cmdParser(
+        kind: .noop,  // This will require adding .noop to CmdKind
+        allowInConfig: true,
+        help: "Does nothing. Useful for clearing a previously bound hotkey or for testing.",
+        options: [:],
+        arguments: []
+    )
 
-	public var windowId: UInt32?
-	public var workspaceName: WorkspaceName?
+    public var windowId: UInt32?
+    public var workspaceName: WorkspaceName?
 }

--- a/Sources/Common/cmdArgs/impl/NoopCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/NoopCmdArgs.swift
@@ -1,0 +1,19 @@
+public struct NoopCmdArgs: CmdArgs {
+    public let rawArgs: EquatableNoop<[String]>
+    public init(rawArgs: [String]) { self.rawArgs = .init(rawArgs) }
+    public static let parser: CmdParser<Self> = cmdParser(
+        kind: .noop,  // This will require adding .noop to CmdKind
+        allowInConfig: true,
+        help: "Does nothing. Useful for clearing a previously bound hotkey or for testing.",
+        options: [:],
+        arguments: []
+    )
+
+    public var windowId: UInt32?
+    public var workspaceName: WorkspaceName?
+}
+
+// We might not need a custom parse function if the default behavior of parseSpecificCmdArgs is sufficient
+// public func parseNoopCmdArgs(_ args: [String]) -> ParsedCmd<NoopCmdArgs> {
+//     parseSpecificCmdArgs(NoopCmdArgs(rawArgs: args), args)
+// }

--- a/Sources/Common/cmdArgs/impl/NoopCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/NoopCmdArgs.swift
@@ -1,16 +1,16 @@
 public struct NoopCmdArgs: CmdArgs {
-	public let rawArgs: EquatableNoop<[String]>
-	public init(rawArgs: [String]) { self.rawArgs = .init(rawArgs) }
-	public static let parser: CmdParser<Self> = cmdParser(
-		kind: .noop,  // This will require adding .noop to CmdKind
-		allowInConfig: true,
-		help: "Does nothing. Useful for clearing a previously bound hotkey or for testing.",
-		options: [:],
-		arguments: []
-	)
+    public let rawArgs: EquatableNoop<[String]>
+    public init(rawArgs: [String]) { self.rawArgs = .init(rawArgs) }
+    public static let parser: CmdParser<Self> = cmdParser(
+        kind: .noop,  // This will require adding .noop to CmdKind
+        allowInConfig: true,
+        help: "Does nothing. Useful for clearing a previously bound hotkey or for testing.",
+        options: [:],
+        arguments: []
+    )
 
-	public var windowId: UInt32?
-	public var workspaceName: WorkspaceName?
+    public var windowId: UInt32?
+    public var workspaceName: WorkspaceName?
 }
 
 // We might not need a custom parse function if the default behavior of parseSpecificCmdArgs is sufficient

--- a/Sources/Common/cmdArgs/impl/NoopCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/NoopCmdArgs.swift
@@ -1,19 +1,14 @@
 public struct NoopCmdArgs: CmdArgs {
-    public let rawArgs: EquatableNoop<[String]>
-    public init(rawArgs: [String]) { self.rawArgs = .init(rawArgs) }
-    public static let parser: CmdParser<Self> = cmdParser(
-        kind: .noop,  // This will require adding .noop to CmdKind
-        allowInConfig: true,
-        help: "Does nothing. Useful for clearing a previously bound hotkey or for testing.",
-        options: [:],
-        arguments: []
-    )
+	public let rawArgs: EquatableNoop<[String]>
+	public init(rawArgs: [String]) { self.rawArgs = .init(rawArgs) }
+	public static let parser: CmdParser<Self> = cmdParser(
+		kind: .noop,  // This will require adding .noop to CmdKind
+		allowInConfig: true,
+		help: "Does nothing. Useful for clearing a previously bound hotkey or for testing.",
+		options: [:],
+		arguments: []
+	)
 
-    public var windowId: UInt32?
-    public var workspaceName: WorkspaceName?
+	public var windowId: UInt32?
+	public var workspaceName: WorkspaceName?
 }
-
-// We might not need a custom parse function if the default behavior of parseSpecificCmdArgs is sufficient
-// public func parseNoopCmdArgs(_ args: [String]) -> ParsedCmd<NoopCmdArgs> {
-//     parseSpecificCmdArgs(NoopCmdArgs(rawArgs: args), args)
-// }

--- a/Sources/Common/cmdArgs/parseCmdArgs.swift
+++ b/Sources/Common/cmdArgs/parseCmdArgs.swift
@@ -21,7 +21,8 @@ public func parseCmdArgs(_ args: [String]) -> ParsedCmd<any CmdArgs> {
     }
 }
 
-public protocol CmdArgs: ConvenienceCopyable, Equatable, CustomStringConvertible, AeroAny, Sendable {
+public protocol CmdArgs: ConvenienceCopyable, Equatable, CustomStringConvertible, AeroAny, Sendable
+{
     static var parser: CmdParser<Self> { get }
     var rawArgs: EquatableNoop<[String]> { get }  // Non Equatable because test comparion
 
@@ -30,19 +31,19 @@ public protocol CmdArgs: ConvenienceCopyable, Equatable, CustomStringConvertible
     var workspaceName: WorkspaceName? { get set }
 }
 
-public extension CmdArgs {
-    static var info: CmdStaticInfo { Self.parser.info }
+extension CmdArgs {
+    public static var info: CmdStaticInfo { Self.parser.info }
 
-    func equals(_ other: any CmdArgs) -> Bool {  // My brain is cursed with Java
+    public func equals(_ other: any CmdArgs) -> Bool {  // My brain is cursed with Java
         (other as? Self).flatMap { self == $0 } ?? false
     }
 
-    var description: String {
+    public var description: String {
         switch Self.info.kind {
-            case .execAndForget:
-                CmdKind.execAndForget.rawValue + " " + (self as! ExecAndForgetCmdArgs).bashScript
-            default:
-                ([Self.info.kind.rawValue] + rawArgs.value).joinArgs()
+        case .execAndForget:
+            CmdKind.execAndForget.rawValue + " " + (self as! ExecAndForgetCmdArgs).bashScript
+        default:
+            ([Self.info.kind.rawValue] + rawArgs.value).joinArgs()
         }
     }
 }

--- a/Sources/Common/cmdArgs/parseCmdArgs.swift
+++ b/Sources/Common/cmdArgs/parseCmdArgs.swift
@@ -21,8 +21,7 @@ public func parseCmdArgs(_ args: [String]) -> ParsedCmd<any CmdArgs> {
     }
 }
 
-public protocol CmdArgs: ConvenienceCopyable, Equatable, CustomStringConvertible, AeroAny, Sendable
-{
+public protocol CmdArgs: ConvenienceCopyable, Equatable, CustomStringConvertible, AeroAny, Sendable {
     static var parser: CmdParser<Self> { get }
     var rawArgs: EquatableNoop<[String]> { get }  // Non Equatable because test comparion
 
@@ -31,19 +30,19 @@ public protocol CmdArgs: ConvenienceCopyable, Equatable, CustomStringConvertible
     var workspaceName: WorkspaceName? { get set }
 }
 
-extension CmdArgs {
-    public static var info: CmdStaticInfo { Self.parser.info }
+public extension CmdArgs {
+    static var info: CmdStaticInfo { Self.parser.info }
 
-    public func equals(_ other: any CmdArgs) -> Bool {  // My brain is cursed with Java
+    func equals(_ other: any CmdArgs) -> Bool {  // My brain is cursed with Java
         (other as? Self).flatMap { self == $0 } ?? false
     }
 
-    public var description: String {
+    var description: String {
         switch Self.info.kind {
-        case .execAndForget:
-            CmdKind.execAndForget.rawValue + " " + (self as! ExecAndForgetCmdArgs).bashScript
-        default:
-            ([Self.info.kind.rawValue] + rawArgs.value).joinArgs()
+            case .execAndForget:
+                CmdKind.execAndForget.rawValue + " " + (self as! ExecAndForgetCmdArgs).bashScript
+            default:
+                ([Self.info.kind.rawValue] + rawArgs.value).joinArgs()
         }
     }
 }

--- a/Sources/Common/cmdArgs/parseCmdArgs.swift
+++ b/Sources/Common/cmdArgs/parseCmdArgs.swift
@@ -3,20 +3,10 @@ public func parseCmdArgs(_ args: [String]) -> ParsedCmd<any CmdArgs> {
     if subcommand.isEmpty {
         return .failure("Can't parse empty string command")
     }
-    // ---- START DEBUG ----
-    // print(
-    //     "DEBUG parseCmdArgs: Looking for subcommand '\(subcommand)'"
-    // )
-    let foundParser = subcommandParsers[subcommand]  // Ensure this line remains active
-    // print("DEBUG parseCmdArgs: Parser found for '\(subcommand)': \(foundParser != nil)")
-    // ---- END DEBUG ----
-    if let subcommandParser = foundParser {  // Use the explicitly looked-up parser
+    let foundParser = subcommandParsers[subcommand]
+    if let subcommandParser = foundParser {
         return subcommandParser.parse(args: Array(args.dropFirst()))
     } else {
-        // This branch should NOT be taken for "noop" if the above debug says "Parser found for 'noop': true"
-        // print(
-        //     "DEBUG parseCmdArgs: SUBCOMMAND '\(subcommand)' NOT FOUND. Ensure it is in CmdKind and initSubcommands."
-        // )
         return .failure("Unrecognized subcommand '\(subcommand)'")
     }
 }

--- a/docs/config-examples/default-config.toml
+++ b/docs/config-examples/default-config.toml
@@ -83,7 +83,11 @@ automatically-unhide-macos-hidden-apps = false
     #                   keypadMinus, keypadMultiply, keypadPlus
     # - Arrows.         left, down, up, right
 
-    # All possible modifiers: cmd, alt, ctrl, shift
+    # Modifiers:
+    # - Generic: cmd, alt, ctrl, shift (e.g., 'alt' means Left-Alt OR Right-Alt)
+    # - Specific: lcmd, rcmd, lalt, ralt, lctrl, rctrl, lshift, rshift, fn
+    #   (e.g., 'lalt' means only Left-Alt)
+    # See the user guide for detailed behavior and combinations.
 
     # All possible commands: https://nikitabobko.github.io/AeroSpace/commands
 

--- a/docs/guide.adoc
+++ b/docs/guide.adoc
@@ -242,7 +242,7 @@ You can configure environment variables of `exec-*` commands and callbacks (such
 +
 Environment variable substitution is supported in form of `+${ENV_VAR}+`
 * You can inspect what is the end result of environment variables using xref:commands.adoc#list-exec-env-vars[`list-exec-env-vars` command]
-* GUI apps on macOS don't have Homebrew's prefix in their `PATH` by default (https://docs.brew.sh/FAQ#my-mac-apps-dont-find-homebrew-utilities[docs.brew.sh]).
+* GUI apps on macOS don't have Homebrew’s prefix in their `PATH` by default (https://docs.brew.sh/FAQ#my-mac-apps-dont-find-homebrew-utilities[docs.brew.sh]).
 That's why unless you override `exec` section in your config, AeroSpace fallbacks to the following `exec` configuration:
 +
 [source,toml]
@@ -271,9 +271,9 @@ WARNING: i3 has a different terminology.
 . <<layouts,Layout>> (Possible values: `tiles`, `accordion`)
 . Orientation (Possible values: `horizontal`, `vertical`)
 
-When we say "layout of the window", we refer to the layout of the window's parent container.
+When we say "layout of the window", we refer to the layout of the window’s parent container.
 
-It's easier to understand tree tiling model by looking at examples
+It’s easier to understand tree tiling model by looking at examples
 
 .Simple tree structure. Two windows side-by-side
 image::assets/h_tiles.png[]
@@ -297,12 +297,12 @@ The tree structure can be changed with three commands:
 
 In total, AeroSpace provides 4 possible layouts:
 
-- `h_tiles` horizontal tiles (in i3, it's called "horizontal split")
-- `v_tiles` vertical tiles (in i3, it's called "vertical split")
-- `h_accordion` horizontal accordion (analog of i3's "tabbed layout")
-- `v_accordion` vertical accordion (analog of i3's "stacked layout")
+- `h_tiles` horizontal tiles (in i3, it’s called "horizontal split")
+- `v_tiles` vertical tiles (in i3, it’s called "vertical split")
+- `h_accordion` horizontal accordion (analog of i3’s "tabbed layout")
+- `v_accordion` vertical accordion (analog of i3’s "stacked layout")
 
-<<tree,From the previous section>>, you're already familiar with the `tiles` layout.
+<<tree,From the previous section>>, you’re already familiar with the `tiles` layout.
 
 Accordion is a layout where windows are placed on top of each other.
 
@@ -336,7 +336,7 @@ Configured by `enable-normalization-opposite-orientation-for-nested-containers`
 [.lead]
 *Example 1*
 
-According to the first normalization, such layout isn't possible:
+According to the first normalization, such layout isn’t possible:
 
 ----
 h_tiles (root node)
@@ -354,7 +354,7 @@ v_tiles (new root node)
 [.lead]
 *Example 2*
 
-According to the second normalization, such layout isn't possible:
+According to the second normalization, such layout isn’t possible:
 
 ----
 h_tiles
@@ -402,24 +402,24 @@ This technique eliminates the need for an additional binding for focusing floati
 Native macOS Spaces have a lot of problems
 
 * The animation for Spaces switching is slow
-** You can't disable animation for Spaces switching (you can only make it slightly faster by turning on `Reduce motion` setting, but it's suboptimal)
+** You can’t disable animation for Spaces switching (you can only make it slightly faster by turning on `Reduce motion` setting, but it’s suboptimal)
 * You have a limit of Spaces (up to 16 Spaces with one monitor)
-* You can't create/delete/reorder Space and move windows between Spaces with hotkeys (you can only switch between Spaces with hotkeys)
+* You can’t create/delete/reorder Space and move windows between Spaces with hotkeys (you can only switch between Spaces with hotkeys)
 * Apple doesn't provide public API to communicate with Spaces (create/delete/reorder/switch Space and move windows between Spaces)
 
 Since Spaces are so hard to deal with, AeroSpace reimplements Spaces and calls them "Workspaces".
-The idea is that if the workspace isn't active then all of its windows are placed outside the visible area of the screen, in the bottom right or left corner.
+The idea is that if the workspace isn’t active then all of its windows are placed outside the visible area of the screen, in the bottom right or left corner.
 Once you switch back to the workspace, (e.g. by the means of xref:commands.adoc#workspace[workspace] command, or `cmd + tab`) windows are placed back to the visible area of the screen.
 
 When you quit the AeroSpace or when the AeroSpace detects that it's about to crash, AeroSpace will place all windows back to the visible area of the screen.
 
 AeroSpace shows the name of currently active workspace in its tray icon (top right corner), to give users a visual feedback on what workspace is currently active.
 
-The intended workflow of using AeroSpace workspaces is to only have one macOS Space (or as many monitors you have, if `Displays have separate Spaces` is enabled) and don't interact with macOS Spaces anymore.
+The intended workflow of using AeroSpace workspaces is to only have one macOS Space (or as many monitors you have, if `Displays have separate Spaces` is enabled) and don’t interact with macOS Spaces anymore.
 
 [NOTE]
 ====
-For better or worse, macOS doesn't allow to place windows outside the visible area entirely.
+For better or worse, macOS doesn’t allow to place windows outside the visible area entirely.
 You will still be able to see a 1 pixel vertical line of "hidden" windows in the bottom right or left corner of your screen.
 That means, that if AeroSpace crashes badly you will still be able to manually "unhide" the windows by dragging these few pixels to the center of the screen.
 
@@ -555,7 +555,7 @@ Available window conditions are:
 a|
 * If `true` then run the callback only during AeroSpace startup.
 * If `false` then run callback only *NOT* during AeroSpace startup.
-* If not specified then the condition isn't checked
+* If not specified then the condition isn’t checked
 
 |`if.workspace`
 |Window's workspace name exact match
@@ -564,7 +564,7 @@ a|
 
 * `if.during-aerospace-startup = true` is useful if you want to do the initial app arrangement only on startup.
 
-* `if.during-aerospace-startup = false` is useful if you want to relaunch AeroSpace, but the callback has side effects that you don't want to run on every relaunch.
+* `if.during-aerospace-startup = false` is useful if you want to relaunch AeroSpace, but the callback has side effects that you don’t want to run on every relaunch.
 (e.g. the callback opens new windows)
 
 There are several ways to know `app-id`:
@@ -652,7 +652,7 @@ xref:./goodies.adoc#show-aerospace-workspaces-in-sketchybar[]
 * The pool of workspaces is shared between monitors
 * Each monitor shows its own workspace.
 The showed workspaces are called"visible" workspaces
-* Different monitors can't show the same workspace at the same time
+* Different monitors can’t show the same workspace at the same time
 * Each workspace (even invisible, even empty) has a monitor assigned to it
 * By default, all workspaces are assigned to the "main" monitor ("main" as in `System -> Displays -> Use as`)
 

--- a/docs/guide.adoc
+++ b/docs/guide.adoc
@@ -113,6 +113,45 @@ link:config-examples/default-config.toml[Download default-config.toml]
 include::config-examples/default-config.toml[]
 ----
 
+==== Understanding Modifier Keys in Bindings
+
+AeroSpace allows you to define precise hotkey bindings using various modifier keys. With recent updates, you can now distinguish between left and right versions of modifier keys and use generic modifiers that trigger on either version.
+
+*Specific Modifiers:*
+You can specify the exact physical modifier key you want to use:
+
+* `lalt`: Left Option (Alt) key
+* `ralt`: Right Option (Alt) key
+* `lcmd`: Left Command key
+* `rcmd`: Right Command key
+* `lctrl`: Left Control key
+* `rctrl`: Right Control key
+* `lshift`: Left Shift key
+* `rshift`: Right Shift key
+* `fn`: Function key
+
+Example: `lalt-h = 'focus left'` (This will only trigger if the Left Alt key and 'h' are pressed).
+
+*Generic Modifiers:*
+For convenience and backward compatibility, you can use generic modifier names. When a generic modifier is used, the binding will trigger if *either* the left or right version of that key is pressed along with the other keys in the combination.
+
+* `alt`: Left Option OR Right Option
+* `cmd`: Left Command OR Right Command
+* `ctrl`: Left Control OR Right Control
+* `shift`: Left Shift OR Right Shift
+
+Example: `alt-h = 'focus left'` (This will trigger if Left Alt + H is pressed, OR if Right Alt + H is pressed).
+
+*Combining Modifiers:*
+You can combine multiple modifiers as before:
+
+* `lcmd-shift-t = 'some-command'` (Left Command + (Left OR Right Shift) + T)
+* `ralt-lctrl-x = 'another-command'` (Right Alt + Left Control + X)
+
+*Important Notes:*
+*   You cannot specify conflicting modifiers for the same key type within a single binding. For example, `alt-lalt-h` is an invalid binding because `alt` (generic option) and `lalt` (specific left option) both refer to the "option" key type. The configuration parser will report an error for such definitions. Use either the generic form (`alt-h`) or one or more specific forms (`lalt-h`, `ralt-h`, or even `lalt-ralt-h` if you intend for both to be pressed).
+*   The `fn` key is always specific; there is no generic "function key" token.
+
 [#binding-modes]
 === Binding modes
 
@@ -203,7 +242,7 @@ You can configure environment variables of `exec-*` commands and callbacks (such
 +
 Environment variable substitution is supported in form of `+${ENV_VAR}+`
 * You can inspect what is the end result of environment variables using xref:commands.adoc#list-exec-env-vars[`list-exec-env-vars` command]
-* GUI apps on macOS don’t have Homebrew’s prefix in their `PATH` by default (https://docs.brew.sh/FAQ#my-mac-apps-dont-find-homebrew-utilities[docs.brew.sh]).
+* GUI apps on macOS don't have Homebrew's prefix in their `PATH` by default (https://docs.brew.sh/FAQ#my-mac-apps-dont-find-homebrew-utilities[docs.brew.sh]).
 That's why unless you override `exec` section in your config, AeroSpace fallbacks to the following `exec` configuration:
 +
 [source,toml]
@@ -232,9 +271,9 @@ WARNING: i3 has a different terminology.
 . <<layouts,Layout>> (Possible values: `tiles`, `accordion`)
 . Orientation (Possible values: `horizontal`, `vertical`)
 
-When we say "layout of the window", we refer to the layout of the window’s parent container.
+When we say "layout of the window", we refer to the layout of the window's parent container.
 
-It’s easier to understand tree tiling model by looking at examples
+It's easier to understand tree tiling model by looking at examples
 
 .Simple tree structure. Two windows side-by-side
 image::assets/h_tiles.png[]
@@ -258,12 +297,12 @@ The tree structure can be changed with three commands:
 
 In total, AeroSpace provides 4 possible layouts:
 
-- `h_tiles` horizontal tiles (in i3, it’s called "horizontal split")
-- `v_tiles` vertical tiles (in i3, it’s called "vertical split")
-- `h_accordion` horizontal accordion (analog of i3’s "tabbed layout")
-- `v_accordion` vertical accordion (analog of i3’s "stacked layout")
+- `h_tiles` horizontal tiles (in i3, it's called "horizontal split")
+- `v_tiles` vertical tiles (in i3, it's called "vertical split")
+- `h_accordion` horizontal accordion (analog of i3's "tabbed layout")
+- `v_accordion` vertical accordion (analog of i3's "stacked layout")
 
-<<tree,From the previous section>>, you’re already familiar with the `tiles` layout.
+<<tree,From the previous section>>, you're already familiar with the `tiles` layout.
 
 Accordion is a layout where windows are placed on top of each other.
 
@@ -297,7 +336,7 @@ Configured by `enable-normalization-opposite-orientation-for-nested-containers`
 [.lead]
 *Example 1*
 
-According to the first normalization, such layout isn’t possible:
+According to the first normalization, such layout isn't possible:
 
 ----
 h_tiles (root node)
@@ -315,7 +354,7 @@ v_tiles (new root node)
 [.lead]
 *Example 2*
 
-According to the second normalization, such layout isn’t possible:
+According to the second normalization, such layout isn't possible:
 
 ----
 h_tiles
@@ -350,7 +389,7 @@ Unless you're hardcore i3 user who knows what they are doing, it's recommended t
 === Floating windows
 
 Normally, floating windows are not considered to be part of the <<tree,tiling tree>>.
-But it’s not the case with xref:commands.adoc#focus[focus] command.
+But it's not the case with xref:commands.adoc#focus[focus] command.
 
 From xref:commands.adoc#focus[focus] command perspective, floating windows are part of <<tree,tiling tree>>.
 The floating window parent container is determined as the smallest tiling container that contains the center of the floating window.
@@ -363,24 +402,24 @@ This technique eliminates the need for an additional binding for focusing floati
 Native macOS Spaces have a lot of problems
 
 * The animation for Spaces switching is slow
-** You can’t disable animation for Spaces switching (you can only make it slightly faster by turning on `Reduce motion` setting, but it’s suboptimal)
+** You can't disable animation for Spaces switching (you can only make it slightly faster by turning on `Reduce motion` setting, but it's suboptimal)
 * You have a limit of Spaces (up to 16 Spaces with one monitor)
-* You can’t create/delete/reorder Space and move windows between Spaces with hotkeys (you can only switch between Spaces with hotkeys)
+* You can't create/delete/reorder Space and move windows between Spaces with hotkeys (you can only switch between Spaces with hotkeys)
 * Apple doesn't provide public API to communicate with Spaces (create/delete/reorder/switch Space and move windows between Spaces)
 
 Since Spaces are so hard to deal with, AeroSpace reimplements Spaces and calls them "Workspaces".
-The idea is that if the workspace isn’t active then all of its windows are placed outside the visible area of the screen, in the bottom right or left corner.
+The idea is that if the workspace isn't active then all of its windows are placed outside the visible area of the screen, in the bottom right or left corner.
 Once you switch back to the workspace, (e.g. by the means of xref:commands.adoc#workspace[workspace] command, or `cmd + tab`) windows are placed back to the visible area of the screen.
 
 When you quit the AeroSpace or when the AeroSpace detects that it's about to crash, AeroSpace will place all windows back to the visible area of the screen.
 
 AeroSpace shows the name of currently active workspace in its tray icon (top right corner), to give users a visual feedback on what workspace is currently active.
 
-The intended workflow of using AeroSpace workspaces is to only have one macOS Space (or as many monitors you have, if `Displays have separate Spaces` is enabled) and don’t interact with macOS Spaces anymore.
+The intended workflow of using AeroSpace workspaces is to only have one macOS Space (or as many monitors you have, if `Displays have separate Spaces` is enabled) and don't interact with macOS Spaces anymore.
 
 [NOTE]
 ====
-For better or worse, macOS doesn’t allow to place windows outside the visible area entirely.
+For better or worse, macOS doesn't allow to place windows outside the visible area entirely.
 You will still be able to see a 1 pixel vertical line of "hidden" windows in the bottom right or left corner of your screen.
 That means, that if AeroSpace crashes badly you will still be able to manually "unhide" the windows by dragging these few pixels to the center of the screen.
 
@@ -516,7 +555,7 @@ Available window conditions are:
 a|
 * If `true` then run the callback only during AeroSpace startup.
 * If `false` then run callback only *NOT* during AeroSpace startup.
-* If not specified then the condition isn’t checked
+* If not specified then the condition isn't checked
 
 |`if.workspace`
 |Window's workspace name exact match
@@ -525,7 +564,7 @@ a|
 
 * `if.during-aerospace-startup = true` is useful if you want to do the initial app arrangement only on startup.
 
-* `if.during-aerospace-startup = false` is useful if you want to relaunch AeroSpace, but the callback has side effects that you don’t want to run on every relaunch.
+* `if.during-aerospace-startup = false` is useful if you want to relaunch AeroSpace, but the callback has side effects that you don't want to run on every relaunch.
 (e.g. the callback opens new windows)
 
 There are several ways to know `app-id`:
@@ -613,7 +652,7 @@ xref:./goodies.adoc#show-aerospace-workspaces-in-sketchybar[]
 * The pool of workspaces is shared between monitors
 * Each monitor shows its own workspace.
 The showed workspaces are called"visible" workspaces
-* Different monitors can’t show the same workspace at the same time
+* Different monitors can't show the same workspace at the same time
 * Each workspace (even invisible, even empty) has a monitor assigned to it
 * By default, all workspaces are assigned to the "main" monitor ("main" as in `System -> Displays -> Use as`)
 

--- a/docs/guide.adoc
+++ b/docs/guide.adoc
@@ -242,7 +242,7 @@ You can configure environment variables of `exec-*` commands and callbacks (such
 +
 Environment variable substitution is supported in form of `+${ENV_VAR}+`
 * You can inspect what is the end result of environment variables using xref:commands.adoc#list-exec-env-vars[`list-exec-env-vars` command]
-* GUI apps on macOS don't have Homebrew’s prefix in their `PATH` by default (https://docs.brew.sh/FAQ#my-mac-apps-dont-find-homebrew-utilities[docs.brew.sh]).
+* GUI apps on macOS don’t have Homebrew’s prefix in their `PATH` by default (https://docs.brew.sh/FAQ#my-mac-apps-dont-find-homebrew-utilities[docs.brew.sh]).
 That's why unless you override `exec` section in your config, AeroSpace fallbacks to the following `exec` configuration:
 +
 [source,toml]
@@ -389,7 +389,7 @@ Unless you're hardcore i3 user who knows what they are doing, it's recommended t
 === Floating windows
 
 Normally, floating windows are not considered to be part of the <<tree,tiling tree>>.
-But it's not the case with xref:commands.adoc#focus[focus] command.
+But it’s not the case with xref:commands.adoc#focus[focus] command.
 
 From xref:commands.adoc#focus[focus] command perspective, floating windows are part of <<tree,tiling tree>>.
 The floating window parent container is determined as the smallest tiling container that contains the center of the floating window.


### PR DESCRIPTION
# Overview

Goal was to test the viability of dropping HotKeys dependency as mentioned in #1012 . This feature has overlaps with requests by users in #1402 , #28 , #1011 . 

My own interest was to distinguish between left and right modifier keys. This PR successfully introduces `lalt`, `ralt` and `fn` keys. I did thoroughly test this functionality, but I am not a Swift developer, so it should be taken as an overly AI-reliant proof-of-concept. (Also, I apologize in advance for the commit hygiene here.) I also cannot recall if "Accessibility" permissions were required for AeroSpace with HotKeys, but they are a requirement with this PR.

# PR Details
## 1. Problem

The existing hotkey system relies on the `HotKey` library, which is a wrapper around Apple's legacy Carbon API (`RegisterEventHotKey`). The Carbon API (and thus `HotKey`) does not provide a straightforward way to differentiate between the left and right instances of modifier keys like Option (Alt), Command, Shift, or Control. It typically provides a single flag for each modifier type.

## 2. Solution Overview

To achieve the desired granularity, the hotkey detection mechanism has been migrated from the `HotKey` library/Carbon API to a lower-level `CGEvent.tapCreate` approach. This allows AeroSpace to directly monitor and interpret system-wide keyboard events, including the specific virtual key codes for each physical key press and release.

**Core changes involve:**

*   Modifying the configuration parsing to accept new syntax for specific modifiers (e.g., `lalt`, `rcmd`) and generic modifiers (e.g., `alt` now means left OR right).
*   Updating internal data structures for hotkey bindings (`HotkeyBinding` struct now uses `exactModifiers` and `genericModifiers`) to store these specific and generic modifier requirements.
*   Implementing a new `GlobalHotkeyMonitor` service that uses `CGEvent.tapCreate` to:
    *   Track the state of individual (left/right) modifier keys based on their virtual key codes.
    *   Match incoming key events against the user's configured hotkeys, respecting specific vs. generic modifiers and ensuring correct modifier counts.
    *   Execute the associated commands.
*   Integrating this new monitor into the application lifecycle.
*   Phasing out and removing the `HotKey` library dependency.


## 3. Details
### 3.1. New `GlobalHotkeyMonitor` (`Sources/AppBundle/GlobalHotkeyMonitor.swift`)

*   A new class responsible for global hotkey detection using `CGEvent.tapCreate`.
*   **Responsibilities:**
    *   Sets up a `CGEventTap` for `keyDown`, `keyUp`, and `flagsChanged` event types.
    *   Maintains a `pressedModifierKeyCodes: Set<UInt16>` to track the real-time state of *specific* modifier keys. This state is protected by an internal `os_unfair_lock_s` (`stateLock`).
    *   Maintains a cached version of the current mode's bindings (`bindingsByKeyCode`) and the `lastKnownModeName`, also protected by `stateLock`. This cache is populated and updated by an `@MainActor`-isolated method (`updateBindingsCache`) that reads the global `@MainActor`-isolated `config` and `activeMode`.
    *   `updateBindingsCache()` is called during `start()` and whenever the global `activeMode` or `config` is potentially changed (e.g., via `activateMode()` or config reload).
    *   `handleEvent_Outer` (the `CGEventTap` callback, marked `nonisolated`):
        *   Runs on the event tap's thread.
        *   For `keyDown`, `keyUp`, and `flagsChanged` events: Updates `pressedModifierKeyCodes` (under `stateLock`).
        *   If it's a non-modifier `keyDown`, it calls `findAndExecuteHotkeyMatch_TapThread` to check for a match.
    *   `findAndExecuteHotkeyMatch_TapThread` method:
        *   Called from `handleEvent_Outer` (on the tap thread).
        *   Briefly acquires `stateLock` to make local copies of the relevant candidate bindings (from `bindingsByKeyCode`) and the current `pressedModifierKeyCodes`.
        *   Releases `stateLock` immediately after copying.
        *   Performs the comparison logic on these local copies (incoming non-modifier key's virtual code and current modifier state vs. `HotkeyBinding` requirements) *without* holding the lock.
        *   If a match is found, it asynchronously dispatches the execution of `binding.commands` to the main actor (using `DispatchQueue.main.async` and `Task`), and returns `true` to indicate the event should be consumed.
        *   This design resolves previous deadlocks, minimizes lock contention, and ensures correct event consumption.
*   Handles starting and stopping the event tap. `start()` and `stop()` methods are `@MainActor`-isolated.

### 3.2. Integration into App Lifecycle (`Sources/AppBundle/initAppBundle.swift`)

*   A global instance of `GlobalHotkeyMonitor` is created.
*   `globalHotkeyMonitor.start()` is called during `initAppBundle()` after accessibility permissions are checked and the initial config is loaded.
*   A `NSApplication.willTerminateNotification` observer is added to call `globalHotkeyMonitor.stop()` on application quit, ensuring the event tap is properly released.

## 4. Key New Concepts/Files

*   **`PhysicalModifierKey` (in `keysMap.swift`):** An enum representing distinct physical modifier keys (e.g., `leftShift`, `rightOption`).
*   **`GenericModifierType` (in `keysMap.swift`):** An enum representing generic modifier types (e.g., `.option`, `.command`).
*   **Virtual Key Code Mappings (in `keysMap.swift`):**
    *   `specificModifiersMap`: String token (e.g., "lalt") to `PhysicalModifierKey`.
    *   `genericModifiersMap`: String token (e.g., "alt") to `GenericModifierType`.
    *   `physicalModifierKeyToKeyCode`: `PhysicalModifierKey` to `UInt16`.
    *   `keyNotationToVirtualKeyCode`: String key name to `UInt16`.
*   **`HotkeyBinding.swift`:** Struct updated with `exactModifiers: Set<PhysicalModifierKey>` and `genericModifiers: Set<GenericModifierType>`.
*   **`GlobalHotkeyMonitor.swift`:** The new central service for capturing and processing global keyboard events via `CGEventTap`.
