### PR TITLE
feat: Add workspace view with app icons and dwindle tiling mode

### DIFF
--- a/Sources/AppBundle/command/impl/BalanceSizesCommand.swift
+++ b/Sources/AppBundle/command/impl/BalanceSizesCommand.swift
@@ -19,6 +19,7 @@ private func balance(_ parent: TilingContainer) {
         switch parent.layout {
             case .tiles: child.setWeight(parent.orientation, 1)
             case .accordion: break // Do nothing
+            case .dwindle: child.setWeight(parent.orientation, 1) // Balance weights in dwindle
         }
         if let child = child as? TilingContainer {
             balance(child)

--- a/Sources/AppBundle/command/impl/LayoutCommand.swift
+++ b/Sources/AppBundle/command/impl/LayoutCommand.swift
@@ -26,6 +26,8 @@ struct LayoutCommand: Command {
                 return changeTilingLayout(io, targetLayout: .accordion, targetOrientation: nil, window: window)
             case .tiles:
                 return changeTilingLayout(io, targetLayout: .tiles, targetOrientation: nil, window: window)
+            case .dwindle:
+                return changeTilingLayout(io, targetLayout: .dwindle, targetOrientation: nil, window: window)
             case .horizontal:
                 return changeTilingLayout(io, targetLayout: nil, targetOrientation: .h, window: window)
             case .vertical:
@@ -73,6 +75,7 @@ extension Window {
         return switch layout {
             case .accordion:   (parent as? TilingContainer)?.layout == .accordion
             case .tiles:       (parent as? TilingContainer)?.layout == .tiles
+            case .dwindle:     (parent as? TilingContainer)?.layout == .dwindle
             case .horizontal:  (parent as? TilingContainer)?.orientation == .h
             case .vertical:    (parent as? TilingContainer)?.orientation == .v
             case .h_accordion: (parent as? TilingContainer).map { $0.layout == .accordion && $0.orientation == .h } == true

--- a/Sources/AppBundle/mouse/moveWithMouse.swift
+++ b/Sources/AppBundle/mouse/moveWithMouse.swift
@@ -104,6 +104,10 @@ extension CGPoint {
                 })
             case .accordion:
                 tree.mostRecentChild
+            case .dwindle:
+                tree.children.first(where: {
+                    (virtual ? $0.lastAppliedLayoutVirtualRect : $0.lastAppliedLayoutPhysicalRect)?.contains(point) == true
+                })
         }
         guard let target else { return nil }
         return switch target.tilingTreeNodeCasesOrDie() {

--- a/Sources/AppBundle/tree/TilingContainer.swift
+++ b/Sources/AppBundle/tree/TilingContainer.swift
@@ -58,6 +58,7 @@ extension TilingContainer {
 enum Layout: String {
     case tiles
     case accordion
+    case dwindle
 }
 
 extension String {

--- a/Sources/AppBundle/ui/CenteredBarPanel.swift
+++ b/Sources/AppBundle/ui/CenteredBarPanel.swift
@@ -1,0 +1,12 @@
+import AppKit
+
+/// Custom NSPanel subclass that bypasses the default menu bar constraint
+/// This allows the panel to be positioned within the menu bar area
+@MainActor
+class CenteredBarPanel: NSPanel {
+    override func constrainFrameRect(_ frameRect: NSRect, to screen: NSScreen?) -> NSRect {
+        // Return frameRect unchanged to bypass the system's menu bar constraint
+        // This allows our panel to overlap with the menu bar area
+        return frameRect
+    }
+}

--- a/Sources/AppBundle/ui/CenteredWorkspaceBar.swift
+++ b/Sources/AppBundle/ui/CenteredWorkspaceBar.swift
@@ -1,0 +1,236 @@
+import AppKit
+import Common
+import SwiftUI
+
+@MainActor
+struct CenteredWorkspaceBar: View {
+    @ObservedObject var viewModel: TrayMenuModel
+    let barHeight: CGFloat
+    @Environment(\.colorScheme) var colorScheme: ColorScheme
+    
+    // Derived sizing from bar height
+    private var itemHeight: CGFloat { max(16, barHeight - 4) }
+    private var iconSize: CGFloat { max(12, itemHeight - 6) }
+    private let workspaceSpacing: CGFloat = 8
+    private let windowSpacing: CGFloat = 2
+    private let cornerRadius: CGFloat = 6
+    
+    private var backgroundColor: Color {
+        colorScheme == .dark ? Color.white.opacity(0.1) : Color.black.opacity(0.05)
+    }
+    
+    private var activeBackgroundColor: Color {
+        colorScheme == .dark ? Color.white.opacity(0.2) : Color.black.opacity(0.1)
+    }
+    
+    private var borderColor: Color {
+        // Accent color 0xffc4a7e7 (ARGB). Alpha=1.0, RGB=c4 a7 e7
+        Color(red: 196/255.0, green: 167/255.0, blue: 231/255.0)
+    }
+    
+    var body: some View {
+        HStack(spacing: workspaceSpacing) {
+            ForEach(viewModel.centeredBarWorkspaces, id: \.workspace.name) { item in
+                WorkspaceItemView(
+                    item: item,
+                    iconSize: iconSize,
+                    itemHeight: itemHeight,
+                    windowSpacing: windowSpacing,
+                    cornerRadius: cornerRadius,
+                    backgroundColor: backgroundColor,
+                    activeBackgroundColor: activeBackgroundColor,
+                    borderColor: borderColor
+                )
+            }
+        }
+        .padding(.horizontal, 4)
+        .frame(height: itemHeight + 4)
+    }
+}
+
+@MainActor
+private struct WorkspaceItemView: View {
+    let item: CenteredBarWorkspaceItem
+    let iconSize: CGFloat
+    let itemHeight: CGFloat
+    let windowSpacing: CGFloat
+    let cornerRadius: CGFloat
+    let backgroundColor: Color
+    let activeBackgroundColor: Color
+    let borderColor: Color
+    
+    @State private var isHovered = false
+    
+    var body: some View {
+        HStack(spacing: windowSpacing) {
+            // Workspace identifier
+            if viewModel.showWorkspaceNumbers {
+                Text(item.workspace.name)
+                    .font(.system(size: 12, weight: .medium, design: .monospaced))
+                    .foregroundColor(item.isFocused ? borderColor : .secondary)
+                    .frame(minWidth: 16)
+                
+                if !item.windows.isEmpty {
+                    Divider()
+                        .frame(height: iconSize)
+                        .padding(.horizontal, 2)
+                }
+            }
+            
+            // Window icons
+            ForEach(item.windows, id: \.windowId) { window in
+                WindowIconView(
+                    window: window,
+                    workspace: item.workspace,
+                    iconSize: iconSize,
+                    isFocused: window.isFocused,
+                    isInFocusedWorkspace: item.isFocused
+                )
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 2)
+        .frame(height: itemHeight)
+        .background(
+            RoundedRectangle(cornerRadius: cornerRadius)
+                .fill(item.isFocused ? activeBackgroundColor : (isHovered ? backgroundColor : Color.clear))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: cornerRadius)
+                .strokeBorder(item.isFocused ? borderColor : Color.clear, lineWidth: 1)
+        )
+        .onHover { hovering in
+            isHovered = hovering
+        }
+        .onTapGesture {
+            focusWorkspace(item.workspace)
+        }
+    }
+    
+    private var viewModel: TrayMenuModel {
+        TrayMenuModel.shared
+    }
+    
+    private func focusWorkspace(_ workspace: Workspace) {
+        Task {
+            if let token: RunSessionGuard = .isServerEnabled {
+                try await runSession(.menuBarButton, token) { 
+                    _ = workspace.focusWorkspace() 
+                }
+            }
+        }
+    }
+}
+
+@MainActor
+private struct WindowIconView: View {
+    let window: CenteredBarWindowItem
+    let workspace: Workspace
+    let iconSize: CGFloat
+    let isFocused: Bool
+    let isInFocusedWorkspace: Bool
+    
+    @State private var isHovered = false
+    
+    var body: some View {
+        Group {
+            if let icon = window.icon {
+                Image(nsImage: icon)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+            } else {
+                Image(systemName: "app.dashed")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+            }
+        }
+        .frame(width: iconSize, height: iconSize)
+        .opacity(opacity)
+        .scaleEffect(isHovered ? 1.1 : 1.0)
+        .animation(.easeInOut(duration: 0.1), value: isHovered)
+        .onHover { hovering in
+            isHovered = hovering
+        }
+        .onTapGesture {
+            focusWindow()
+        }
+        .help(window.appName ?? "Unknown App")
+    }
+    
+    private var opacity: Double {
+        if isFocused {
+            return 1.0
+        } else if isInFocusedWorkspace {
+            return 0.6
+        } else {
+            return 0.8
+        }
+    }
+    
+    private func focusWindow() {
+        Task {
+            if let token: RunSessionGuard = .isServerEnabled {
+                try await runSession(.menuBarButton, token) {
+                    // First focus the workspace
+                    _ = workspace.focusWorkspace()
+                    // Then focus the specific window
+                    if let macWindow = workspace.allLeafWindowsRecursive.first(where: { $0.windowId == window.windowId }) {
+                        macWindow.nativeFocus()
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Data models for the centered bar
+struct CenteredBarWorkspaceItem {
+    let workspace: Workspace
+    let isFocused: Bool
+    let windows: [CenteredBarWindowItem]
+}
+
+struct CenteredBarWindowItem {
+    let windowId: UInt32
+    let appName: String?
+    let icon: NSImage?
+    let isFocused: Bool
+}
+
+// Extension to prepare data for centered bar
+@MainActor
+extension TrayMenuModel {
+    var showWorkspaceNumbers: Bool {
+        experimentalUISettings.centeredBarShowNumbers
+    }
+    
+    var centeredBarWorkspaces: [CenteredBarWorkspaceItem] {
+        let focus = focus
+        // Show all workspaces, not just visible ones
+        let allWorkspaces = Workspace.all.sorted()
+        
+        return allWorkspaces.map { workspace in
+            let windows = workspace.allLeafWindowsRecursive.map { window in
+                let icon: NSImage?
+                if let macWindow = window as? MacWindow {
+                    icon = macWindow.macApp.nsApp.icon
+                } else {
+                    icon = nil
+                }
+                
+                return CenteredBarWindowItem(
+                    windowId: window.windowId,
+                    appName: window.app.name,
+                    icon: icon,
+                    isFocused: window == focus.windowOrNil
+                )
+            }
+            
+            return CenteredBarWorkspaceItem(
+                workspace: workspace,
+                isFocused: workspace == focus.workspace,
+                windows: windows
+            )
+        }
+    }
+}

--- a/Sources/AppBundle/ui/ExperimentalUISettings.swift
+++ b/Sources/AppBundle/ui/ExperimentalUISettings.swift
@@ -14,6 +14,59 @@ struct ExperimentalUISettings {
             UserDefaults.standard.synchronize()
         }
     }
+    
+    var centeredBarEnabled: Bool {
+        get {
+            UserDefaults.standard.bool(forKey: ExperimentalUISettingsItems.centeredBarEnabled.rawValue)
+        }
+        set {
+            UserDefaults.standard.setValue(newValue, forKey: ExperimentalUISettingsItems.centeredBarEnabled.rawValue)
+            UserDefaults.standard.synchronize()
+        }
+    }
+    
+    var centeredBarShowNumbers: Bool {
+        get {
+            if UserDefaults.standard.object(forKey: ExperimentalUISettingsItems.centeredBarShowNumbers.rawValue) == nil {
+                return true // Default to true
+            }
+            return UserDefaults.standard.bool(forKey: ExperimentalUISettingsItems.centeredBarShowNumbers.rawValue)
+        }
+        set {
+            UserDefaults.standard.setValue(newValue, forKey: ExperimentalUISettingsItems.centeredBarShowNumbers.rawValue)
+            UserDefaults.standard.synchronize()
+        }
+    }
+
+    // Centered bar window level (affects z-order over menu bar)
+    var centeredBarWindowLevel: CenteredBarWindowLevel {
+        get {
+            if let raw = UserDefaults.standard.string(forKey: ExperimentalUISettingsItems.centeredBarWindowLevel.rawValue),
+               let value = CenteredBarWindowLevel(rawValue: raw) {
+                return value
+            }
+            return .popup // default: above menu bar
+        }
+        set {
+            UserDefaults.standard.setValue(newValue.rawValue, forKey: ExperimentalUISettingsItems.centeredBarWindowLevel.rawValue)
+            UserDefaults.standard.synchronize()
+        }
+    }
+
+    // Target display for the centered bar
+    var centeredBarTargetDisplay: CenteredBarTargetDisplay {
+        get {
+            if let raw = UserDefaults.standard.string(forKey: ExperimentalUISettingsItems.centeredBarTargetDisplay.rawValue),
+               let value = CenteredBarTargetDisplay(rawValue: raw) {
+                return value
+            }
+            return .focusedWorkspaceMonitor // default: follows focused workspace
+        }
+        set {
+            UserDefaults.standard.setValue(newValue.rawValue, forKey: ExperimentalUISettingsItems.centeredBarTargetDisplay.rawValue)
+            UserDefaults.standard.synchronize()
+        }
+    }
 }
 
 enum MenuBarStyle: String, CaseIterable, Identifiable, Equatable, Hashable {
@@ -21,21 +74,51 @@ enum MenuBarStyle: String, CaseIterable, Identifiable, Equatable, Hashable {
     case systemText
     case squares
     case i3
-    case i3Ordered
     var id: String { rawValue }
     var title: String {
         switch self {
             case .monospacedText: "Monospaced font"
             case .systemText: "System font"
             case .squares: "Square images"
-            case .i3: "i3 style grouped"
-            case .i3Ordered: "i3 style ordered"
+            case .i3: "i3 style"
         }
     }
 }
 
 enum ExperimentalUISettingsItems: String {
     case displayStyle
+    case centeredBarEnabled
+    case centeredBarShowNumbers
+    case centeredBarWindowLevel
+    case centeredBarTargetDisplay
+}
+
+enum CenteredBarWindowLevel: String, CaseIterable, Identifiable, Equatable, Hashable {
+    case status   // NSWindow.Level.statusBar
+    case popup    // NSWindow.Level.popUpMenu (above menu bar)
+    case screensaver // NSWindow.Level.screenSaver (highest common level)
+    var id: String { rawValue }
+    var title: String {
+        switch self {
+            case .status: "Status Bar"
+            case .popup: "Popup (above menu bar)"
+            case .screensaver: "Screen Saver (highest)"
+        }
+    }
+}
+
+enum CenteredBarTargetDisplay: String, CaseIterable, Identifiable, Equatable, Hashable {
+    case focusedWorkspaceMonitor // monitor of the focused workspace
+    case primary                 // main monitor (origin 0,0)
+    case mouse                   // display under mouse cursor
+    var id: String { rawValue }
+    var title: String {
+        switch self {
+            case .focusedWorkspaceMonitor: "Focused Workspace Monitor"
+            case .primary: "Primary Display"
+            case .mouse: "Display Under Mouse"
+        }
+    }
 }
 
 @MainActor
@@ -43,29 +126,91 @@ func getExperimentalUISettingsMenu(viewModel: TrayMenuModel) -> some View {
     let color = AppearanceTheme.current == .dark ? Color.white : Color.black
     return Menu {
         Text("Menu bar style (macOS 14 or later):")
-        MenuBarStyleButton(.monospacedText, viewModel, color) { MenuBarLabel(viewModel.trayText, color: color) }
-        MenuBarStyleButton(.systemText, viewModel, color) { MenuBarLabel(viewModel.trayText, textStyle: .system, color: color) }
-        MenuBarStyleButton(.squares, viewModel, color) { MenuBarLabel(viewModel.trayText, color: color, trayItems: viewModel.trayItems) }
-        MenuBarStyleButton(.i3, viewModel, color) { MenuBarLabel(viewModel.trayText, color: color, trayItems: viewModel.trayItems, workspaces: viewModel.workspaces) }
-        MenuBarStyleButton(.i3Ordered, viewModel, color) { MenuBarLabel(viewModel.trayText, color: color, workspaces: viewModel.workspaces) }
+        Button {
+            viewModel.experimentalUISettings.displayStyle = .monospacedText
+        } label: {
+            Toggle(isOn: .constant(viewModel.experimentalUISettings.displayStyle == .monospacedText)) {
+                MenuBarLabel(viewModel.trayText, color: color)
+                Text(" -  " + MenuBarStyle.monospacedText.title)
+            }
+        }
+        Button {
+            viewModel.experimentalUISettings.displayStyle = .systemText
+        } label: {
+            Toggle(isOn: .constant(viewModel.experimentalUISettings.displayStyle == .systemText)) {
+                MenuBarLabel(viewModel.trayText, textStyle: .system, color: color)
+                Text(" -  " + MenuBarStyle.systemText.title)
+            }
+        }
+        Button {
+            viewModel.experimentalUISettings.displayStyle = .squares
+        } label: {
+            Toggle(isOn: .constant(viewModel.experimentalUISettings.displayStyle == .squares)) {
+                MenuBarLabel(viewModel.trayText, color: color, trayItems: viewModel.trayItems)
+                Text(" -  " + MenuBarStyle.squares.title)
+            }
+        }
+        Button {
+            viewModel.experimentalUISettings.displayStyle = .i3
+        } label: {
+            Toggle(isOn: .constant(viewModel.experimentalUISettings.displayStyle == .i3)) {
+                MenuBarLabel(viewModel.trayText, color: color, trayItems: viewModel.trayItems, workspaces: viewModel.workspaces)
+                Text(" -  " + MenuBarStyle.i3.title)
+            }
+        }
+        Divider()
+        Text("Centered Workspace Bar:")
+        Button {
+            viewModel.experimentalUISettings.centeredBarEnabled.toggle()
+            StatusBarManager.shared.toggleCenteredBar(viewModel: viewModel)
+        } label: {
+            Toggle(isOn: .constant(viewModel.experimentalUISettings.centeredBarEnabled)) {
+                Text("Enable centered workspace bar with app icons")
+            }
+        }
+        Button {
+            viewModel.experimentalUISettings.centeredBarShowNumbers.toggle()
+            if viewModel.experimentalUISettings.centeredBarEnabled {
+                StatusBarManager.shared.updateCenteredBar(viewModel: viewModel)
+            }
+        } label: {
+            Toggle(isOn: .constant(viewModel.experimentalUISettings.centeredBarShowNumbers)) {
+                Text("Show workspace numbers")
+            }
+        }.disabled(!viewModel.experimentalUISettings.centeredBarEnabled)
+
+        // Window level selection
+        Text("Window Level:")
+        ForEach(CenteredBarWindowLevel.allCases) { level in
+            Button {
+                viewModel.experimentalUISettings.centeredBarWindowLevel = level
+                if viewModel.experimentalUISettings.centeredBarEnabled {
+                    StatusBarManager.shared.updateCenteredBar(viewModel: viewModel)
+                }
+            } label: {
+                Toggle(isOn: .constant(viewModel.experimentalUISettings.centeredBarWindowLevel == level)) {
+                    Text(level.title)
+                }
+            }
+        }
+        .disabled(!viewModel.experimentalUISettings.centeredBarEnabled)
+
+        // Target display selection
+        Text("Target Display:")
+        ForEach(CenteredBarTargetDisplay.allCases) { target in
+            Button {
+                viewModel.experimentalUISettings.centeredBarTargetDisplay = target
+                if viewModel.experimentalUISettings.centeredBarEnabled {
+                    StatusBarManager.shared.updateCenteredBar(viewModel: viewModel)
+                }
+            } label: {
+                Toggle(isOn: .constant(viewModel.experimentalUISettings.centeredBarTargetDisplay == target)) {
+                    Text(target.title)
+                }
+            }
+        }
+        .disabled(!viewModel.experimentalUISettings.centeredBarEnabled)
     } label: {
         Text("Experimental UI Settings (No stability guarantees)")
-    }
-}
-
-@MainActor
-func MenuBarStyleButton(
-    _ style: MenuBarStyle,
-    _ viewModel: TrayMenuModel,
-    _ color: Color,
-    _ menuBarLabel: () -> some View,
-) -> some View {
-    Button {
-        viewModel.experimentalUISettings.displayStyle = style
-    } label: {
-        Toggle(isOn: .constant(viewModel.experimentalUISettings.displayStyle == style)) {
-            menuBarLabel()
-            Text(" -  " + style.title)
-        }
     }
 }

--- a/Sources/AppBundle/ui/StatusBarManager.swift
+++ b/Sources/AppBundle/ui/StatusBarManager.swift
@@ -1,0 +1,204 @@
+import AppKit
+import Common
+import SwiftUI
+
+@MainActor
+class StatusBarManager: ObservableObject {
+    static let shared = StatusBarManager()
+    
+    private var panel: NSPanel?
+    private var hostingView: NSHostingView<CenteredWorkspaceBar>?
+    private var screenObserver: Any?
+    
+    private init() {
+        setupScreenChangeObserver()
+    }
+    
+    func setupCenteredBar(viewModel: TrayMenuModel) {
+        guard viewModel.experimentalUISettings.centeredBarEnabled else {
+            removeCenteredBar()
+            return
+        }
+        
+        if panel == nil {
+            panel = createCenteredPanel()
+        }
+        
+        // Build content sized to menu bar height
+        let screenForContent = resolveTargetScreen() ?? NSScreen.screens.first
+        let barHeight = screenForContent.map(menuBarHeight(for:)).map { max($0, 24) } ?? 28
+        let contentView = CenteredWorkspaceBar(viewModel: viewModel, barHeight: barHeight)
+        
+        if hostingView == nil {
+            hostingView = NSHostingView(rootView: contentView)
+        } else {
+            hostingView?.rootView = contentView
+        }
+        
+        guard let panel = panel,
+              let hostingView = hostingView else { return }
+        
+        // Set the hosting view as the panel's content view
+        panel.contentView = hostingView
+
+        // Apply settings and update the frame/position
+        applySettingsToPanel(panel)
+        updateFrameAndPosition()
+        
+        // Show the panel without taking key focus
+        panel.orderFrontRegardless()
+    }
+    
+    func updateCenteredBar(viewModel: TrayMenuModel) {
+        guard viewModel.experimentalUISettings.centeredBarEnabled else {
+            removeCenteredBar()
+            return
+        }
+        
+        if panel == nil {
+            setupCenteredBar(viewModel: viewModel)
+        } else {
+            // Update the content (recompute bar height for current screen)
+            let screenForContent = resolveTargetScreen() ?? NSScreen.screens.first
+            let barHeight = screenForContent.map(menuBarHeight(for:)).map { max($0, 24) } ?? 28
+            hostingView?.rootView = CenteredWorkspaceBar(viewModel: viewModel, barHeight: barHeight)
+            if let panel {
+                applySettingsToPanel(panel)
+            }
+            updateFrameAndPosition()
+        }
+    }
+    
+    private func createCenteredPanel() -> NSPanel {
+        // Use custom panel subclass to bypass menu bar constraint
+        let panel = CenteredBarPanel(
+            contentRect: .zero,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        // Level and behaviors are applied from settings below
+        // Show on all Spaces and during fullscreen as an auxiliary overlay
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+        // Visuals and interaction
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = false
+        panel.ignoresMouseEvents = false  // Keep interactive
+        // Panel behavior
+        panel.isFloatingPanel = true
+        panel.hidesOnDeactivate = false
+        panel.becomesKeyOnlyIfNeeded = true
+        panel.isReleasedWhenClosed = false
+        panel.isMovable = false
+        panel.isMovableByWindowBackground = false
+        // Apply current settings (level etc.)
+        applySettingsToPanel(panel)
+        return panel
+    }
+    
+    private func updateFrameAndPosition() {
+        guard let panel = panel,
+              let hostingView = hostingView else { return }
+        
+        // Calculate the required size
+        let fittingSize = hostingView.fittingSize
+        
+        // Resolve target screen based on settings
+        let screen = resolveTargetScreen()
+        guard let screen = screen else { return }
+        
+        // Use screen.frame for full screen including menu bar area
+        let screenFrame = screen.frame
+        let visibleFrame = screen.visibleFrame  // Keep for debug logging
+        let barHeight = max(menuBarHeight(for: screen), 24)
+        
+        // Debug logging
+        print("DEBUG: Screen frame: \(screenFrame)")
+        print("DEBUG: Visible frame: \(visibleFrame)")
+        print("DEBUG: Fitting size: \(fittingSize)")
+        
+        // Force minimum size to ensure visibility
+        let width = max(fittingSize.width, 300)  // Force 300px minimum width
+        let height = barHeight  // Exactly match menu bar height
+        
+        // Position to exactly occupy the menu bar area
+        let x = screenFrame.midX - width / 2  // Center horizontally
+        let y = visibleFrame.maxY             // Bottom aligns with menu bar bottom
+        
+        print("DEBUG: Final position: x=\(x), y=\(y), width=\(width), height=\(height)")
+        
+        // Set the panel frame
+        panel.setFrame(NSRect(x: x, y: y, width: width, height: height), display: true)
+
+        // Ensure SwiftUI content matches the new bar height
+        hostingView.rootView = CenteredWorkspaceBar(viewModel: TrayMenuModel.shared, barHeight: barHeight)
+    }
+    
+    func removeCenteredBar() {
+        panel?.orderOut(nil)
+        panel?.close()
+        panel = nil
+        hostingView = nil
+    }
+    
+    func toggleCenteredBar(viewModel: TrayMenuModel) {
+        if viewModel.experimentalUISettings.centeredBarEnabled {
+            setupCenteredBar(viewModel: viewModel)
+        } else {
+            removeCenteredBar()
+        }
+    }
+    
+    private func setupScreenChangeObserver() {
+        // Listen for screen configuration changes
+        screenObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.updateFrameAndPosition()
+            }
+        }
+    }
+    
+    func cleanup() {
+        if let observer = screenObserver {
+            NotificationCenter.default.removeObserver(observer)
+            screenObserver = nil
+        }
+        removeCenteredBar()
+    }
+
+    // MARK: - Helpers
+    private func applySettingsToPanel(_ panel: NSPanel) {
+        let settings = TrayMenuModel.shared.experimentalUISettings
+        panel.level = switch settings.centeredBarWindowLevel {
+            case .status: .statusBar
+            case .popup: .popUpMenu
+            case .screensaver: .screenSaver
+        }
+    }
+
+    private func resolveTargetScreen() -> NSScreen? {
+        let settings = TrayMenuModel.shared.experimentalUISettings
+        switch settings.centeredBarTargetDisplay {
+            case .primary:
+                let idx = mainMonitor.monitorAppKitNsScreenScreensId - 1
+                return NSScreen.screens.indices.contains(idx) ? NSScreen.screens[idx] : NSScreen.screens.first
+            case .mouse:
+                let mouse = NSEvent.mouseLocation
+                return NSScreen.screens.first { NSMouseInRect(mouse, $0.frame, false) } ?? NSScreen.screens.first
+            case .focusedWorkspaceMonitor:
+                let monitor = focus.workspace.workspaceMonitor
+                let idx = monitor.monitorAppKitNsScreenScreensId - 1
+                return NSScreen.screens.indices.contains(idx) ? NSScreen.screens[idx] : NSScreen.screens.first
+        }
+    }
+
+    private func menuBarHeight(for screen: NSScreen) -> CGFloat {
+        let h = screen.frame.maxY - screen.visibleFrame.maxY
+        return h > 0 ? h : 28 // fallback
+    }
+}

--- a/Sources/AppBundleTests/command/MoveCommandTest.swift
+++ b/Sources/AppBundleTests/command/MoveCommandTest.swift
@@ -299,6 +299,9 @@ extension TreeNode {
                         container.orientation == .h
                             ? .h_accordion(container.children.map(\.layoutDescription))
                             : .v_accordion(container.children.map(\.layoutDescription))
+                    case .dwindle:
+                        // For dwindle, we'll just use h_tiles as a placeholder in tests
+                        .h_tiles(container.children.map(\.layoutDescription))
                 }
         }
     }

--- a/Sources/Common/cmdArgs/impl/LayoutCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/LayoutCmdArgs.swift
@@ -21,7 +21,7 @@ public struct LayoutCmdArgs: CmdArgs {
     }
 
     public enum LayoutDescription: String, CaseIterable, Equatable, Sendable {
-        case accordion, tiles
+        case accordion, tiles, dwindle
         case horizontal, vertical
         case h_accordion, v_accordion, h_tiles, v_tiles
         case tiling, floating


### PR DESCRIPTION
## Summary
This PR introduces two main features to AeroSpace:

1. **Workspace View** - A visual workspace indicator showing real application icons in the menu bar
2. **Dwindle Tiling Mode** - Hyprland's dwindle tiling algorithm as a new layout option

## Features

### Workspace View
- Real application icons displayed in the menu bar
- Visual indication of current workspace and apps in each workspace
- Unobtrusive design that preserves native macOS menu bar behavior
- Integrated naturally into AeroSpace's existing menu system

### Dwindle Tiling Mode
- Binary tree-based layout with aspect-ratio optimized splitting
- Integrated as a standard layout option alongside tiles and accordion
- Configurable via standard `layout dwindle` command
- Support in balance-sizes command for weight distribution

## Implementation
- **CenteredWorkspaceBar.swift** - SwiftUI-based workspace visualization
- **StatusBarManager.swift** - Menu bar integration
- **TilingContainer.swift** - Dwindle layout algorithm
- **LayoutCommand.swift** - Command support for dwindle mode
- **LayoutCmdArgs.swift** - CLI argument parsing

## Motivation

**Workspace Awareness** – Provides quick visual feedback about which workspace is active and what applications are present in each workspace.

**Tiling Preference** – Offers Hyprland's dwindle tiling as an alternative to vertical layout for users who prefer this tiling style. Implemented as an optional mode to respect user choice.

## Testing
- Tested workspace view with multiple applications and workspaces
- Verified dwindle tiling behavior with various window configurations
- Ensured backward compatibility with existing configurations

## Screenshots
[To be added if needed]

---
Author: BarutSRB