### PR TITLE
Improve --format flag error messages

### DIFF
--- a/Sources/AppBundle/command/format.swift
+++ b/Sources/AppBundle/command/format.swift
@@ -207,8 +207,9 @@ extension String {
         }
         if self == PlainInterVar.newline.rawValue { return .success(.string("\n")) }
         if self == PlainInterVar.tab.rawValue { return .success(.string("\t")) }
-        return .failure("Unknown interpolation variable '\(self)'. " +
-            "Possible values: \(getAvailableInterVars(for: obj.kind).joined(separator: "|"))")
+        let availableVars = getAvailableInterVars(for: obj.kind)
+        let formattedVars = availableVars.map { "    \($0)" }.joined(separator: "\n")
+        return .failure("Unknown interpolation variable '\(self)'.\nPossible values:\n\(formattedVars)")
     }
 
     private func toFormatVar() -> FormatVar? {

--- a/Sources/Common/cmdArgs/impl/ListWindowsCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/ListWindowsCmdArgs.swift
@@ -83,13 +83,19 @@ public func parseListWindowsCmdArgs(_ args: [String]) -> ParsedCmd<ListWindowsCm
 }
 
 func parseFormat(arg: String, nextArgs: inout [String]) -> Parsed<[StringInterToken]> {
-    return if let nextArg = nextArgs.nextNonFlagOrNil() {
+    if let nextArg = nextArgs.nextNonFlagOrNil() {
         switch nextArg.interpolationTokens(interpolationChar: "%") {
-            case .success(let tokens): .success(tokens)
-            case .failure(let err): .failure("Failed to parse <output-format>. \(err)")
+            case .success(let tokens): return .success(tokens)
+            case .failure(let err): return .failure("Failed to parse <output-format>. \(err)")
         }
     } else {
-        .failure("<output-format> is mandatory")
+        let availableVars = [
+            "window-id", "window-is-fullscreen", "window-title", "workspace", "workspace-is-focused", "workspace-is-visible",
+            "monitor-id", "monitor-appkit-nsscreen-screens-id", "monitor-name", "app-bundle-id", "app-name", "app-pid",
+            "app-exec-path", "app-bundle-path", "right-padding", "newline", "tab",
+        ]
+        let formattedVars = availableVars.map { "    \($0)" }.joined(separator: "\n")
+        return .failure("<output-format> is mandatory.\nPossible interpolation variables:\n\(formattedVars)")
     }
 }
 


### PR DESCRIPTION
This PR improves the error messages for the `--format` flag as requested in [#1573](https://github.com/nikitabobko/AeroSpace/issues/1573)
  - Unknown interpolation variables now display available options on separate lines
  - Missing format argument now shows all possible interpolation variables

 ## Testing

<img width="886" height="551" alt="CleanShot 2025-07-23 at 00 41 30" src="https://github.com/user-attachments/assets/3b348ae0-5431-4742-a041-29cf1f71808d" />

<img width="1215" height="551" alt="CleanShot 2025-07-23 at 00 42 23" src="https://github.com/user-attachments/assets/6fb262d0-a1da-4c6c-a3c9-721133161fde" />

I don't like having hardcoded values inside `Sources/Common/cmdArgs/impl/ListWindowsCmdArgs.swift`. However, I don't have access to the `getAvailableInterVars` function because `ListWindowsCmdArgs.swift` is in the `Common` module while
`getAvailableInterVars` is in the `AppBundle` module. 

Do you have any ideas on how to avoid hardcoding these variables? What would be a better way to implement this? @nikitabobko

Thanks




Fixes [#1573](https://github.com/nikitabobko/AeroSpace/issues/1573)