### PR TITLE
Add `--json` and `--count` flag to `list-modes` command

### DIFF
--- a/Sources/AppBundle/command/impl/ListModesCommand.swift
+++ b/Sources/AppBundle/command/impl/ListModesCommand.swift
@@ -9,14 +9,14 @@ struct ListModesCommand: Command {
             let count = args.current ? 1 : config.modes.count
             return io.out("\(count)")
         }
-        
+
         if args.json {
             let modeNames = args.current ? [activeMode ?? mainModeId] : config.modes.keys.sorted()
             let modeData = modeNames.map { ["mode-id": $0] }
             return JSONEncoder.aeroSpaceDefault.encodeToString(modeData).map(io.out)
                 ?? io.err("Failed to encode JSON")
         }
-        
+
         if args.current {
             return io.out(activeMode ?? mainModeId)
         } else {

--- a/Sources/AppBundle/command/impl/ListModesCommand.swift
+++ b/Sources/AppBundle/command/impl/ListModesCommand.swift
@@ -5,6 +5,11 @@ struct ListModesCommand: Command {
     let args: ListModesCmdArgs
 
     func run(_ env: CmdEnv, _ io: CmdIo) -> Bool {
+        if args.outputOnlyCount {
+            let count = args.current ? 1 : config.modes.count
+            return io.out("\(count)")
+        }
+        
         if args.current {
             return io.out(activeMode ?? mainModeId)
         } else {

--- a/Sources/AppBundle/command/impl/ListModesCommand.swift
+++ b/Sources/AppBundle/command/impl/ListModesCommand.swift
@@ -10,10 +10,17 @@ struct ListModesCommand: Command {
             return io.out("\(count)")
         }
         
+        if args.json {
+            let modeNames = args.current ? [activeMode ?? mainModeId] : config.modes.keys.sorted()
+            let modeData = modeNames.map { ["mode-id": $0] }
+            return JSONEncoder.aeroSpaceDefault.encodeToString(modeData).map(io.out)
+                ?? io.err("Failed to encode JSON")
+        }
+        
         if args.current {
             return io.out(activeMode ?? mainModeId)
         } else {
-            let modeNames: [String] = config.modes.map { $0.key }
+            let modeNames: [String] = config.modes.keys.sorted()
             return io.out(modeNames)
         }
     }

--- a/Sources/AppBundleTests/command/ListModesTest.swift
+++ b/Sources/AppBundleTests/command/ListModesTest.swift
@@ -6,5 +6,55 @@ final class ListModesTest: XCTestCase {
     func testParseListModesCommand() {
         testParseCommandSucc("list-modes", ListModesCmdArgs(rawArgs: []))
         testParseCommandSucc("list-modes --current", ListModesCmdArgs(rawArgs: []).copy(\.current, true))
+        testParseCommandSucc("list-modes --json", ListModesCmdArgs(rawArgs: []).copy(\.json, true))
+        testParseCommandSucc("list-modes --count", ListModesCmdArgs(rawArgs: []).copy(\.outputOnlyCount, true))
+        testParseCommandSucc("list-modes --current --json", ListModesCmdArgs(rawArgs: []).copy(\.current, true).copy(\.json, true))
+    }
+
+    func testParseListModesCommandConflicts() {
+        assertEquals(parseCommand("list-modes --json --count").errorOrNil, "ERROR: Conflicting options: --count, --json")
+        assertEquals(parseCommand("list-modes --current --count").errorOrNil, "ERROR: Conflicting options: --count, --current")
+    }
+    
+    @MainActor
+    func testListModesOutput() async throws {
+        config.modes = [
+            "main": Mode(name: nil, bindings: [:]),
+            "service": Mode(name: nil, bindings: [:]),
+            "resize": Mode(name: nil, bindings: [:])
+        ]
+        
+        let defaultResult = try await ListModesCommand(args: ListModesCmdArgs(rawArgs: [])).run(.defaultEnv, .emptyStdin)
+        assertEquals(defaultResult.exitCode, 0)
+        assertEquals(defaultResult.stdout.sorted(), ["main", "resize", "service"])
+        assertEquals(defaultResult.stderr, [])
+        
+        let currentResult = try await ListModesCommand(args: ListModesCmdArgs(rawArgs: []).copy(\.current, true)).run(.defaultEnv, .emptyStdin)
+        assertEquals(currentResult.exitCode, 0)
+        assertEquals(currentResult.stdout, ["main"])
+        assertEquals(currentResult.stderr, [])
+        
+        let countResult = try await ListModesCommand(args: ListModesCmdArgs(rawArgs: []).copy(\.outputOnlyCount, true)).run(.defaultEnv, .emptyStdin)
+        assertEquals(countResult.exitCode, 0)
+        assertEquals(countResult.stdout, ["3"])
+        assertEquals(countResult.stderr, [])
+        
+        let jsonResult = try await ListModesCommand(args: ListModesCmdArgs(rawArgs: []).copy(\.json, true)).run(.defaultEnv, .emptyStdin)
+        let expectedJson = JSONEncoder.aeroSpaceDefault.encodeToString([
+            ["mode-id": "main"],
+            ["mode-id": "resize"],
+            ["mode-id": "service"]
+        ])
+        assertEquals(jsonResult.exitCode, 0)
+        assertEquals(jsonResult.stdout, [expectedJson])
+        assertEquals(jsonResult.stderr, [])
+        
+        let currentJsonResult = try await ListModesCommand(args: ListModesCmdArgs(rawArgs: []).copy(\.current, true).copy(\.json, true)).run(.defaultEnv, .emptyStdin)
+        let expectedCurrentJson = JSONEncoder.aeroSpaceDefault.encodeToString([
+            ["mode-id": "main"]
+        ])
+        assertEquals(currentJsonResult.exitCode, 0)
+        assertEquals(currentJsonResult.stdout, [expectedCurrentJson])
+        assertEquals(currentJsonResult.stderr, [])
     }
 }

--- a/Sources/AppBundleTests/command/ListModesTest.swift
+++ b/Sources/AppBundleTests/command/ListModesTest.swift
@@ -15,43 +15,43 @@ final class ListModesTest: XCTestCase {
         assertEquals(parseCommand("list-modes --json --count").errorOrNil, "ERROR: Conflicting options: --count, --json")
         assertEquals(parseCommand("list-modes --current --count").errorOrNil, "ERROR: Conflicting options: --count, --current")
     }
-    
+
     @MainActor
     func testListModesOutput() async throws {
         config.modes = [
             "main": Mode(name: nil, bindings: [:]),
             "service": Mode(name: nil, bindings: [:]),
-            "resize": Mode(name: nil, bindings: [:])
+            "resize": Mode(name: nil, bindings: [:]),
         ]
-        
+
         let defaultResult = try await ListModesCommand(args: ListModesCmdArgs(rawArgs: [])).run(.defaultEnv, .emptyStdin)
         assertEquals(defaultResult.exitCode, 0)
         assertEquals(defaultResult.stdout, ["main", "resize", "service"])
         assertEquals(defaultResult.stderr, [])
-        
+
         let currentResult = try await ListModesCommand(args: ListModesCmdArgs(rawArgs: []).copy(\.current, true)).run(.defaultEnv, .emptyStdin)
         assertEquals(currentResult.exitCode, 0)
         assertEquals(currentResult.stdout, ["main"])
         assertEquals(currentResult.stderr, [])
-        
+
         let countResult = try await ListModesCommand(args: ListModesCmdArgs(rawArgs: []).copy(\.outputOnlyCount, true)).run(.defaultEnv, .emptyStdin)
         assertEquals(countResult.exitCode, 0)
         assertEquals(countResult.stdout, ["3"])
         assertEquals(countResult.stderr, [])
-        
+
         let jsonResult = try await ListModesCommand(args: ListModesCmdArgs(rawArgs: []).copy(\.json, true)).run(.defaultEnv, .emptyStdin)
         let expectedJson = JSONEncoder.aeroSpaceDefault.encodeToString([
             ["mode-id": "main"],
             ["mode-id": "resize"],
-            ["mode-id": "service"]
+            ["mode-id": "service"],
         ])
         assertEquals(jsonResult.exitCode, 0)
         assertEquals(jsonResult.stdout, [expectedJson])
         assertEquals(jsonResult.stderr, [])
-        
+
         let currentJsonResult = try await ListModesCommand(args: ListModesCmdArgs(rawArgs: []).copy(\.current, true).copy(\.json, true)).run(.defaultEnv, .emptyStdin)
         let expectedCurrentJson = JSONEncoder.aeroSpaceDefault.encodeToString([
-            ["mode-id": "main"]
+            ["mode-id": "main"],
         ])
         assertEquals(currentJsonResult.exitCode, 0)
         assertEquals(currentJsonResult.stdout, [expectedCurrentJson])

--- a/Sources/AppBundleTests/command/ListModesTest.swift
+++ b/Sources/AppBundleTests/command/ListModesTest.swift
@@ -26,7 +26,7 @@ final class ListModesTest: XCTestCase {
         
         let defaultResult = try await ListModesCommand(args: ListModesCmdArgs(rawArgs: [])).run(.defaultEnv, .emptyStdin)
         assertEquals(defaultResult.exitCode, 0)
-        assertEquals(defaultResult.stdout.sorted(), ["main", "resize", "service"])
+        assertEquals(defaultResult.stdout, ["main", "resize", "service"])
         assertEquals(defaultResult.stderr, [])
         
         let currentResult = try await ListModesCommand(args: ListModesCmdArgs(rawArgs: []).copy(\.current, true)).run(.defaultEnv, .emptyStdin)

--- a/Sources/Common/cmdArgs/impl/ListModesCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/ListModesCmdArgs.swift
@@ -8,14 +8,22 @@ public struct ListModesCmdArgs: CmdArgs {
         allowInConfig: false,
         help: list_modes_help_generated,
         options: [
+            "--count": trueBoolFlag(\.outputOnlyCount),
             "--current": trueBoolFlag(\.current),
+            "--json": trueBoolFlag(\.json),
         ],
         arguments: [],
+        conflictingOptions: [
+            ["--count", "--current"],
+            ["--count", "--json"],
+        ],
     )
 
     /*conforms*/ public var windowId: UInt32?
     /*conforms*/ public var workspaceName: WorkspaceName?
     public var current: Bool = false
+    public var json: Bool = false
+    public var outputOnlyCount: Bool = false
 }
 
 public func parseListModesCmdArgs(_ args: [String]) -> ParsedCmd<ListModesCmdArgs> {

--- a/Sources/Common/cmdHelpGenerated.swift
+++ b/Sources/Common/cmdHelpGenerated.swift
@@ -64,7 +64,7 @@ let list_exec_env_vars_help_generated = """
     USAGE: list-exec-env-vars [-h|--help]
     """
 let list_modes_help_generated = """
-    USAGE: list-modes [-h|--help] [--current]
+    USAGE: list-modes [-h|--help] [--current] [--count] [--json]
     """
 let list_monitors_help_generated = """
     USAGE: list-monitors [-h|--help] [--focused [no]] [--mouse [no]] [--format <output-format>] [--count] [--json]

--- a/docs/aerospace-list-modes.adoc
+++ b/docs/aerospace-list-modes.adoc
@@ -9,7 +9,7 @@ include::util/man-attributes.adoc[]
 == Synopsis
 [verse]
 // tag::synopsis[]
-aerospace list-modes [-h|--help] [--current]
+aerospace list-modes [-h|--help] [--current] [--count] [--json]
 
 // end::synopsis[]
 
@@ -26,8 +26,14 @@ include::util/conditional-options-header.adoc[]
 
 -h, --help:: Print help
 
---current::
-Only print the currently active mode
+--current:: Only print the currently active mode.
+Incompatible with `--count`
+
+--count:: Output only the number of modes.
+Incompatible with `--current`, `--json`
+
+--json:: Output in JSON format.
+Incompatible with `--count`
 
 // end::body[]
 


### PR DESCRIPTION
I've tried to implement the `--json` command as specified in the [issue](https://github.com/nikitabobko/AeroSpace/issues/1026). I was looking at `list-apps` as a reference and decided to add `--count` as well, because it seemed simple enough. 

Happy to make any adjustments necessary, just let me know!

### 🧪 Testing Outputs

```sh
❯ ./.debug/aerospace list-modes
main
service

❯ ./.debug/aerospace list-modes --current
main

❯ ./.debug/aerospace list-modes --json
[
  {
    "mode-id" : "main"
  },
  {
    "mode-id" : "service"
  }
]

❯ ./.debug/aerospace list-modes --count
2

❯ ./.debug/aerospace list-modes --current --json
[
  {
    "mode-id" : "main"
  }
]

❯ ./.debug/aerospace list-modes --count --json
ERROR: Conflicting options: --count, --json

❯ ./.debug/aerospace list-modes --count --current
ERROR: Conflicting options: --count, --current
```