### PR TITLE
Display shortcut for each MessageView button

### DIFF
--- a/Sources/AppBundle/ui/MessageView.swift
+++ b/Sources/AppBundle/ui/MessageView.swift
@@ -67,14 +67,17 @@ public struct MessageView: View {
                 if let type = model.message?.type {
                     switch type {
                         case .config:
-                            reloadConfigButton
-                            openConfigButton
+                            reloadConfigButton(showShortcutGroup: true)
+                            openConfigButton(showShortcutGroup: true)
                     }
                 }
-                Button("Close") {
+                let closeButton = Button {
                     model.message = nil
+                } label: {
+                    Text("Close")
                 }
                 .keyboardShortcut(.defaultAction)
+                shortcutGroup(label: Image(systemName: "return.left"), content: closeButton)
             }
             .padding()
         }


### PR DESCRIPTION
Based on [this comment](https://github.com/nikitabobko/AeroSpace/pull/1545#discussion_r2207008384) I added this functionality to display the shortcut of each button in the MessageView.

Dark mode
<img width="607" height="405" alt="image" src="https://github.com/user-attachments/assets/d3f530af-9fc4-4c5a-8ae1-c8c9369485cf" />

and Light mode
<img width="607" height="407" alt="image" src="https://github.com/user-attachments/assets/7bf77b8e-ea6a-4ac8-b72f-547a1d735078" />
