### PR TITLE
Add an indication when secure input is on (Issue #1486)

### DIFF
--- a/Sources/AppBundle/layout/refresh.swift
+++ b/Sources/AppBundle/layout/refresh.swift
@@ -38,6 +38,7 @@ func runRefreshSessionBlocking(
             gcMonitors()
 
             updateTrayText()
+            SecureInputPanel.shared.refresh()
             try await normalizeLayoutReason()
             if shouldLayoutWorkspaces { try await layoutWorkspaces() }
         }
@@ -68,6 +69,7 @@ func runSession<T>(
             let focusAfter = focus.windowOrNil
 
             updateTrayText()
+            SecureInputPanel.shared.refresh()
             try await layoutWorkspaces()
             if focusBefore != focusAfter {
                 focusAfter?.nativeFocus() // syncFocusToMacOs

--- a/Sources/AppBundle/ui/NSPanelHud.swift
+++ b/Sources/AppBundle/ui/NSPanelHud.swift
@@ -1,0 +1,20 @@
+import AppKit
+
+public class NSPanelHud: NSPanel {
+    init() {
+        super.init(
+            contentRect: .zero,
+            styleMask: [.nonactivatingPanel, .borderless, .hudWindow, .utilityWindow],
+            backing: .buffered,
+            defer: false,
+        )
+        self.level = .floating
+        self.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        self.isReleasedWhenClosed = false
+        self.hidesOnDeactivate = false
+        self.isMovableByWindowBackground = false
+        self.alphaValue = 1
+        self.hasShadow = true
+        self.backgroundColor = .clear
+    }
+}

--- a/Sources/AppBundle/ui/SecureInputView.swift
+++ b/Sources/AppBundle/ui/SecureInputView.swift
@@ -5,25 +5,12 @@ import SwiftUI
 private let iconSize = CGSize(width: 50, height: 50)
 private let textSize = CGSize(width: 440, height: 100)
 
-public class SecureInputPanel: NSPanel {
+public class SecureInputPanel: NSPanelHud {
     @MainActor public static var shared: SecureInputPanel = SecureInputPanel()
     private var hostingView = NSHostingView(rootView: SecureInputView())
 
-    private init() {
-        super.init(
-            contentRect: .zero,
-            styleMask: [.nonactivatingPanel, .borderless, .hudWindow, .utilityWindow],
-            backing: .buffered,
-            defer: false,
-        )
-        self.level = .floating
-        self.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
-        self.isReleasedWhenClosed = false
-        self.hidesOnDeactivate = false
-        self.isMovableByWindowBackground = false
-        self.alphaValue = 1
-        self.hasShadow = true
-        self.backgroundColor = .clear
+    override private init() {
+        super.init()
     }
 
     public func refresh() {

--- a/Sources/AppBundle/ui/SecureInputView.swift
+++ b/Sources/AppBundle/ui/SecureInputView.swift
@@ -3,7 +3,7 @@ import Carbon
 import SwiftUI
 
 private let iconSize = CGSize(width: 50, height: 50)
-private let textSize = CGSize(width: 440, height: 100)
+private let textSize = CGSize(width: 440, height: 110)
 
 public class SecureInputPanel: NSPanelHud {
     @MainActor public static var shared: SecureInputPanel = SecureInputPanel()
@@ -13,9 +13,13 @@ public class SecureInputPanel: NSPanelHud {
         super.init()
     }
 
+    @MainActor
     public func refresh() {
-        self.contentView?.subviews.removeAll()
-        if IsSecureEventInputEnabled() {
+        if isVisible && !TrayMenuModel.shared.isEnabled {
+            close()
+        } else if IsSecureEventInputEnabled() {
+            if isVisible { return }
+            self.contentView?.subviews.removeAll()
             hostingView = NSHostingView(rootView: SecureInputView())
             hostingView.frame = NSRect(x: 0, y: 0, width: iconSize.width, height: iconSize.height)
             self.contentView?.addSubview(hostingView)
@@ -24,7 +28,7 @@ public class SecureInputPanel: NSPanelHud {
             self.setFrame(panelFrame, display: true)
             self.orderFrontRegardless()
         } else {
-            close()
+            if isVisible { close() }
         }
     }
 
@@ -56,8 +60,8 @@ struct SecureInputView: View {
                     .aspectRatio(contentMode: .fit)
                     .padding(6)
             } else {
-                Text("**Secure Input** is active. **Secure Input** is a macOS security feature that prevents applications from reading keyboard events.")
-                    .font(.system(.title3, design: .monospaced))
+                Text("AeroSpace cannot respond to keyboard shortcuts while **Secure Input** is active. **Secure Input** is a macOS security feature that prevents applications from reading keyboard events.")
+                    .font(.title3)
                     .padding(10)
             }
         }

--- a/Sources/AppBundle/ui/SecureInputView.swift
+++ b/Sources/AppBundle/ui/SecureInputView.swift
@@ -1,0 +1,93 @@
+import AppKit
+import Carbon
+import SwiftUI
+
+private let iconSize = CGSize(width: 50, height: 50)
+private let textSize = CGSize(width: 440, height: 100)
+
+public class SecureInputPanel: NSPanel {
+    @MainActor public static var shared: SecureInputPanel = SecureInputPanel()
+    private var hostingView = NSHostingView(rootView: SecureInputView())
+
+    private init() {
+        super.init(
+            contentRect: .zero,
+            styleMask: [.nonactivatingPanel, .borderless, .hudWindow, .utilityWindow],
+            backing: .buffered,
+            defer: false,
+        )
+        self.level = .floating
+        self.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        self.isReleasedWhenClosed = false
+        self.hidesOnDeactivate = false
+        self.isMovableByWindowBackground = false
+        self.alphaValue = 1
+        self.hasShadow = true
+        self.backgroundColor = .clear
+    }
+
+    public func refresh() {
+        self.contentView?.subviews.removeAll()
+        if IsSecureEventInputEnabled() {
+            hostingView = NSHostingView(rootView: SecureInputView())
+            hostingView.frame = NSRect(x: 0, y: 0, width: iconSize.width, height: iconSize.height)
+            self.contentView?.addSubview(hostingView)
+            let x = mainMonitor.width - iconSize.width - 20
+            let panelFrame = NSRect(x: x, y: 20, width: iconSize.width, height: iconSize.width)
+            self.setFrame(panelFrame, display: true)
+            self.orderFrontRegardless()
+        } else {
+            close()
+        }
+    }
+
+    public func updateFrame(isMinimized: Bool) {
+        let width = isMinimized ? iconSize.width : textSize.width
+        let height = isMinimized ? iconSize.height : textSize.height
+        hostingView.frame = NSRect(x: 0, y: 0, width: width, height: height)
+        let x = mainMonitor.width - width - 20
+        let panelFrame = NSRect(x: x, y: 20, width: width, height: height)
+        self.setFrame(panelFrame, display: true)
+    }
+}
+
+struct SecureInputView: View {
+    @State var isMinimized: Bool = true
+
+    @Environment(\.colorScheme) var colorScheme: ColorScheme
+    private var fontColor: Color {
+        colorScheme == .dark ? Color.black : Color.white
+    }
+
+    var body: some View {
+        ZStack(alignment: .center) {
+            Rectangle()
+                .fill(Color.gray.opacity(isMinimized ? 0.8 : 1.0))
+            if isMinimized {
+                Image(systemName: "lock.shield.fill")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .padding(6)
+            } else {
+                Text("**Secure Input** is active. **Secure Input** is a macOS security feature that prevents applications from reading keyboard events.")
+                    .font(.system(.title3, design: .monospaced))
+                    .padding(10)
+            }
+        }
+        .foregroundStyle(fontColor)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .onTapGesture {
+            isMinimized.toggle()
+            SecureInputPanel.shared.updateFrame(isMinimized: isMinimized)
+        }
+        .frame(
+            width: isMinimized ? iconSize.width : textSize.width,
+            height: isMinimized ? iconSize.height : textSize.height,
+        )
+    }
+}
+
+#Preview {
+    SecureInputView()
+        .frame(width: 500, height: 120)
+}

--- a/Sources/AppBundle/ui/VolumeView.swift
+++ b/Sources/AppBundle/ui/VolumeView.swift
@@ -1,26 +1,13 @@
 import AppKit
 import SwiftUI
 
-public class VolumePanel: NSPanel {
+public class VolumePanel: NSPanelHud {
     @MainActor public static var shared: VolumePanel = VolumePanel()
     private var timer: Timer?
     private var panelFrame = NSRect(x: 0, y: 0, width: 50, height: 206)
 
-    private init() {
-        super.init(
-            contentRect: panelFrame,
-            styleMask: [.nonactivatingPanel, .borderless, .hudWindow, .utilityWindow],
-            backing: .buffered,
-            defer: false,
-        )
-        self.level = .floating
-        self.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
-        self.isReleasedWhenClosed = false
-        self.hidesOnDeactivate = false
-        self.isMovableByWindowBackground = false
-        self.alphaValue = 1
-        self.hasShadow = true
-        self.backgroundColor = .clear
+    override private init() {
+        super.init()
     }
 
     public func update(with volume: Float) {


### PR DESCRIPTION
Adding SecureInputPanel to display a new NSPanel to inform the user why the shortcuts are not working while Secure Input is enabled in the focused app. - (Issue: https://github.com/nikitabobko/AeroSpace/issues/1486)

Ended up using the same icon that Ghostty uses, that's a default system icon. The panel will be displayed at the bottom right of the screen

The panel has 2 states, by default is minimized 
<img width="538" height="173" alt="image" src="https://github.com/user-attachments/assets/91283468-e262-404b-88b0-4f5c1e9652de" />

On click it expand to show more information about Secure Input
<img width="633" height="226" alt="image" src="https://github.com/user-attachments/assets/d622b7af-7532-4ff8-a047-9e093ce98f6f" />
