### PR TITLE
Add error message + docs to stdin commands

### DIFF
--- a/Sources/AppBundle/command/impl/WorkspaceCommand.swift
+++ b/Sources/AppBundle/command/impl/WorkspaceCommand.swift
@@ -18,7 +18,7 @@ struct WorkspaceCommand: Command {
                     stdin: io.readStdin(),
                     target: target,
                 )
-                guard let workspace else { return false }
+                guard let workspace else { return io.err("Can't resolve next or prev workspace") }
                 workspaceName = workspace.name
             case .direct(let name):
                 workspaceName = name.raw

--- a/docs/aerospace-move-node-to-workspace.adoc
+++ b/docs/aerospace-move-node-to-workspace.adoc
@@ -41,7 +41,11 @@ include::./util/window-id-flag-desc.adoc[]
 // =========================================================== Arguments
 include::./util/conditional-arguments-header.adoc[]
 
-(next|prev):: Move window to next or prev workspace
+(next|prev):: Move window to next or prev workspace in *the list* -
+
+* If stdin is not TTY and stdin contains non whitespace characters then *the list* is taken from stdin
+* Otherwise, *the list* is defined as all workspaces on focused monitor in alphabetical order
+
 <workspace-name>:: Specifies workspace name where to move window to
 
 // end::body[]


### PR DESCRIPTION
[cmd(workspace): add error message](https://github.com/nikitabobko/AeroSpace/commit/729ef7de3f1959a337fafa8f1791094243a69755) 

Align 'workspace' cmd with 'move-node-to-workspace'.

[docs(move-node-to-workspace): describe stdin usage](https://github.com/nikitabobko/AeroSpace/commit/6ba5d6e2c8dd945b1d216abe5904eac6714a3e79) 

Similar to docs/aerospace-workspace.adoc

## Test plan
1. tested with -
```bash
# current-workspace=4
echo "1\n2" | ./.debug/aerospace workspace prev # fail (now with an error message)
echo "1\n2\n4" | ./.debug/aerospace workspace prev # success

```

2. built docs -
<img width="880" alt="Screenshot 2025-07-09 at 1 01 15" src="https://github.com/user-attachments/assets/a0bbedfb-8c4b-4771-83bb-0c5290a2f855" />

