### PR TITLE
Add max width settings for single-window workspaces and fullscreen

### DIFF
--- a/Sources/AppBundle/command/impl/FullscreenCommand.swift
+++ b/Sources/AppBundle/command/impl/FullscreenCommand.swift
@@ -21,6 +21,7 @@ struct FullscreenCommand: Command {
         }
         window.isFullscreen = newState
         window.noOuterGapsInFullscreen = args.noOuterGaps
+        window.noMaxWidthInFullscreen = args.noMaxWidth
 
         // Focus on its own workspace
         window.markAsMostRecentChild()

--- a/Sources/AppBundle/config/Config.swift
+++ b/Sources/AppBundle/config/Config.swift
@@ -52,6 +52,8 @@ struct Config: ConvenienceCopyable {
     var onFocusedMonitorChanged: [any Command] = []
 
     var gaps: Gaps = .zero
+    var singleWindowMaxWidthPercent: DynamicConfigValue<Int> = .constant(100)
+    var singleWindowExcludeAppIds: [String] = []
     var workspaceToMonitorForceAssignment: [String: [MonitorDescription]] = [:]
     var modes: [String: Mode] = [:]
     var onWindowDetected: [WindowDetectedCallback] = []

--- a/Sources/AppBundle/config/parseGaps.swift
+++ b/Sources/AppBundle/config/parseGaps.swift
@@ -68,17 +68,34 @@ struct ResolvedGaps {
         let right: Int
     }
 
-    init(gaps: Gaps, monitor: any Monitor) {
+    init(gaps: Gaps, monitor: any Monitor, singleWindowSideGap: Int = 0) {
         inner = .init(
             vertical: gaps.inner.vertical.getValue(for: monitor),
             horizontal: gaps.inner.horizontal.getValue(for: monitor),
         )
 
+        let baseOuterLeft = gaps.outer.left.getValue(for: monitor)
+        let baseOuterBottom = gaps.outer.bottom.getValue(for: monitor)
+        let baseOuterTop = gaps.outer.top.getValue(for: monitor)
+        let baseOuterRight = gaps.outer.right.getValue(for: monitor)
+
+        let finalLeft = baseOuterLeft + singleWindowSideGap
+        let finalRight = baseOuterRight + singleWindowSideGap
+
         outer = .init(
-            left: gaps.outer.left.getValue(for: monitor),
-            bottom: gaps.outer.bottom.getValue(for: monitor),
-            top: gaps.outer.top.getValue(for: monitor),
-            right: gaps.outer.right.getValue(for: monitor),
+            left: finalLeft,
+            bottom: baseOuterBottom,
+            top: baseOuterTop,
+            right: finalRight,
+        )
+    }
+
+    func applyToRect(_ baseRect: Rect) -> Rect {
+        return Rect(
+            topLeftX: baseRect.topLeftX + outer.left.toDouble(),
+            topLeftY: baseRect.topLeftY + outer.top.toDouble(),
+            width: baseRect.width - outer.left.toDouble() - outer.right.toDouble(),
+            height: baseRect.height - outer.top.toDouble() - outer.bottom.toDouble(),
         )
     }
 }

--- a/Sources/AppBundle/focus.swift
+++ b/Sources/AppBundle/focus.swift
@@ -68,6 +68,11 @@ struct FrozenFocus: AeroAny, Equatable, Sendable {
         oldFocus.windowOrNil?.markAsMostRecentChild()
     }
 
+    // Clear fullscreen state when focus switches away from a fullscreen window
+    if let oldWindow = oldFocus.windowOrNil, oldWindow.isFullscreen, oldWindow != newFocus.windowOrNil {
+        oldWindow.isFullscreen = false
+    }
+
     _focus = newFocus.frozen
     let status = newFocus.workspace.workspaceMonitor.setActiveWorkspace(newFocus.workspace)
 

--- a/Sources/AppBundle/model/MonitorEx.swift
+++ b/Sources/AppBundle/model/MonitorEx.swift
@@ -1,14 +1,8 @@
 extension Monitor {
     @MainActor
     var visibleRectPaddedByOuterGaps: Rect {
-        let topLeft = visibleRect.topLeftCorner
         let gaps = ResolvedGaps(gaps: config.gaps, monitor: self)
-        return Rect(
-            topLeftX: topLeft.x + gaps.outer.left.toDouble(),
-            topLeftY: topLeft.y + gaps.outer.top.toDouble(),
-            width: visibleRect.width - gaps.outer.left.toDouble() - gaps.outer.right.toDouble(),
-            height: visibleRect.height - gaps.outer.top.toDouble() - gaps.outer.bottom.toDouble(),
-        )
+        return gaps.applyToRect(visibleRect)
     }
 
     /// todo make 1-based

--- a/Sources/AppBundle/tree/Window.swift
+++ b/Sources/AppBundle/tree/Window.swift
@@ -7,6 +7,7 @@ class Window: TreeNode, Hashable {
     var lastFloatingSize: CGSize?
     var isFullscreen: Bool = false
     var noOuterGapsInFullscreen: Bool = false
+    var noMaxWidthInFullscreen: Bool = false
     var layoutReason: LayoutReason = .standard
 
     @MainActor

--- a/Sources/AppBundleTests/command/FullscreenCommandTest.swift
+++ b/Sources/AppBundleTests/command/FullscreenCommandTest.swift
@@ -1,0 +1,455 @@
+@testable import AppBundle
+import Common
+import XCTest
+
+@MainActor
+final class FullscreenCommandTest: XCTestCase {
+    override func setUp() async throws { setUpWorkspacesForTests() }
+
+    func testFullscreenToggle() async throws {
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+        assertEquals(window.focusWindow(), true)
+
+        // Test toggle on
+        let result1 = try await parseCommand("fullscreen").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result1.exitCode, 0)
+        assertEquals(window.isFullscreen, true)
+
+        // Test toggle off
+        let result2 = try await parseCommand("fullscreen").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result2.exitCode, 0)
+        assertEquals(window.isFullscreen, false)
+    }
+
+    func testFullscreenOn() async throws {
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+        assertEquals(window.focusWindow(), true)
+
+        let result = try await parseCommand("fullscreen on").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode, 0)
+        assertEquals(window.isFullscreen, true)
+    }
+
+    func testFullscreenOff() async throws {
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+        assertEquals(window.focusWindow(), true)
+        window.isFullscreen = true
+
+        let result = try await parseCommand("fullscreen off").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode, 0)
+        assertEquals(window.isFullscreen, false)
+    }
+
+    func testNoOuterGapsFlag() async throws {
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+        assertEquals(window.focusWindow(), true)
+
+        let result = try await parseCommand("fullscreen --no-outer-gaps on").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode, 0)
+        assertEquals(window.isFullscreen, true)
+        assertEquals(window.noOuterGapsInFullscreen, true)
+        assertEquals(window.noMaxWidthInFullscreen, false)
+    }
+
+    func testNoMaxWidthFlag() async throws {
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+        assertEquals(window.focusWindow(), true)
+
+        let result = try await parseCommand("fullscreen --no-max-width on").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode, 0)
+        assertEquals(window.isFullscreen, true)
+        assertEquals(window.noMaxWidthInFullscreen, true)
+        assertEquals(window.noOuterGapsInFullscreen, false)
+    }
+
+    func testBothFlags() async throws {
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+        assertEquals(window.focusWindow(), true)
+
+        let result = try await parseCommand("fullscreen --no-outer-gaps --no-max-width on").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode, 0)
+        assertEquals(window.isFullscreen, true)
+        assertEquals(window.noOuterGapsInFullscreen, true)
+        assertEquals(window.noMaxWidthInFullscreen, true)
+    }
+
+    func testNoMaxWidthFlagWithToggle() async throws {
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+        assertEquals(window.focusWindow(), true)
+
+        // Toggle on with --no-max-width
+        let result1 = try await parseCommand("fullscreen --no-max-width").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result1.exitCode, 0)
+        assertEquals(window.isFullscreen, true)
+        assertEquals(window.noMaxWidthInFullscreen, true)
+
+        // Toggle off should preserve window state but turn off fullscreen
+        let result2 = try await parseCommand("fullscreen").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result2.exitCode, 0)
+        assertEquals(window.isFullscreen, false)
+    }
+
+    func testNoMaxWidthFlagDoubleToggle() async throws {
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+        assertEquals(window.focusWindow(), true)
+
+        // First toggle: Turn on fullscreen with --no-max-width
+        let result1 = try await parseCommand("fullscreen --no-max-width").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result1.exitCode, 0)
+        assertEquals(window.isFullscreen, true)
+        assertEquals(window.noMaxWidthInFullscreen, true)
+
+        // Second toggle: Run the same command again - should turn OFF fullscreen
+        let result2 = try await parseCommand("fullscreen --no-max-width").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result2.exitCode, 0)
+        assertEquals(window.isFullscreen, false)
+        assertEquals(window.noMaxWidthInFullscreen, true)  // Should preserve the flag
+    }
+
+
+    func testFailIfNoop() async throws {
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+        assertEquals(window.focusWindow(), true)
+        window.isFullscreen = true
+
+        let result = try await parseCommand("fullscreen --fail-if-noop on").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode, 1)
+        assertEquals(window.isFullscreen, true)
+    }
+
+    func testNoWindowFocused() async throws {
+        // No focused window
+        let result = try await parseCommand("fullscreen on").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode, 1)
+        assertEquals(result.stderr.joined(separator: "\n"), "No window is focused")
+    }
+
+    func testFullscreenCallsMarkAsMostRecentChild() async throws {
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+        assertEquals(window.focusWindow(), true)
+
+        let result = try await parseCommand("fullscreen on").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode, 0)
+        assertEquals(window.isFullscreen, true)
+
+        // This test verifies that the fullscreen command executes without error
+        // and properly sets the fullscreen state - the implementation calls markAsMostRecentChild
+    }
+
+    // MARK: - Command Argument Parsing Tests
+
+    func testParseNoMaxWidthFlag() {
+        testParseCommandSucc(
+            "fullscreen --no-max-width on",
+            createFullscreenCmdArgs(toggle: .on, noMaxWidth: true),
+        )
+    }
+
+    func testParseNoOuterGapsFlag() {
+        testParseCommandSucc(
+            "fullscreen --no-outer-gaps on",
+            createFullscreenCmdArgs(toggle: .on, noOuterGaps: true),
+        )
+    }
+
+    func testParseBothFlags() {
+        testParseCommandSucc(
+            "fullscreen --no-outer-gaps --no-max-width on",
+            createFullscreenCmdArgs(toggle: .on, noOuterGaps: true, noMaxWidth: true),
+        )
+    }
+
+    func testParseToggleDefault() {
+        testParseCommandSucc(
+            "fullscreen --no-max-width",
+            createFullscreenCmdArgs(toggle: .toggle, noMaxWidth: true),
+        )
+    }
+
+    func testParseFailIfNoop() {
+        testParseCommandSucc(
+            "fullscreen --fail-if-noop on",
+            createFullscreenCmdArgs(toggle: .on, failIfNoop: true),
+        )
+    }
+
+    // MARK: - Error Cases
+
+    func testNoOuterGapsIncompatibleWithOff() {
+        testParseCommandFail(
+            "fullscreen --no-outer-gaps off",
+            msg: "--no-outer-gaps is incompatible with 'off' argument",
+        )
+    }
+
+    func testNoMaxWidthIncompatibleWithOff() {
+        testParseCommandFail(
+            "fullscreen --no-max-width off",
+            msg: "--no-max-width is incompatible with 'off' argument",
+        )
+    }
+
+    func testFailIfNoopRequiresOnOrOff() {
+        testParseCommandFail(
+            "fullscreen --fail-if-noop",
+            msg: "--fail-if-noop requires 'on' or 'off' argument",
+        )
+    }
+
+    // MARK: - Single-Window Max Width Integration Tests
+
+    func testFullscreenRespectsSingleWindowMaxWidth() async throws {
+        config.singleWindowMaxWidthPercent = .constant(70)
+
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+        assertEquals(window.focusWindow(), true)
+
+        let result = try await parseCommand("fullscreen on").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode, 0)
+        assertEquals(window.isFullscreen, true)
+
+        // Trigger layout to verify fullscreen respects single-window width constraints
+        try await workspace.layoutWorkspace()
+
+        let monitorWidth = workspace.workspaceMonitor.visibleRect.width
+        let expectedMaxWidth = monitorWidth * 0.7
+        let actualRect = window.lastAppliedLayoutPhysicalRect!
+
+        // Fullscreen should respect single-window max width by default
+        assertEquals(actualRect.width, expectedMaxWidth)
+    }
+
+    func testFullscreenWithNoMaxWidthBypassesSingleWindowConstraints() async throws {
+        config.singleWindowMaxWidthPercent = .constant(60)
+
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+        assertEquals(window.focusWindow(), true)
+
+        let result = try await parseCommand("fullscreen --no-max-width on").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode, 0)
+        assertEquals(window.isFullscreen, true)
+        assertEquals(window.noMaxWidthInFullscreen, true)
+
+        // Trigger layout to verify --no-max-width bypasses width constraints
+        try await workspace.layoutWorkspace()
+
+        let monitorWidth = workspace.workspaceMonitor.visibleRect.width
+        let actualRect = window.lastAppliedLayoutPhysicalRect!
+
+        // With --no-max-width, should use full monitor width
+        assertEquals(actualRect.width, monitorWidth)
+        assertEquals(actualRect.topLeftX, 0.0)
+    }
+
+    func testFullscreenWithBothFlagsAndSingleWindowConfig() async throws {
+        config.singleWindowMaxWidthPercent = .constant(80)
+        config.gaps.outer.left = .constant(10)
+        config.gaps.outer.right = .constant(10)
+
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+        assertEquals(window.focusWindow(), true)
+
+        // Use both flags - --no-max-width should override single-window constraints
+        let result = try await parseCommand("fullscreen --no-outer-gaps --no-max-width on").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode, 0)
+        assertEquals(window.isFullscreen, true)
+        assertEquals(window.noOuterGapsInFullscreen, true)
+        assertEquals(window.noMaxWidthInFullscreen, true)
+
+        try await workspace.layoutWorkspace()
+
+        let monitorRect = workspace.workspaceMonitor.visibleRect
+        let actualRect = window.lastAppliedLayoutPhysicalRect!
+
+        // Should use full monitor rect (no gaps, no width constraints)
+        assertEquals(actualRect.width, monitorRect.width)
+        assertEquals(actualRect.height, monitorRect.height)
+        assertEquals(actualRect.topLeftX, monitorRect.topLeftX)
+        assertEquals(actualRect.topLeftY, monitorRect.topLeftY)
+    }
+
+
+    func testFullscreenExcludedAppBypassesSingleWindowConstraints() async throws {
+        config.singleWindowMaxWidthPercent = .constant(50)
+        config.singleWindowExcludeAppIds = ["bobko.AeroSpace.test-app"]
+
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+        assertEquals(window.focusWindow(), true)
+
+        let result = try await parseCommand("fullscreen on").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode, 0)
+        assertEquals(window.isFullscreen, true)
+
+        try await workspace.layoutWorkspace()
+
+        let monitorWidth = workspace.workspaceMonitor.visibleRect.width
+        let actualRect = window.lastAppliedLayoutPhysicalRect!
+
+        // Excluded app should bypass single-window width constraints even in fullscreen
+        assertEquals(actualRect.width, monitorWidth)
+    }
+
+    func testFullscreenPerMonitorSingleWindowConfig() async throws {
+        config.singleWindowMaxWidthPercent = .perMonitor([
+            PerMonitorValue(description: MonitorDescription.pattern(".*")!, value: 75),
+        ], default: 100)
+
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+        assertEquals(window.focusWindow(), true)
+
+        let result = try await parseCommand("fullscreen on").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode, 0)
+        assertEquals(window.isFullscreen, true)
+
+        try await workspace.layoutWorkspace()
+
+        let monitorWidth = workspace.workspaceMonitor.visibleRect.width
+        let expectedMaxWidth = monitorWidth * 0.75
+        let actualRect = window.lastAppliedLayoutPhysicalRect!
+
+        // Should respect per-monitor single-window configuration
+        assertEquals(actualRect.width, expectedMaxWidth)
+    }
+
+    // MARK: - Focus Switching Tests
+
+    func testFullscreenExitsWhenFocusSwitchesToOtherWindow() async throws {
+        let workspace = Workspace.get(byName: name)
+        let window1 = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+        let window2 = TestWindow.new(id: 2, parent: workspace.rootTilingContainer)
+
+        // Focus and fullscreen window1
+        assertEquals(window1.focusWindow(), true)
+        let result1 = try await parseCommand("fullscreen on").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result1.exitCode, 0)
+        assertEquals(window1.isFullscreen, true)
+
+        // Switch focus to window2
+        assertEquals(window2.focusWindow(), true)
+
+        // Window1 should no longer be fullscreen
+        assertEquals(window1.isFullscreen, false)
+        assertEquals(window2.isFullscreen, false)
+    }
+
+    func testFullscreenExitsWhenFocusSwitchesToWorkspace() async throws {
+        let workspace1 = Workspace.get(byName: name)
+        let workspace2 = Workspace.get(byName: "workspace2")
+        let window1 = TestWindow.new(id: 1, parent: workspace1.rootTilingContainer)
+        let window2 = TestWindow.new(id: 2, parent: workspace2.rootTilingContainer)
+
+        // Focus and fullscreen window1 in workspace1
+        assertEquals(window1.focusWindow(), true)
+        let result1 = try await parseCommand("fullscreen on").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result1.exitCode, 0)
+        assertEquals(window1.isFullscreen, true)
+
+        // Switch to workspace2 and focus window2
+        assertEquals(window2.focusWindow(), true)
+
+        // Window1 should no longer be fullscreen
+        assertEquals(window1.isFullscreen, false)
+        assertEquals(window2.isFullscreen, false)
+    }
+
+    func testFullscreenDoesNotReturnWhenRefocusingPreviouslyFullscreenWindow() async throws {
+        let workspace = Workspace.get(byName: name)
+        let window1 = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+        let window2 = TestWindow.new(id: 2, parent: workspace.rootTilingContainer)
+
+        // Focus and fullscreen window1
+        assertEquals(window1.focusWindow(), true)
+        let result1 = try await parseCommand("fullscreen on").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result1.exitCode, 0)
+        assertEquals(window1.isFullscreen, true)
+
+        // Switch focus to window2
+        assertEquals(window2.focusWindow(), true)
+        assertEquals(window1.isFullscreen, false)
+
+        // Switch focus back to window1
+        assertEquals(window1.focusWindow(), true)
+
+        // Window1 should remain NOT fullscreen
+        assertEquals(window1.isFullscreen, false)
+        assertEquals(window2.isFullscreen, false)
+    }
+
+    func testMultipleFullscreenWindowsInDifferentWorkspaces() async throws {
+        let workspace1 = Workspace.get(byName: name)
+        let workspace2 = Workspace.get(byName: "workspace2")
+        let window1 = TestWindow.new(id: 1, parent: workspace1.rootTilingContainer)
+        let window2 = TestWindow.new(id: 2, parent: workspace2.rootTilingContainer)
+
+        // Fullscreen window1 in workspace1
+        assertEquals(window1.focusWindow(), true)
+        let result1 = try await parseCommand("fullscreen on").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result1.exitCode, 0)
+        assertEquals(window1.isFullscreen, true)
+
+        // Switch to workspace2 and fullscreen window2
+        assertEquals(window2.focusWindow(), true)
+        assertEquals(window1.isFullscreen, false) // Should exit fullscreen
+
+        let result2 = try await parseCommand("fullscreen on").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result2.exitCode, 0)
+        assertEquals(window2.isFullscreen, true)
+
+        // Switch back to workspace1
+        assertEquals(window1.focusWindow(), true)
+        assertEquals(window2.isFullscreen, false) // Should exit fullscreen
+        assertEquals(window1.isFullscreen, false) // Should remain not fullscreen
+    }
+
+    func testFullscreenOnlyExitWhenActuallyChangingFocus() async throws {
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+
+        // Focus and fullscreen window
+        assertEquals(window.focusWindow(), true)
+        let result1 = try await parseCommand("fullscreen on").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result1.exitCode, 0)
+        assertEquals(window.isFullscreen, true)
+
+        // "Focus" the same window again (should be no-op)
+        assertEquals(window.focusWindow(), true)
+
+        // Window should remain fullscreen since focus didn't actually change
+        assertEquals(window.isFullscreen, true)
+    }
+}
+
+private func createFullscreenCmdArgs(toggle: ToggleEnum, noOuterGaps: Bool = false, noMaxWidth: Bool = false, failIfNoop: Bool = false) -> FullscreenCmdArgs {
+    var cmdArgs: [String] = []
+
+    if noOuterGaps { cmdArgs.append("--no-outer-gaps") }
+    if noMaxWidth { cmdArgs.append("--no-max-width") }
+    if failIfNoop { cmdArgs.append("--fail-if-noop") }
+
+    switch toggle {
+        case .on: cmdArgs.append("on")
+        case .off: cmdArgs.append("off")
+        case .toggle: break // default, no argument needed
+    }
+
+    switch parseFullscreenCmdArgs(cmdArgs) {
+        case .cmd(let args): return args
+        case .failure(let msg): fatalError("Failed to create test args: \(msg)")
+        case .help: fatalError("Unexpected help result")
+    }
+}

--- a/Sources/AppBundleTests/config/ResolvedGapsTest.swift
+++ b/Sources/AppBundleTests/config/ResolvedGapsTest.swift
@@ -1,0 +1,84 @@
+@testable import AppBundle
+import Common
+import XCTest
+
+@MainActor
+final class ResolvedGapsTest: XCTestCase {
+    func testApplyToRectWithStandardGaps() {
+        let gaps = Gaps(inner: .init(vertical: 5, horizontal: 5), outer: .init(left: 10, bottom: 10, top: 10, right: 10))
+        let resolvedGaps = ResolvedGaps(gaps: gaps, monitor: mainMonitor)
+
+        let baseRect = Rect(topLeftX: 0, topLeftY: 0, width: 1000, height: 1000)
+        let result = resolvedGaps.applyToRect(baseRect)
+
+        assertEquals(result.topLeftX, 10.0)
+        assertEquals(result.topLeftY, 10.0)
+        assertEquals(result.width, 980.0)
+        assertEquals(result.height, 980.0)
+    }
+
+    func testApplyToRectWithZeroGaps() {
+        let gaps = Gaps.zero
+        let resolvedGaps = ResolvedGaps(gaps: gaps, monitor: mainMonitor)
+
+        let baseRect = Rect(topLeftX: 100, topLeftY: 100, width: 800, height: 600)
+        let result = resolvedGaps.applyToRect(baseRect)
+
+        assertEquals(result.topLeftX, 100.0)
+        assertEquals(result.topLeftY, 100.0)
+        assertEquals(result.width, 800.0)
+        assertEquals(result.height, 600.0)
+    }
+
+    func testApplyToRectWithAsymmetricGaps() {
+        let gaps = Gaps(inner: .init(vertical: 5, horizontal: 5), outer: .init(left: 20, bottom: 5, top: 30, right: 10))
+        let resolvedGaps = ResolvedGaps(gaps: gaps, monitor: mainMonitor)
+
+        let baseRect = Rect(topLeftX: 0, topLeftY: 0, width: 1920, height: 1080)
+        let result = resolvedGaps.applyToRect(baseRect)
+
+        assertEquals(result.topLeftX, 20.0)
+        assertEquals(result.topLeftY, 30.0)
+        assertEquals(result.width, 1890.0)
+        assertEquals(result.height, 1045.0)
+    }
+
+    func testApplyToRectWithSingleWindowGap() {
+        let gaps = Gaps(inner: .init(vertical: 5, horizontal: 5), outer: .init(left: 10, bottom: 10, top: 10, right: 10))
+        let resolvedGaps = ResolvedGaps(gaps: gaps, monitor: mainMonitor, singleWindowSideGap: 100)
+
+        let baseRect = Rect(topLeftX: 0, topLeftY: 0, width: 1920, height: 1080)
+        let result = resolvedGaps.applyToRect(baseRect)
+
+        assertEquals(result.topLeftX, 110.0)
+        assertEquals(result.topLeftY, 10.0)
+        assertEquals(result.width, 1700.0)
+        assertEquals(result.height, 1060.0)
+    }
+
+    func testApplyToRectWithLargeGaps() {
+        let gaps = Gaps(inner: .init(vertical: 5, horizontal: 5), outer: .init(left: 400, bottom: 300, top: 300, right: 400))
+        let resolvedGaps = ResolvedGaps(gaps: gaps, monitor: mainMonitor)
+
+        let baseRect = Rect(topLeftX: 0, topLeftY: 0, width: 1920, height: 1080)
+        let result = resolvedGaps.applyToRect(baseRect)
+
+        assertEquals(result.topLeftX, 400.0)
+        assertEquals(result.topLeftY, 300.0)
+        assertEquals(result.width, 1120.0)
+        assertEquals(result.height, 480.0)
+    }
+
+    func testApplyToRectWithNegativePosition() {
+        let gaps = Gaps(inner: .init(vertical: 5, horizontal: 5), outer: .init(left: 10, bottom: 10, top: 10, right: 10))
+        let resolvedGaps = ResolvedGaps(gaps: gaps, monitor: mainMonitor)
+
+        let baseRect = Rect(topLeftX: -100, topLeftY: -100, width: 1920, height: 1080)
+        let result = resolvedGaps.applyToRect(baseRect)
+
+        assertEquals(result.topLeftX, -90.0)
+        assertEquals(result.topLeftY, -90.0)
+        assertEquals(result.width, 1900.0)
+        assertEquals(result.height, 1060.0)
+    }
+}

--- a/Sources/AppBundleTests/layout/MultiMonitorSingleWindowTest.swift
+++ b/Sources/AppBundleTests/layout/MultiMonitorSingleWindowTest.swift
@@ -1,0 +1,210 @@
+@testable import AppBundle
+import Common
+import XCTest
+
+@MainActor
+final class MultiMonitorSingleWindowTest: XCTestCase {
+    override func setUp() async throws { setUpWorkspacesForTests() }
+
+    func testPerMonitorSingleWindowConfigurationConstant() async throws {
+        config.singleWindowMaxWidthPercent = .perMonitor([
+            PerMonitorValue(description: MonitorDescription.pattern(".*")!, value: 80),
+        ], default: 90)
+
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+
+        try await workspace.layoutWorkspace()
+
+        let monitorWidth = workspace.workspaceMonitor.visibleRect.width
+        let expectedMaxWidth = monitorWidth * 0.8 // Should use per-monitor value
+        let expectedSideGap = (monitorWidth - expectedMaxWidth) / 2
+
+        let actualRect = window.lastAppliedLayoutPhysicalRect!
+        assertEquals(actualRect.width, expectedMaxWidth)
+        assertEquals(actualRect.topLeftX, expectedSideGap)
+    }
+
+    func testPerMonitorSingleWindowConfigurationFallbackToDefault() async throws {
+        // Create per-monitor config that won't match current monitor
+        config.singleWindowMaxWidthPercent = .perMonitor([
+            PerMonitorValue(description: MonitorDescription.pattern("NonExistentMonitor")!, value: 60),
+        ], default: 75)
+
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+
+        try await workspace.layoutWorkspace()
+
+        let monitorWidth = workspace.workspaceMonitor.visibleRect.width
+        let expectedMaxWidth = monitorWidth * 0.75 // Should use default value
+        let expectedSideGap = (monitorWidth - expectedMaxWidth) / 2
+
+        let actualRect = window.lastAppliedLayoutPhysicalRect!
+        assertEquals(actualRect.width, expectedMaxWidth)
+        assertEquals(actualRect.topLeftX, expectedSideGap)
+    }
+
+    func testMultiplePerMonitorPatterns() async throws {
+        // Test with multiple separate patterns (now requires separate entries)
+        config.singleWindowMaxWidthPercent = .perMonitor([
+            PerMonitorValue(description: MonitorDescription.pattern(".*")!, value: 70),
+            PerMonitorValue(description: MonitorDescription.pattern("Built-in.*")!, value: 80),
+        ], default: 95)
+
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+
+        try await workspace.layoutWorkspace()
+
+        let monitorWidth = workspace.workspaceMonitor.visibleRect.width
+        let expectedMaxWidth = monitorWidth * 0.7 // Should use first matching pattern
+        let expectedSideGap = (monitorWidth - expectedMaxWidth) / 2
+
+        let actualRect = window.lastAppliedLayoutPhysicalRect!
+        assertEquals(actualRect.width, expectedMaxWidth)
+        assertEquals(actualRect.topLeftX, expectedSideGap)
+    }
+
+    func testPerMonitorConfigWithExcludedApp() async throws {
+        config.singleWindowMaxWidthPercent = .perMonitor([
+            PerMonitorValue(description: MonitorDescription.pattern(".*")!, value: 50),
+        ], default: 100)
+        config.singleWindowExcludeAppIds = ["bobko.AeroSpace.test-app"]
+
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+
+        try await workspace.layoutWorkspace()
+
+        let monitorWidth = workspace.workspaceMonitor.visibleRect.width
+        let actualRect = window.lastAppliedLayoutPhysicalRect!
+
+        // App is excluded, should use full width regardless of per-monitor config
+        assertEquals(actualRect.width, monitorWidth)
+        assertEquals(actualRect.topLeftX, 0.0)
+    }
+
+    func testPerMonitorConfigWithMultipleWindows() async throws {
+        config.singleWindowMaxWidthPercent = .perMonitor([
+            PerMonitorValue(description: MonitorDescription.pattern(".*")!, value: 60),
+        ], default: 100)
+
+        let workspace = Workspace.get(byName: name)
+        TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+        TestWindow.new(id: 2, parent: workspace.rootTilingContainer)
+
+        try await workspace.layoutWorkspace()
+
+        let monitorWidth = workspace.workspaceMonitor.visibleRect.width
+        let totalWindowsWidth = workspace.rootTilingContainer.children
+            .compactMap { ($0 as? Window)?.lastAppliedLayoutPhysicalRect?.width }
+            .reduce(0, +)
+
+        // Multiple windows should ignore single-window config and use full width
+        assertEquals(totalWindowsWidth, monitorWidth)
+    }
+
+    func testPerMonitorConfigWithGaps() async throws {
+        config.singleWindowMaxWidthPercent = .perMonitor([
+            PerMonitorValue(description: MonitorDescription.pattern(".*")!, value: 80),
+        ], default: 100)
+        config.gaps.outer.left = .constant(20)
+        config.gaps.outer.right = .constant(30)
+        config.gaps.outer.top = .constant(15)
+        config.gaps.outer.bottom = .constant(25)
+
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+
+        try await workspace.layoutWorkspace()
+
+        let monitorWidth = workspace.workspaceMonitor.visibleRect.width
+        let monitorHeight = workspace.workspaceMonitor.visibleRect.height
+        let expectedMaxWidth = monitorWidth * 0.8
+        let singleWindowSideGap = (monitorWidth - expectedMaxWidth) / 2
+
+        let actualRect = window.lastAppliedLayoutPhysicalRect!
+
+        // Width should account for both base gaps and single-window gaps
+        assertEquals(actualRect.width, expectedMaxWidth - 50) // Max width minus left/right gaps
+        assertEquals(actualRect.topLeftX, 20 + singleWindowSideGap) // Base left gap + single-window gap
+        assertEquals(actualRect.height, monitorHeight - 40 - 1) // Height minus top/bottom gaps and layout adjustment
+        assertEquals(actualRect.topLeftY, 15.0) // Top gap
+    }
+
+    func testPerMonitorConfigInFullscreen() async throws {
+        config.singleWindowMaxWidthPercent = .perMonitor([
+            PerMonitorValue(description: MonitorDescription.pattern(".*")!, value: 65),
+        ], default: 100)
+
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+        assertEquals(window.focusWindow(), true)
+
+        // Enable fullscreen
+        let result = try await parseCommand("fullscreen on").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode, 0)
+        assertEquals(window.isFullscreen, true)
+
+        try await workspace.layoutWorkspace()
+
+        let monitorWidth = workspace.workspaceMonitor.visibleRect.width
+        let expectedMaxWidth = monitorWidth * 0.65
+        let actualRect = window.lastAppliedLayoutPhysicalRect!
+
+        // Fullscreen should respect per-monitor single-window configuration
+        assertEquals(actualRect.width, expectedMaxWidth)
+    }
+
+    func testPerMonitorConfigInFullscreenWithNoMaxWidth() async throws {
+        config.singleWindowMaxWidthPercent = .perMonitor([
+            PerMonitorValue(description: MonitorDescription.pattern(".*")!, value: 40),
+        ], default: 100)
+
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+        assertEquals(window.focusWindow(), true)
+
+        // Enable fullscreen with --no-max-width flag
+        let result = try await parseCommand("fullscreen --no-max-width on").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode, 0)
+        assertEquals(window.isFullscreen, true)
+        assertEquals(window.noMaxWidthInFullscreen, true)
+
+        try await workspace.layoutWorkspace()
+
+        let monitorWidth = workspace.workspaceMonitor.visibleRect.width
+        let actualRect = window.lastAppliedLayoutPhysicalRect!
+
+        // --no-max-width should override per-monitor single-window configuration
+        assertEquals(actualRect.width, monitorWidth)
+        assertEquals(actualRect.topLeftX, 0.0)
+    }
+
+    func testPerMonitorGapsConfiguration() async throws {
+        // Test per-monitor gaps alongside single-window config
+        config.singleWindowMaxWidthPercent = .constant(90)
+        config.gaps.outer.left = .perMonitor([
+            PerMonitorValue(description: MonitorDescription.pattern(".*")!, value: 25),
+        ], default: 10)
+        config.gaps.outer.right = .perMonitor([
+            PerMonitorValue(description: MonitorDescription.pattern(".*")!, value: 35),
+        ], default: 15)
+
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+
+        try await workspace.layoutWorkspace()
+
+        let monitorWidth = workspace.workspaceMonitor.visibleRect.width
+        let expectedMaxWidth = monitorWidth * 0.9
+        let singleWindowSideGap = (monitorWidth - expectedMaxWidth) / 2
+
+        let actualRect = window.lastAppliedLayoutPhysicalRect!
+
+        // Should combine per-monitor gaps with single-window gaps
+        assertEquals(actualRect.topLeftX, 25 + singleWindowSideGap) // Per-monitor left gap + single-window gap
+        assertEquals(actualRect.width, expectedMaxWidth - 60) // Max width minus per-monitor left/right gaps
+    }
+}

--- a/Sources/AppBundleTests/layout/SingleWindowLayoutTest.swift
+++ b/Sources/AppBundleTests/layout/SingleWindowLayoutTest.swift
@@ -1,0 +1,186 @@
+@testable import AppBundle
+import Common
+import XCTest
+
+@MainActor
+final class SingleWindowLayoutTest: XCTestCase {
+    override func setUp() async throws { setUpWorkspacesForTests() }
+
+    func testSingleWindowRespectsMaxWidthPercent() async throws {
+        config.singleWindowMaxWidthPercent = .constant(70)
+
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+
+        try await workspace.layoutWorkspace()
+
+        let monitorWidth = workspace.workspaceMonitor.visibleRect.width
+        let expectedMaxWidth = monitorWidth * 0.7
+        let expectedSideGap = (monitorWidth - expectedMaxWidth) / 2
+
+        let actualRect = window.lastAppliedLayoutPhysicalRect!
+        let actualWidth = actualRect.width
+        let actualX = actualRect.topLeftX
+
+        assertEquals(actualWidth, expectedMaxWidth)
+        assertEquals(actualX, expectedSideGap)
+    }
+
+    func testSingleWindowWith50PercentWidth() async throws {
+        config.singleWindowMaxWidthPercent = .constant(50)
+
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+
+        try await workspace.layoutWorkspace()
+
+        let monitorWidth = workspace.workspaceMonitor.visibleRect.width
+        let expectedMaxWidth = monitorWidth * 0.5
+        let expectedSideGap = (monitorWidth - expectedMaxWidth) / 2
+
+        let actualRect = window.lastAppliedLayoutPhysicalRect!
+        assertEquals(actualRect.width, expectedMaxWidth)
+        assertEquals(actualRect.topLeftX, expectedSideGap)
+    }
+
+    func testSingleWindowWith100PercentWidth() async throws {
+        config.singleWindowMaxWidthPercent = .constant(100)
+
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+
+        try await workspace.layoutWorkspace()
+
+        let monitorWidth = workspace.workspaceMonitor.visibleRect.width
+        let actualRect = window.lastAppliedLayoutPhysicalRect!
+
+        assertEquals(actualRect.width, monitorWidth)
+        assertEquals(actualRect.topLeftX, 0.0)
+    }
+
+    func testMultipleWindowsIgnoreMaxWidth() async throws {
+        config.singleWindowMaxWidthPercent = .constant(70)
+
+        let workspace = Workspace.get(byName: name)
+        TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+        TestWindow.new(id: 2, parent: workspace.rootTilingContainer)
+
+        try await workspace.layoutWorkspace()
+
+        let monitorWidth = workspace.workspaceMonitor.visibleRect.width
+        let totalWindowsWidth = workspace.rootTilingContainer.children
+            .compactMap { ($0 as? Window)?.lastAppliedLayoutPhysicalRect?.width }
+            .reduce(0, +)
+
+        // With multiple windows, should use full width (minus normal gaps)
+        assertEquals(totalWindowsWidth, monitorWidth)
+    }
+
+    func testExcludedAppBypassesMaxWidth() async throws {
+        config.singleWindowMaxWidthPercent = .constant(50)
+        config.singleWindowExcludeAppIds = ["bobko.AeroSpace.test-app"]
+
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+
+        try await workspace.layoutWorkspace()
+
+        let monitorWidth = workspace.workspaceMonitor.visibleRect.width
+        let actualRect = window.lastAppliedLayoutPhysicalRect!
+
+        // Should use full width since app is excluded
+        assertEquals(actualRect.width, monitorWidth)
+        assertEquals(actualRect.topLeftX, 0.0)
+    }
+
+    func testNonExcludedAppRespectsMaxWidth() async throws {
+        config.singleWindowMaxWidthPercent = .constant(60)
+        config.singleWindowExcludeAppIds = ["com.different.app"]
+
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+
+        try await workspace.layoutWorkspace()
+
+        let monitorWidth = workspace.workspaceMonitor.visibleRect.width
+        let expectedMaxWidth = monitorWidth * 0.6
+        let expectedSideGap = (monitorWidth - expectedMaxWidth) / 2
+
+        let actualRect = window.lastAppliedLayoutPhysicalRect!
+        assertEquals(actualRect.width, expectedMaxWidth)
+        assertEquals(actualRect.topLeftX, expectedSideGap)
+    }
+
+    func testSingleWindowWithExistingGaps() async throws {
+        config.singleWindowMaxWidthPercent = .constant(80)
+        config.gaps.outer.left = .constant(20)
+        config.gaps.outer.right = .constant(20)
+
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+
+        try await workspace.layoutWorkspace()
+
+        let monitorWidth = workspace.workspaceMonitor.visibleRect.width
+        _ = monitorWidth - 40 // Subtract outer gaps
+        let expectedMaxWidth = monitorWidth * 0.8
+        let singleWindowSideGap = (monitorWidth - expectedMaxWidth) / 2
+        let totalLeftGap = 20 + singleWindowSideGap // base outer gap + single-window gap
+
+        let actualRect = window.lastAppliedLayoutPhysicalRect!
+        assertEquals(actualRect.topLeftX, totalLeftGap)
+        assertEquals(actualRect.width, expectedMaxWidth - 40) // Max width minus base outer gaps
+    }
+
+    func testPerMonitorSingleWindowConfig() async throws {
+        let workspace = Workspace.get(byName: name)
+        _ = workspace.workspaceMonitor
+        config.singleWindowMaxWidthPercent = .perMonitor([
+            PerMonitorValue(description: MonitorDescription.pattern(".*")!, value: 75),
+        ], default: 100)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+
+        try await workspace.layoutWorkspace()
+
+        let monitorWidth = workspace.workspaceMonitor.visibleRect.width
+        let expectedMaxWidth = monitorWidth * 0.75
+        let expectedSideGap = (monitorWidth - expectedMaxWidth) / 2
+
+        let actualRect = window.lastAppliedLayoutPhysicalRect!
+        assertEquals(actualRect.width, expectedMaxWidth)
+        assertEquals(actualRect.topLeftX, expectedSideGap)
+    }
+
+    func testSingleWindowHeightUnaffected() async throws {
+        config.singleWindowMaxWidthPercent = .constant(70)
+
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+
+        try await workspace.layoutWorkspace()
+
+        let monitorHeight = workspace.workspaceMonitor.visibleRect.height
+        let actualRect = window.lastAppliedLayoutPhysicalRect!
+
+        // Height should remain full (minus 1 for the layout adjustment)
+        assertEquals(actualRect.height, monitorHeight - 1)
+        assertEquals(actualRect.topLeftY, 0.0)
+    }
+
+    func testZeroPercentWidthFallsBackToDefault() async throws {
+        // This test ensures invalid config values are handled gracefully
+        config.singleWindowMaxWidthPercent = .constant(100) // Should fall back to this
+
+        let workspace = Workspace.get(byName: name)
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+
+        try await workspace.layoutWorkspace()
+
+        let monitorWidth = workspace.workspaceMonitor.visibleRect.width
+        let actualRect = window.lastAppliedLayoutPhysicalRect!
+
+        // Should use full width
+        assertEquals(actualRect.width, monitorWidth)
+        assertEquals(actualRect.topLeftX, 0.0)
+    }
+}

--- a/Sources/AppBundleTests/tree/TestWindow.swift
+++ b/Sources/AppBundleTests/tree/TestWindow.swift
@@ -35,4 +35,34 @@ final class TestWindow: Window, CustomStringConvertible {
     @MainActor override func getAxRect() async throws -> Rect? { // todo change to not Optional
         _rect
     }
+
+    @MainActor override func getAxTopLeftCorner() async throws -> CGPoint? {
+        guard let rect = _rect else { return nil }
+        return CGPoint(x: rect.topLeftX, y: rect.topLeftY)
+    }
+
+    @MainActor override func getAxSize() async throws -> CGSize? {
+        guard let rect = _rect else { return nil }
+        return CGSize(width: rect.width, height: rect.height)
+    }
+
+    @MainActor override var isMacosFullscreen: Bool {
+        get async throws { false }
+    }
+
+    @MainActor override var isMacosMinimized: Bool {
+        get async throws { false }
+    }
+
+    override func setAxFrame(_ topLeft: CGPoint?, _ size: CGSize?) {
+        if let topLeft, let size {
+            _rect = Rect(topLeftX: topLeft.x, topLeftY: topLeft.y, width: size.width, height: size.height)
+        }
+    }
+
+    @MainActor override func setAxFrameBlocking(_ topLeft: CGPoint?, _ size: CGSize?) async throws {
+        if let topLeft, let size {
+            _rect = Rect(topLeftX: topLeft.x, topLeftY: topLeft.y, width: size.width, height: size.height)
+        }
+    }
 }

--- a/Sources/Common/cmdArgs/impl/FullscreenCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/FullscreenCmdArgs.swift
@@ -7,6 +7,7 @@ public struct FullscreenCmdArgs: CmdArgs {
         help: fullscreen_help_generated,
         options: [
             "--no-outer-gaps": trueBoolFlag(\.noOuterGaps),
+            "--no-max-width": trueBoolFlag(\.noMaxWidth),
             "--fail-if-noop": trueBoolFlag(\.failIfNoop),
             "--window-id": optionalWindowIdFlag(),
         ],
@@ -15,6 +16,7 @@ public struct FullscreenCmdArgs: CmdArgs {
 
     public var toggle: ToggleEnum = .toggle
     public var noOuterGaps: Bool = false
+    public var noMaxWidth: Bool = false
     public var failIfNoop: Bool = false
     /*conforms*/ public var windowId: UInt32?
     /*conforms*/ public var workspaceName: WorkspaceName?
@@ -23,5 +25,6 @@ public struct FullscreenCmdArgs: CmdArgs {
 public func parseFullscreenCmdArgs(_ args: [String]) -> ParsedCmd<FullscreenCmdArgs> {
     parseSpecificCmdArgs(FullscreenCmdArgs(rawArgs: args), args)
         .filterNot("--no-outer-gaps is incompatible with 'off' argument") { $0.toggle == .off && $0.noOuterGaps }
+        .filterNot("--no-max-width is incompatible with 'off' argument") { $0.toggle == .off && $0.noMaxWidth }
         .filter("--fail-if-noop requires 'on' or 'off' argument") { $0.failIfNoop.implies($0.toggle == .on || $0.toggle == .off) }
 }

--- a/docs/aerospace-fullscreen.adoc
+++ b/docs/aerospace-fullscreen.adoc
@@ -9,8 +9,8 @@ include::util/man-attributes.adoc[]
 == Synopsis
 [verse]
 // tag::synopsis[]
-aerospace fullscreen [-h|--help]     [--window-id <window-id>] [--no-outer-gaps]
-aerospace fullscreen [-h|--help] on  [--window-id <window-id>] [--no-outer-gaps] [--fail-if-noop]
+aerospace fullscreen [-h|--help]     [--window-id <window-id>] [--no-outer-gaps] [--no-max-width]
+aerospace fullscreen [-h|--help] on  [--window-id <window-id>] [--no-outer-gaps] [--no-max-width] [--fail-if-noop]
 aerospace fullscreen [-h|--help] off [--window-id <window-id>] [--fail-if-noop]
 
 // end::synopsis[]
@@ -21,13 +21,14 @@ aerospace fullscreen [-h|--help] off [--window-id <window-id>] [--fail-if-noop]
 // tag::body[]
 {manpurpose}
 
-Switching to a different tiling window within the same workspace while the current focused window is in fullscreen mode results in the fullscreen window exiting fullscreen mode.
+Fullscreen windows automatically exit fullscreen mode when focus switches to another window or workspace.
 
 // =========================================================== Options
 include::./util/conditional-options-header.adoc[]
 
 -h, --help:: Print help
 --no-outer-gaps:: Remove the outer gaps when in fullscreen mode
+--no-max-width:: Ignore the single window maximum width constraint when in fullscreen mode
 --fail-if-noop:: Exit with non-zero exit code if already fullscreen or already not fullscreen
 
 --window-id <window-id>::

--- a/docs/config-examples/default-config.toml
+++ b/docs/config-examples/default-config.toml
@@ -58,6 +58,25 @@ automatically-unhide-macos-hidden-apps = false
     outer.top =        0
     outer.right =      0
 
+# Single-window maximum width configuration
+# When there's only one window in a workspace, limit it to this percentage of screen width
+# and center it. Set to 100 to disable (default).
+# Possible values:
+# - Constant:     single-window-max-width-percent = 70
+# - Per monitor:  single-window-max-width-percent = [{ monitor."built-in" = 100 }, { monitor."secondary" = 70 }, 80]
+#                 In this example, 80 is a default value when there is no match.
+# - Multiple monitor patterns with fallback (same syntax as workspace-to-monitor-force-assignment):
+#                 single-window-max-width-percent = [{ monitor."secondary" = 70 }, { monitor."dell" = 70 }, { monitor."built-in" = 100 }, 85]
+#                 The first matching pattern wins. Useful for handling monitor name variations.
+# single-window-max-width-percent = 100
+
+# Applications that should be excluded from single-window width limiting
+# single-window-exclude-app-ids = [
+#     'com.figma.Desktop',
+#     'com.adobe.Photoshop',
+#     'com.apple.finder'
+# ]
+
 # 'main' binding mode declaration
 # See: https://nikitabobko.github.io/AeroSpace/guide#binding-modes
 # 'main' binding mode must be always presented

--- a/docs/guide.adoc
+++ b/docs/guide.adoc
@@ -283,6 +283,48 @@ While in a `v_accordion`, you can navigate the windows using the `focus (up|down
 
 Accordion padding is configurable via `accordion-padding` option.
 
+[#single-window-max-width]
+=== Single window max width configuration
+
+When you have only one window in a workspace, AeroSpace can automatically limit its width and center it on the screen.
+
+The xref:commands.adoc#fullscreen[fullscreen] command will also, by default, respect this setting.
+
+Configuration options:
+
+* `single-window-max-width-percent` - Limits single windows to a percentage of screen width (1-100, default 100)
+* `single-window-exclude-app-ids` - Array of bundle IDs to exclude from width limiting
+
+The feature only applies when exactly one window exists in the workspace, automatically centering the window using the gap system.
+
+[source,toml]
+----
+# Limit single windows to 70% of screen width
+single-window-max-width-percent = 70
+
+# Per-monitor configuration
+single-window-max-width-percent = [
+    { monitor."built-in" = 100 },    # Full width on built-in display
+    { monitor."secondary" = 70 },    # 70% width on secondary monitor
+    80                               # Default 80% for other monitors
+]
+
+# Exclude design applications that benefit from full width
+single-window-exclude-app-ids = [
+    'com.figma.Desktop',
+    'com.adobe.Photoshop',
+    'com.apple.finder'
+]
+----
+
+Per-monitor configuration supports the same monitor patterns as <<assign-workspaces-to-monitors,workspace-to-monitor assignment>>:
+
+* `main` - Main monitor
+* `secondary` - Non-main monitor (when only two monitors)
+* `<number>` - Monitor sequence number from left to right (1-based)
+* `<regex-pattern>` - Case insensitive regex substring pattern
+
+
 [#normalization]
 === Normalization
 


### PR DESCRIPTION
## The problem

When using an ultrawide monitor, a single window in a workspace can often be too wide.

## The solution

This commit introduces two new settings and an additional flag to the fullscreen command that make single windows behave better on wider monitors. The changes are fully backwards compatible.

New settings:

1. `single-window-max-width-percent`: Sets maximum width percentage (1-100) for windows which are the only window in a workspace, and also limits the width of the workspace when in fullscreen mode
2. `single-window-exclude-app-ids`: An array of app bundle IDs to exclude from the width limit

New flag to the `fullscreen` command:

- `--no-max-width`: Ignores single-window width constraints when in fullscreen mode

## Additional notes

With these settings and the flag, the user can separately bind fullscreen in both the normal (constrained) mode and in the unconstrained mode, allowing quick switching between the two. (This is how I use it and it feels very natural.)

This addresses #60.