### PR TITLE
Make users explicitly supply --stdin flag to workspace command when stdin is used

### DIFF
--- a/Sources/AppBundle/command/impl/MoveNodeToWorkspaceCommand.swift
+++ b/Sources/AppBundle/command/impl/MoveNodeToWorkspaceCommand.swift
@@ -17,6 +17,7 @@ struct MoveNodeToWorkspaceCommand: Command {
                     isNext: nextPrev == .next,
                     wrapAround: args.wrapAround,
                     stdin: io.readStdin(),
+                    useStdin: false,
                     target: target,
                 )
                 guard let ws else { return io.err("Can't resolve next or prev workspace") }

--- a/Sources/AppBundle/command/impl/WorkspaceCommand.swift
+++ b/Sources/AppBundle/command/impl/WorkspaceCommand.swift
@@ -12,16 +12,11 @@ struct WorkspaceCommand: Command {
         let workspaceName: String
         switch args.target.val {
             case .relative(let nextPrev):
-                let stdin = io.readStdin()
-                let hasImplicitStdin = !stdin.isEmpty && args._stdin == nil
-                if hasImplicitStdin {
-                    return io.err("ERROR: Implicit stdin is detected (stdin is not TTY). Implicit stdin was forbidden in AeroSpace v0.20.0.\n1. Please supply '--stdin' flag to make stdin explicit and preserve old AeroSpace behavior\n2. You can also use '--no-stdin' flag to behave as if no stdin was supplied\nBreaking change issue: https://github.com/nikitabobko/AeroSpace/issues/1683")
-                }
                 let workspace = getNextPrevWorkspace(
                     current: focusedWs,
                     isNext: nextPrev == .next,
                     wrapAround: args.wrapAround,
-                    stdin: stdin,
+                    stdin: io.readStdin(),
                     useStdin: args.stdin,
                     target: target,
                 )

--- a/Sources/AppBundle/command/impl/WorkspaceCommand.swift
+++ b/Sources/AppBundle/command/impl/WorkspaceCommand.swift
@@ -13,7 +13,7 @@ struct WorkspaceCommand: Command {
         switch args.target.val {
             case .relative(let nextPrev):
                 let stdin = io.readStdin()
-                let hasImplicitStdin = !stdin.isEmpty && args._noStdin == nil && !args.stdin
+                let hasImplicitStdin = !stdin.isEmpty && args._stdin == nil
                 if hasImplicitStdin {
                     return io.err("ERROR: Implicit stdin is detected (stdin is not TTY). Implicit stdin was forbidden in AeroSpace v0.20.0.\n1. Please supply '--stdin' flag to make stdin explicit and preserve old AeroSpace behavior\n2. You can also use '--no-stdin' flag to behave as if no stdin was supplied\nBreaking change issue: https://github.com/nikitabobko/AeroSpace/issues/1683")
                 }
@@ -22,7 +22,7 @@ struct WorkspaceCommand: Command {
                     isNext: nextPrev == .next,
                     wrapAround: args.wrapAround,
                     stdin: stdin,
-                    useStdin: args._noStdin.map { !$0 } ?? args.stdin,
+                    useStdin: args.stdin,
                     target: target,
                 )
                 guard let workspace else { return false }

--- a/Sources/AppBundle/command/impl/WorkspaceCommand.swift
+++ b/Sources/AppBundle/command/impl/WorkspaceCommand.swift
@@ -13,16 +13,16 @@ struct WorkspaceCommand: Command {
         switch args.target.val {
             case .relative(let nextPrev):
                 let stdin = io.readStdin()
-                let useStdin = args.stdin
-                if !stdin.isEmpty && !useStdin {
-                    return io.err("ERROR: Implicit stdin is detected (stdin is not TTY). Implicit stdin was forbidden in AeroSpace v0.20.0.\nPlease supply '--stdin' flag to make stdin explicit and preserve old AeroSpace behavior.\nBreaking change issue: https://github.com/nikitabobko/AeroSpace/issues/1683")
+                let hasImplicitStdin = !stdin.isEmpty && args._noStdin == nil && !args.stdin
+                if hasImplicitStdin {
+                    return io.err("ERROR: Implicit stdin is detected (stdin is not TTY). Implicit stdin was forbidden in AeroSpace v0.20.0.\n1. Please supply '--stdin' flag to make stdin explicit and preserve old AeroSpace behavior\n2. You can also use '--no-stdin' flag to behave as if no stdin was supplied\nBreaking change issue: https://github.com/nikitabobko/AeroSpace/issues/1683")
                 }
                 let workspace = getNextPrevWorkspace(
                     current: focusedWs,
                     isNext: nextPrev == .next,
                     wrapAround: args.wrapAround,
                     stdin: stdin,
-                    useStdin: useStdin,
+                    useStdin: args._noStdin.map { !$0 } ?? args.stdin,
                     target: target,
                 )
                 guard let workspace else { return false }

--- a/Sources/AppBundleTests/command/WorkspaceCommandTest.swift
+++ b/Sources/AppBundleTests/command/WorkspaceCommandTest.swift
@@ -15,5 +15,6 @@ final class WorkspaceCommandTest: XCTestCase {
         assertEquals(parseCommand("workspace --wrap-around W").errorOrNil, "--wrapAround requires using (next|prev) argument")
         assertEquals(parseCommand("workspace --auto-back-and-forth next").errorOrNil, "--auto-back-and-forth is incompatible with (next|prev)")
         testParseCommandSucc("workspace next --wrap-around", WorkspaceCmdArgs(target: .relative(.next), wrapAround: true))
+        assertEquals(parseCommand("workspace --stdin foo").errorOrNil, "--stdin requires using (next|prev) argument")
     }
 }

--- a/Sources/AppBundleTests/command/WorkspaceCommandTest.swift
+++ b/Sources/AppBundleTests/command/WorkspaceCommandTest.swift
@@ -15,8 +15,8 @@ final class WorkspaceCommandTest: XCTestCase {
         assertEquals(parseCommand("workspace --wrap-around W").errorOrNil, "--wrapAround requires using (next|prev) argument")
         assertEquals(parseCommand("workspace --auto-back-and-forth next").errorOrNil, "--auto-back-and-forth is incompatible with (next|prev)")
         testParseCommandSucc("workspace next --wrap-around", WorkspaceCmdArgs(target: .relative(.next), wrapAround: true))
-        assertEquals(parseCommand("workspace --stdin foo").errorOrNil, "--stdin requires using (next|prev) argument")
-        assertEquals(parseCommand("workspace --no-stdin foo").errorOrNil, "--no-stdin requires using (next|prev) argument")
-        testParseCommandSucc("workspace --no-stdin next", WorkspaceCmdArgs(target: .relative(.next), noStdin: true))
+        assertEquals(parseCommand("workspace --stdin foo").errorOrNil, "--stdin and --no-stdin require using (next|prev) argument")
+        testParseCommandSucc("workspace --stdin next", WorkspaceCmdArgs(target: .relative(.next), stdin: true))
+        testParseCommandSucc("workspace --no-stdin next", WorkspaceCmdArgs(target: .relative(.next), stdin: false))
     }
 }

--- a/Sources/AppBundleTests/command/WorkspaceCommandTest.swift
+++ b/Sources/AppBundleTests/command/WorkspaceCommandTest.swift
@@ -16,5 +16,7 @@ final class WorkspaceCommandTest: XCTestCase {
         assertEquals(parseCommand("workspace --auto-back-and-forth next").errorOrNil, "--auto-back-and-forth is incompatible with (next|prev)")
         testParseCommandSucc("workspace next --wrap-around", WorkspaceCmdArgs(target: .relative(.next), wrapAround: true))
         assertEquals(parseCommand("workspace --stdin foo").errorOrNil, "--stdin requires using (next|prev) argument")
+        assertEquals(parseCommand("workspace --no-stdin foo").errorOrNil, "--no-stdin requires using (next|prev) argument")
+        testParseCommandSucc("workspace --no-stdin next", WorkspaceCmdArgs(target: .relative(.next), noStdin: true))
     }
 }

--- a/Sources/AppBundleTests/testUtil.swift
+++ b/Sources/AppBundleTests/testUtil.swift
@@ -70,12 +70,12 @@ func testParseCommandFail(_ command: String, msg expected: String) {
 }
 
 extension WorkspaceCmdArgs {
-    init(target: WorkspaceTarget, autoBackAndForth: Bool? = nil, wrapAround: Bool? = nil, noStdin: Bool? = nil) {
+    init(target: WorkspaceTarget, autoBackAndForth: Bool? = nil, wrapAround: Bool? = nil, stdin: Bool? = nil) {
         self = WorkspaceCmdArgs(rawArgs: [])
         self.target = .initialized(target)
         self._autoBackAndForth = autoBackAndForth
         self._wrapAround = wrapAround
-        self._noStdin = noStdin
+        self._stdin = stdin
     }
 }
 

--- a/Sources/AppBundleTests/testUtil.swift
+++ b/Sources/AppBundleTests/testUtil.swift
@@ -70,11 +70,12 @@ func testParseCommandFail(_ command: String, msg expected: String) {
 }
 
 extension WorkspaceCmdArgs {
-    init(target: WorkspaceTarget, autoBackAndForth: Bool? = nil, wrapAround: Bool? = nil) {
+    init(target: WorkspaceTarget, autoBackAndForth: Bool? = nil, wrapAround: Bool? = nil, noStdin: Bool? = nil) {
         self = WorkspaceCmdArgs(rawArgs: [])
         self.target = .initialized(target)
         self._autoBackAndForth = autoBackAndForth
         self._wrapAround = wrapAround
+        self._noStdin = noStdin
     }
 }
 

--- a/Sources/Cli/_main.swift
+++ b/Sources/Cli/_main.swift
@@ -26,11 +26,11 @@ struct Main {
         }
 
         let isVersion: Bool = args.first == "--version" || args.first == "-v"
-
+        var parsedArgs: (any CmdArgs)! = nil
         if !isVersion {
             switch parseCmdArgs(args) {
-                case .cmd:
-                    break
+                case .cmd(let _parsedArgs):
+                    parsedArgs = _parsedArgs
                 case .help(let help):
                     print(help)
                     exit(0)
@@ -55,7 +55,17 @@ struct Main {
         }
 
         var stdin = ""
-        if hasStdin() {
+        if let workspaceCmdArgs = parsedArgs as? WorkspaceCmdArgs, hasStdin() {
+            if workspaceCmdArgs._stdin == nil {
+                cliError(
+                    """
+                    ERROR: Implicit stdin is detected (stdin is not TTY). Implicit stdin was forbidden in AeroSpace v0.20.0.
+                    1. Please supply '--stdin' flag to make stdin explicit and preserve old AeroSpace behavior
+                    2. You can also use '--no-stdin' flag to behave as if no stdin was supplied
+                    Breaking change issue: https://github.com/nikitabobko/AeroSpace/issues/1683
+                    """,
+                )
+            }
             var index = 0
             while let line = readLine(strippingNewline: false) {
                 stdin += line

--- a/Sources/Common/cmdArgs/ArgParser.swift
+++ b/Sources/Common/cmdArgs/ArgParser.swift
@@ -84,6 +84,10 @@ public func optionalTrueBoolFlag<T: ConvenienceCopyable>(_ keyPath: SendableWrit
     ArgParser(keyPath) { _, _ in .success(true) }
 }
 
+public func optionalFalseBoolFlag<T: ConvenienceCopyable>(_ KeyPath: SendableWritableKeyPath<T, Bool?>) -> ArgParser<T, Bool?> {
+    ArgParser(KeyPath) { _, _ in .success(false) }
+}
+
 // todo reuse in config
 public func parseEnum<T: RawRepresentable>(_ raw: String, _ _: T.Type) -> Parsed<T> where T.RawValue == String, T: CaseIterable {
     T(rawValue: raw).orFailure("Can't parse '\(raw)'.\nPossible values: \(T.unionLiteral)")

--- a/Sources/Common/cmdArgs/impl/WorkspaceCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/WorkspaceCmdArgs.swift
@@ -9,8 +9,8 @@ public struct WorkspaceCmdArgs: CmdArgs {
             "--auto-back-and-forth": optionalTrueBoolFlag(\._autoBackAndForth),
             "--wrap-around": optionalTrueBoolFlag(\._wrapAround),
             "--fail-if-noop": trueBoolFlag(\.failIfNoop),
-            "--stdin": trueBoolFlag(\.stdin),
-            "--no-stdin": optionalTrueBoolFlag(\._noStdin),
+            "--stdin": optionalTrueBoolFlag(\._stdin),
+            "--no-stdin": optionalFalseBoolFlag(\._stdin),
         ],
         arguments: [newArgParser(\.target, parseWorkspaceTarget, mandatoryArgPlaceholder: workspaceTargetPlaceholder)],
         conflictingOptions: [
@@ -24,8 +24,7 @@ public struct WorkspaceCmdArgs: CmdArgs {
     public var _autoBackAndForth: Bool?
     public var failIfNoop: Bool = false
     public var _wrapAround: Bool?
-    public var stdin: Bool = false
-    public var _noStdin: Bool?
+    public var _stdin: Bool? = nil
 }
 
 public func parseWorkspaceCmdArgs(_ args: [String]) -> ParsedCmd<WorkspaceCmdArgs> {
@@ -34,13 +33,13 @@ public func parseWorkspaceCmdArgs(_ args: [String]) -> ParsedCmd<WorkspaceCmdArg
         .filterNot("--auto-back-and-forth is incompatible with \(NextPrev.unionLiteral)") { $0._autoBackAndForth != nil && $0.target.val.isRelatve }
         .filterNot("--fail-if-noop is incompatible with \(NextPrev.unionLiteral)") { $0.failIfNoop && $0.target.val.isRelatve }
         .filterNot("--fail-if-noop is incompatible with --auto-back-and-forth") { $0.autoBackAndForth && $0.failIfNoop }
-        .filterNot("--stdin requires using \(NextPrev.unionLiteral) argument") { $0.stdin && !$0.target.val.isRelatve }
-        .filterNot("--no-stdin requires using \(NextPrev.unionLiteral) argument") { $0._noStdin != nil && !$0.target.val.isRelatve }
+        .filterNot("--stdin and --no-stdin require using \(NextPrev.unionLiteral) argument") { $0._stdin != nil && !$0.target.val.isRelatve }
 }
 
 extension WorkspaceCmdArgs {
     public var wrapAround: Bool { _wrapAround ?? false }
     public var autoBackAndForth: Bool { _autoBackAndForth ?? false }
+    public var stdin: Bool { _stdin ?? false }
 }
 
 public enum WorkspaceTarget: Equatable, Sendable {

--- a/Sources/Common/cmdArgs/impl/WorkspaceCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/WorkspaceCmdArgs.swift
@@ -9,6 +9,7 @@ public struct WorkspaceCmdArgs: CmdArgs {
             "--auto-back-and-forth": optionalTrueBoolFlag(\._autoBackAndForth),
             "--wrap-around": optionalTrueBoolFlag(\._wrapAround),
             "--fail-if-noop": trueBoolFlag(\.failIfNoop),
+            "--stdin": trueBoolFlag(\.stdin),
         ],
         arguments: [newArgParser(\.target, parseWorkspaceTarget, mandatoryArgPlaceholder: workspaceTargetPlaceholder)],
     )
@@ -19,6 +20,7 @@ public struct WorkspaceCmdArgs: CmdArgs {
     public var _autoBackAndForth: Bool?
     public var failIfNoop: Bool = false
     public var _wrapAround: Bool?
+    public var stdin: Bool = false
 }
 
 public func parseWorkspaceCmdArgs(_ args: [String]) -> ParsedCmd<WorkspaceCmdArgs> {
@@ -27,6 +29,7 @@ public func parseWorkspaceCmdArgs(_ args: [String]) -> ParsedCmd<WorkspaceCmdArg
         .filterNot("--auto-back-and-forth is incompatible with \(NextPrev.unionLiteral)") { $0._autoBackAndForth != nil && $0.target.val.isRelatve }
         .filterNot("--fail-if-noop is incompatible with \(NextPrev.unionLiteral)") { $0.failIfNoop && $0.target.val.isRelatve }
         .filterNot("--fail-if-noop is incompatible with --auto-back-and-forth") { $0.autoBackAndForth && $0.failIfNoop }
+        .filterNot("--stdin requires using \(NextPrev.unionLiteral) argument") { $0.stdin && !$0.target.val.isRelatve }
 }
 
 extension WorkspaceCmdArgs {

--- a/Sources/Common/cmdArgs/impl/WorkspaceCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/WorkspaceCmdArgs.swift
@@ -10,8 +10,12 @@ public struct WorkspaceCmdArgs: CmdArgs {
             "--wrap-around": optionalTrueBoolFlag(\._wrapAround),
             "--fail-if-noop": trueBoolFlag(\.failIfNoop),
             "--stdin": trueBoolFlag(\.stdin),
+            "--no-stdin": optionalTrueBoolFlag(\._noStdin),
         ],
         arguments: [newArgParser(\.target, parseWorkspaceTarget, mandatoryArgPlaceholder: workspaceTargetPlaceholder)],
+        conflictingOptions: [
+            ["--stdin", "--no-stdin"],
+        ],
     )
 
     /*conforms*/ public var windowId: UInt32?
@@ -21,6 +25,7 @@ public struct WorkspaceCmdArgs: CmdArgs {
     public var failIfNoop: Bool = false
     public var _wrapAround: Bool?
     public var stdin: Bool = false
+    public var _noStdin: Bool?
 }
 
 public func parseWorkspaceCmdArgs(_ args: [String]) -> ParsedCmd<WorkspaceCmdArgs> {
@@ -30,6 +35,7 @@ public func parseWorkspaceCmdArgs(_ args: [String]) -> ParsedCmd<WorkspaceCmdArg
         .filterNot("--fail-if-noop is incompatible with \(NextPrev.unionLiteral)") { $0.failIfNoop && $0.target.val.isRelatve }
         .filterNot("--fail-if-noop is incompatible with --auto-back-and-forth") { $0.autoBackAndForth && $0.failIfNoop }
         .filterNot("--stdin requires using \(NextPrev.unionLiteral) argument") { $0.stdin && !$0.target.val.isRelatve }
+        .filterNot("--no-stdin requires using \(NextPrev.unionLiteral) argument") { $0._noStdin != nil && !$0.target.val.isRelatve }
 }
 
 extension WorkspaceCmdArgs {

--- a/Sources/Common/cmdHelpGenerated.swift
+++ b/Sources/Common/cmdHelpGenerated.swift
@@ -149,5 +149,5 @@ let workspace_back_and_forth_help_generated = """
     """
 let workspace_help_generated = """
     USAGE: workspace [-h|--help] [--auto-back-and-forth] [--fail-if-noop] <workspace-name>
-       OR: workspace [-h|--help] [--wrap-around] (next|prev)
+       OR: workspace [-h|--help] [--wrap-around] [--stdin] (next|prev)
     """

--- a/Sources/Common/cmdHelpGenerated.swift
+++ b/Sources/Common/cmdHelpGenerated.swift
@@ -149,5 +149,5 @@ let workspace_back_and_forth_help_generated = """
     """
 let workspace_help_generated = """
     USAGE: workspace [-h|--help] [--auto-back-and-forth] [--fail-if-noop] <workspace-name>
-       OR: workspace [-h|--help] [--wrap-around] [--stdin] (next|prev)
+       OR: workspace [-h|--help] [--wrap-around] [--stdin] [--no-stdin] (next|prev)
     """

--- a/docs/aerospace-workspace.adoc
+++ b/docs/aerospace-workspace.adoc
@@ -10,7 +10,7 @@ include::util/man-attributes.adoc[]
 [verse]
 // tag::synopsis[]
 aerospace workspace [-h|--help] [--auto-back-and-forth] [--fail-if-noop] <workspace-name>
-aerospace workspace [-h|--help] [--wrap-around] [--stdin] (next|prev)
+aerospace workspace [-h|--help] [--wrap-around] [--stdin] [--no-stdin] (next|prev)
 
 // end::synopsis[]
 
@@ -45,6 +45,11 @@ Incompatible with `--auto-back-and-forth`
 
 --stdin::
 Read the list of workspaces from stdin
+Incompatible with `--no-stdin`
+
+--no-stdin::
+Ignore the list of workspaces from stdin, even if provided
+Incompatible with `--stdin`
 
 // =========================================================== Examples
 include::util/conditional-examples-header.adoc[]

--- a/docs/aerospace-workspace.adoc
+++ b/docs/aerospace-workspace.adoc
@@ -10,7 +10,7 @@ include::util/man-attributes.adoc[]
 [verse]
 // tag::synopsis[]
 aerospace workspace [-h|--help] [--auto-back-and-forth] [--fail-if-noop] <workspace-name>
-aerospace workspace [-h|--help] [--wrap-around] (next|prev)
+aerospace workspace [-h|--help] [--wrap-around] [--stdin] (next|prev)
 
 // end::synopsis[]
 
@@ -26,7 +26,7 @@ aerospace workspace [-h|--help] [--wrap-around] (next|prev)
 
 Focuses next or previous workspace in *the list*.
 
-* If stdin is not TTY and stdin contains non whitespace characters then *the list* is taken from stdin
+* If `--stdin` is specified then *the list* is taken from stdin
 * Otherwise, *the list* is defined as all workspaces on focused monitor in alphabetical order
 
 // =========================================================== Options
@@ -42,6 +42,9 @@ Incompatible with `--fail-if-noop`
 --fail-if-noop::
 Exit with non-zero exit code if switch to the already focused workspace
 Incompatible with `--auto-back-and-forth`
+
+--stdin::
+Read the list of workspaces from stdin
 
 // =========================================================== Examples
 include::util/conditional-examples-header.adoc[]


### PR DESCRIPTION
Closes #1683 

This PR has several changes to how the `workspace (prev|next)` command handles stdin.

1. Detect stdin explicitly
   - Replaced the previous reliance on `isatty(STDIN_FILENO)` with a poll-based check to directly detect whether `STDIN_FILENO` has readable data.
   - This ensures that input from pipes or redirection is correctly recognized.
2. Add `--stdin` flag for `workspace (prev|next)` command
   - When this flag is specified, the command will accept input from stdin.
3. Add `--no-stdin` flag for `workspace (prev|next)` command
   - When this flag is specified, CLI ignores stdin input when it exists.

If there is stdin input but `--stdin` flag or `--no-stdin` flag is not specified, a warning will be displayed.

(The commit messages contains the same explanation.)

## PR checklist

- [x] Explain your changes in the relevant commit messages rather than in the PR description. The PR description must not contain more information than the commit messages (except for images and other media).
- [x] Each commit must explain what/why/how in its description. https://cbea.ms/git-commit/
- [x] Don't forget to link the appropriate issues/discussions in commit messages (if applicable).
- [x] Each commit must be an atomic change (a PR may contain several commits). Don't introduce new functional changes together with refactorings in the same commit.
- [x] The GitHub Actions CI must pass (you can fix failures after submitting a PR).

Failure to follow the checklist with no apparent reasons will result in silent PR rejection.
