### PR TITLE
Add a customizable MesssageView (initially for config error reporting)

### DIFF
--- a/Sources/AeroSpaceApp/AeroSpaceApp.swift
+++ b/Sources/AeroSpaceApp/AeroSpaceApp.swift
@@ -8,6 +8,9 @@ import SwiftUI
 struct AeroSpaceApp: App {
     @MainActor // macOS 13
     @StateObject var viewModel = TrayMenuModel.shared
+    @MainActor // macOS 13
+    @StateObject var messageModel = MessageModel.shared
+    @Environment(\.openWindow) var openWindow
 
     init() {
         initAppBundle()
@@ -16,5 +19,11 @@ struct AeroSpaceApp: App {
     @MainActor // macOS 13
     var body: some Scene {
         menuBar(viewModel: viewModel)
+        getMessageWindow(messageModel: messageModel)
+            .onChange(of: messageModel.message) { message in
+                if message != nil {
+                    openWindow(id: messageWindowId)
+                }
+            }
     }
 }

--- a/Sources/AppBundle/command/impl/ReloadConfigCommand.swift
+++ b/Sources/AppBundle/command/impl/ReloadConfigCommand.swift
@@ -33,16 +33,15 @@ struct ReloadConfigCommand: Command {
                 configUrl = url
                 activateMode(activeMode)
                 syncStartAtLogin()
+                MessageModel.shared.message = nil
             }
             return true
         case .failure(let msg):
             stdout.append(msg)
             if !args.noGui {
-                showMessageInGui(
-                    filenameIfConsoleApp: nil,
-                    title: "AeroSpace Config Error",
-                    message: msg,
-                )
+                Task { @MainActor in
+                    MessageModel.shared.message = Message(description: "AeroSpace Config Error", body: msg)
+                }
             }
             return false
     }

--- a/Sources/AppBundle/tree/MacApp.swift
+++ b/Sources/AppBundle/tree/MacApp.swift
@@ -42,6 +42,10 @@ final class MacApp: AbstractApp {
         // Don't perceive any of the lock screen windows as real windows
         // Otherwise, false positive ax notifications might trigger that lead to gcWindows
         if nsApp.bundleIdentifier == lockScreenAppBundleId { return nil }
+        if nsApp.bundleIdentifier == aeroSpaceAppId { return nil }
+        #if DEBUG
+            if let bundleURL = nsApp.bundleURL, bundleURL.absoluteString.contains("AeroSpaceApp") { return nil }
+        #endif
         let pid = nsApp.processIdentifier
 
         while true {

--- a/Sources/AppBundle/ui/MenuBar.swift
+++ b/Sources/AppBundle/ui/MenuBar.swift
@@ -42,19 +42,7 @@ public func menuBar(viewModel: TrayMenuModel) -> some Scene { // todo should it 
             }
         }.keyboardShortcut("E", modifiers: .command)
         getExperimentalUISettingsMenu(viewModel: viewModel)
-        let editor = getTextEditorToOpenConfig()
-        Button("Open config in '\(editor.lastPathComponent)'") {
-            let fallbackConfig: URL = FileManager.default.homeDirectoryForCurrentUser.appending(path: configDotfileName)
-            switch findCustomConfigUrl() {
-                case .file(let url):
-                    url.open(with: editor)
-                case .noCustomConfigExists:
-                    _ = try? FileManager.default.copyItem(atPath: defaultConfigUrl.path, toPath: fallbackConfig.path)
-                    fallbackConfig.open(with: editor)
-                case .ambiguousConfigError:
-                    fallbackConfig.open(with: editor)
-            }
-        }.keyboardShortcut(",", modifiers: .command)
+        openConfigButton.keyboardShortcut(",", modifiers: .command)
         if let token: RunSessionGuard = .isServerEnabled {
             Button("Reload config") {
                 Task {
@@ -84,6 +72,22 @@ public func menuBar(viewModel: TrayMenuModel) -> some Scene { // todo should it 
             Image(systemName: "pause.circle.fill")
                 .resizable()
                 .aspectRatio(contentMode: .fit)
+        }
+    }
+}
+
+var openConfigButton: some View {
+    let editor = getTextEditorToOpenConfig()
+    return Button("Open config in '\(editor.lastPathComponent)'") {
+        let fallbackConfig: URL = FileManager.default.homeDirectoryForCurrentUser.appending(path: configDotfileName)
+        switch findCustomConfigUrl() {
+            case .file(let url):
+                url.open(with: editor)
+            case .noCustomConfigExists:
+                _ = try? FileManager.default.copyItem(atPath: defaultConfigUrl.path, toPath: fallbackConfig.path)
+                fallbackConfig.open(with: editor)
+            case .ambiguousConfigError:
+                fallbackConfig.open(with: editor)
         }
     }
 }

--- a/Sources/AppBundle/ui/MenuBar.swift
+++ b/Sources/AppBundle/ui/MenuBar.swift
@@ -42,14 +42,8 @@ public func menuBar(viewModel: TrayMenuModel) -> some Scene { // todo should it 
             }
         }.keyboardShortcut("E", modifiers: .command)
         getExperimentalUISettingsMenu(viewModel: viewModel)
-        openConfigButton.keyboardShortcut(",", modifiers: .command)
-        if let token: RunSessionGuard = .isServerEnabled {
-            Button("Reload config") {
-                Task {
-                    try await runSession(.menuBarButton, token) { _ = reloadConfig() }
-                }
-            }.keyboardShortcut("R", modifiers: .command)
-        }
+        openConfigButton
+        reloadConfigButton
         Button("Quit \(aeroSpaceAppName)") {
             Task {
                 defer { terminateApp() }
@@ -89,6 +83,19 @@ var openConfigButton: some View {
             case .ambiguousConfigError:
                 fallbackConfig.open(with: editor)
         }
+    }.keyboardShortcut(",", modifiers: .command)
+}
+
+@MainActor @ViewBuilder
+var reloadConfigButton: some View {
+    if let token: RunSessionGuard = .isServerEnabled {
+        Button("Reload config") {
+            Task {
+                try await runSession(.menuBarButton, token) { _ = reloadConfig() }
+            }
+        }.keyboardShortcut("R", modifiers: .command)
+    } else {
+        Text("").hidden()
     }
 }
 

--- a/Sources/AppBundle/ui/MessageView.swift
+++ b/Sources/AppBundle/ui/MessageView.swift
@@ -1,0 +1,112 @@
+import Common
+import SwiftUI
+
+@MainActor
+public func getMessageWindow(messageModel: MessageModel) -> some Scene {
+    // Using SwiftUI.Window because another class in AeroSpace is already called Window
+    SwiftUI.Window(messageModel.message?.title ?? aeroSpaceAppName, id: messageWindowId) {
+        MessageView(model: messageModel)
+            .onAppear {
+                NSApplication.shared.windows.forEach {
+                    if let identifier = $0.identifier?.rawValue, identifier == messageWindowId {
+                        $0.level = .floating
+                    }
+                }
+            }
+    }
+    .windowResizability(.contentMinSize)
+    //.windowLevel(.floating) //This might be the SwiftUI way of doing window level instead of the onAppear block above, but it's only available from macOS 15.0
+}
+
+public let messageWindowId = "\(aeroSpaceAppName).messageView"
+
+public struct MessageView: View {
+    @StateObject private var model: MessageModel
+    @Environment(\.dismiss) private var dismiss
+
+    public init(model: MessageModel) {
+        self._model = .init(wrappedValue: model)
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading) {
+            HStack(alignment: .center) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundColor(.yellow)
+                    .font(.system(size: 48))
+                Text("\(model.message?.description ?? "")")
+                    .padding(.horizontal)
+            }
+            .padding()
+            ScrollView {
+                VStack(alignment: .leading) {
+                    HStack {
+                        TextEditor(text: .constant(model.message?.body ?? ""))
+                            .font(.system(size: 12).monospaced())
+                            .textSelection(.enabled)
+                        Spacer()
+                    }
+                    Spacer()
+                }
+                .padding()
+            }
+            .background(Color(.controlBackgroundColor))
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .padding(.horizontal)
+            HStack {
+                Spacer()
+                if let type = model.message?.type {
+                    switch type {
+                        case .config:
+                            openConfigButton
+                    }
+                }
+                Button("Continue") {
+                    model.message = nil
+                    self.dismiss()
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+            .padding()
+        }
+        .textSelection(.enabled)
+        .frame(minWidth: 480, maxWidth: 960, minHeight: 200)
+        .onChange(of: model.message) { message in
+            if message == nil {
+                self.dismiss()
+            }
+        }
+    }
+}
+
+public class MessageModel: ObservableObject {
+    @MainActor public static let shared = MessageModel()
+    @Published public var message: Message? = nil
+
+    private init() {}
+}
+
+public enum MessageType {
+    case config
+}
+
+public struct Message: Hashable, Equatable {
+    public let type: MessageType
+    public let title: String
+    public let description: String
+    public let body: String
+
+    init(type: MessageType = .config, title: String = aeroSpaceAppName, description: String, body: String) {
+        self.type = type
+        self.title = title
+        self.description = description
+        self.body = body
+    }
+}
+
+#Preview {
+    MessageView(model: MessageModel.shared)
+        .onAppear {
+            MessageModel.shared.message = Message(type: .config, description: "Description", body: "Body")
+        }
+}

--- a/Sources/AppBundle/ui/MessageView.swift
+++ b/Sources/AppBundle/ui/MessageView.swift
@@ -57,6 +57,7 @@ public struct MessageView: View {
                 if let type = model.message?.type {
                     switch type {
                         case .config:
+                            reloadConfigButton
                             openConfigButton
                     }
                 }

--- a/Sources/AppBundle/ui/MessageView.swift
+++ b/Sources/AppBundle/ui/MessageView.swift
@@ -43,7 +43,6 @@ public struct MessageView: View {
                     HStack {
                         TextEditor(text: .constant(model.message?.body ?? ""))
                             .font(.system(size: 12).monospaced())
-                            .textSelection(.enabled)
                         Spacer()
                     }
                     Spacer()
@@ -61,9 +60,8 @@ public struct MessageView: View {
                             openConfigButton
                     }
                 }
-                Button("Continue") {
+                Button("Close") {
                     model.message = nil
-                    self.dismiss()
                 }
                 .keyboardShortcut(.defaultAction)
             }
@@ -75,6 +73,10 @@ public struct MessageView: View {
             if message == nil {
                 self.dismiss()
             }
+        }
+        .onDisappear {
+            // If user closes the screen with the macOS native close (x) button and then the error is still the same, this window will not appear again
+            model.message = nil
         }
     }
 }

--- a/Sources/Common/util/showMessageInGui.swift
+++ b/Sources/Common/util/showMessageInGui.swift
@@ -1,37 +1,15 @@
 import Foundation
 
-// todo refactor. showMessageInGui in common code looks weird
-public func showMessageInGui(filenameIfConsoleApp: String?, title: String, message: String) {
+public func showMessageInGui(filenameIfConsoleApp: String, title: String, message: String) {
     let titleAndMessage = "##### \(title) #####\n\n" + message
     if isCli {
         print(titleAndMessage)
-    } else if let filenameIfConsoleApp {
+    } else {
         let cachesDir = URL(filePath: "/tmp/bobko.aerospace/")
         Result { try FileManager.default.createDirectory(at: cachesDir, withIntermediateDirectories: true) }.getOrDie()
         let file = cachesDir.appending(component: filenameIfConsoleApp)
         Result { try (titleAndMessage + "\n").write(to: file, atomically: true, encoding: .utf8) }.getOrDie()
 
         file.absoluteURL.open(with: URL(filePath: "/System/Applications/Utilities/Console.app"))
-    } else {
-        let args = [
-            "-e",
-            """
-            display dialog "\(message.replacing("\"", with: "\\\""))" with title "\(title)"
-            """,
-        ]
-        Result { try? Process.run(URL(filePath: "/usr/bin/osascript"), arguments: args) }.getOrDie()
-        // === Alternatives ===
-        // let myPopup = NSAlert()
-        // myPopup.messageText = message
-        // myPopup.alertStyle = NSAlert.Style.informational
-        // myPopup.addButton(withTitle: "OK")
-        // myPopup.runModal()
-
-        // let alert = UIAlertController(title: "Alert", message: message, preferredStyle: UIAlertControllerStyle.alert)
-        // alert.addAction(UIAlertAction(title: "Click", style: UIAlertActionStyle.default, handler: nil))
-        // self.present(alert, animated: true, completion: nil)
-
-        // file.absoluteURL.open(with: URL(filePath: "/System/Applications/Utilities/Console.app"))
-        // file.absoluteURL.open(with: URL(filePath: "/System/Applications/TextEdit.app"))
     }
 }


### PR DESCRIPTION
This PR is meant to help solve issue #1495  - As required the text is selectable, both description and body.

Notes:
- Refactored `MenuBar` to moved `"Open config in [editor]"` into a `var openConfigButton: some View { ...` to be able to be reused inside the MessageView to show that same option in this new window for easy access.
- `Message` has a `type`, for now it's a 1 case enum that uses `config` as default, it's meant to support later customizations if other type of messages need to be displayed (to customize for example the extra button action or even the image that wants to be displayed).
- Used the `#Preview` macro inside `MessageView.swift` to use live previews in Xcode to iterate through the UI faster (this can be removed it won't affect functionality, but it's nice to have when working with UI).