### PR TITLE
Add "--no-preserve-windows" flag to "enable" command 

### DIFF
--- a/Sources/AppBundle/command/impl/EnableCommand.swift
+++ b/Sources/AppBundle/command/impl/EnableCommand.swift
@@ -16,9 +16,14 @@ struct EnableCommand: Command {
                 "Tip: use --fail-if-noop to exit with non-zero code")
             return !args.failIfNoop
         }
+        if newState && args.noPreserveWindows {
+            io.out("--no-preserve-windows doesn't mean anything when aerospace is enabled")
+            return false
+        }
 
         TrayMenuModel.shared.isEnabled = newState
         if newState {
+            TrayMenuModel.shared.shouldPreserveWindowsOnDisable = true
             for workspace in Workspace.all {
                 for window in workspace.allLeafWindowsRecursive where window.isFloating {
                     window.lastFloatingSize = try await window.getAxSize() ?? window.lastFloatingSize
@@ -26,6 +31,7 @@ struct EnableCommand: Command {
             }
             activateMode(mainModeId)
         } else {
+            TrayMenuModel.shared.shouldPreserveWindowsOnDisable = !args.noPreserveWindows
             activateMode(nil)
         }
         return true

--- a/Sources/AppBundle/layout/refresh.swift
+++ b/Sources/AppBundle/layout/refresh.swift
@@ -138,9 +138,11 @@ enum OptimalHideCorner {
 @MainActor
 private func layoutWorkspaces() async throws {
     if !TrayMenuModel.shared.isEnabled {
-        for workspace in Workspace.all {
-            workspace.allLeafWindowsRecursive.forEach { ($0 as! MacWindow).unhideFromCorner() } // todo as!
-            try await workspace.layoutWorkspace() // Unhide tiling windows from corner
+        if TrayMenuModel.shared.shouldPreserveWindowsOnDisable {
+            for workspace in Workspace.all {
+                workspace.allLeafWindowsRecursive.forEach { ($0 as! MacWindow).unhideFromCorner() } // todo as!
+                try await workspace.layoutWorkspace() // Unhide tiling windows from corner
+            }
         }
         return
     }

--- a/Sources/AppBundle/ui/TrayMenuModel.swift
+++ b/Sources/AppBundle/ui/TrayMenuModel.swift
@@ -10,6 +10,7 @@ public class TrayMenuModel: ObservableObject {
     @Published var trayItems: [TrayItem] = []
     /// Is "layouting" enabled
     @Published var isEnabled: Bool = true
+    @Published var shouldPreserveWindowsOnDisable: Bool = true
     @Published var workspaces: [WorkspaceViewModel] = []
     @Published var experimentalUISettings: ExperimentalUISettings = ExperimentalUISettings()
 }

--- a/Sources/Common/cmdArgs/impl/EnableCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/EnableCmdArgs.swift
@@ -7,6 +7,7 @@ public struct EnableCmdArgs: CmdArgs {
         help: enable_help_generated,
         options: [
             "--fail-if-noop": trueBoolFlag(\.failIfNoop),
+            "--no-preserve-windows": trueBoolFlag(\.noPreserveWindows),
         ],
         arguments: [newArgParser(\.targetState, parseState, mandatoryArgPlaceholder: EnableCmdArgs.State.unionLiteral)]
     )
@@ -14,6 +15,7 @@ public struct EnableCmdArgs: CmdArgs {
     public var workspaceName: WorkspaceName?
     public var targetState: Lateinit<State> = .uninitialized
     public var failIfNoop: Bool = false
+    public var noPreserveWindows: Bool = false
 
     public init(rawArgs: [String], targetState: State) {
         self.rawArgs = .init(rawArgs)
@@ -28,6 +30,7 @@ public struct EnableCmdArgs: CmdArgs {
 public func parseEnableCmdArgs(_ args: [String]) -> ParsedCmd<EnableCmdArgs> {
     return parseSpecificCmdArgs(EnableCmdArgs(rawArgs: args), args)
         .filterNot("--fail-if-noop is incompatible with 'toggle' argument") { $0.targetState.val == .toggle && $0.failIfNoop }
+        .filterNot("--no-preserve-windows is incompatible with 'enable' argument") { $0.targetState.val == .on && $0.noPreserveWindows }
 }
 
 private func parseState(arg: String, nextArgs: inout [String]) -> Parsed<EnableCmdArgs.State> {


### PR DESCRIPTION
First off, I'm excited to contribute to Aerospace, an app I've relied on heavily on macOS. This is my first ever open-source contribution, and I hope it meets expectations.

This PR adds a --no-preserve-windows option to the enable command, as discussed in #705. When used with off or toggle, it prevents windows from being moved or rearranged.

Implementation details:
- Shared state is introduced in TrayMenuModel to communicate preservation intent between the command and layout system.
- Validation is added to prevent incompatible flag combinations.

Proposed syntax:
```
aerospace enable off --no-preserve-windows    # Disable without moving hidden windows
aerospace enable toggle --no-preserve-windows # Toggle with preservation if disabling
aerospace enable on --no-preserve-windows     # Error: incompatible
```
I'm happy to make any necessary adjustments or additions.