### PR TITLE
Automatic key-mapping preset based on currently selected keyboard layout

### DIFF
--- a/Sources/AppBundle/config/KeycodeToString.swift
+++ b/Sources/AppBundle/config/KeycodeToString.swift
@@ -1,0 +1,113 @@
+import Carbon
+import Foundation
+
+// This file is a Swift translation of the Objective-C code provided by the user.
+// It translates a keycode to a string, taking the current keyboard layout into account.
+func keycodeToString(_ keyCode: UInt16) -> String? {
+    // Handle special keys first.
+    switch Int(keyCode) {
+        case kVK_F1: return "f1"
+        case kVK_F2: return "f2"
+        case kVK_F3: return "f3"
+        case kVK_F4: return "f4"
+        case kVK_F5: return "f5"
+        case kVK_F6: return "f6"
+        case kVK_F7: return "f7"
+        case kVK_F8: return "f8"
+        case kVK_F9: return "f9"
+        case kVK_F10: return "f10"
+        case kVK_F11: return "f11"
+        case kVK_F12: return "f12"
+        case kVK_F13: return "f13"
+        case kVK_F14: return "f14"
+        case kVK_F15: return "f15"
+        case kVK_F16: return "f16"
+        case kVK_F17: return "f17"
+        case kVK_F18: return "f18"
+        case kVK_F19: return "f19"
+        case kVK_Space: return "space"
+        case kVK_Escape: return "esc"
+        case kVK_Delete: return "backspace"
+        case kVK_ForwardDelete: return "forwardDelete"
+        case kVK_LeftArrow: return "left"
+        case kVK_RightArrow: return "right"
+        case kVK_UpArrow: return "up"
+        case kVK_DownArrow: return "down"
+        case kVK_Help: return "help"
+        case kVK_Home: return "home"
+        case kVK_End: return "end"
+        case kVK_PageUp: return "pageUp"
+        case kVK_PageDown: return "pageDown"
+        case kVK_Tab: return "tab"
+        case kVK_Return: return "enter"
+
+        // Keypad
+        case kVK_ANSI_Keypad0: return "keypad0"
+        case kVK_ANSI_Keypad1: return "keypad1"
+        case kVK_ANSI_Keypad2: return "keypad2"
+        case kVK_ANSI_Keypad3: return "keypad3"
+        case kVK_ANSI_Keypad4: return "keypad4"
+        case kVK_ANSI_Keypad5: return "keypad5"
+        case kVK_ANSI_Keypad6: return "keypad6"
+        case kVK_ANSI_Keypad7: return "keypad7"
+        case kVK_ANSI_Keypad8: return "keypad8"
+        case kVK_ANSI_Keypad9: return "keypad9"
+        case kVK_ANSI_KeypadDecimal: return "keypadDecimalMark"
+        case kVK_ANSI_KeypadMultiply: return "keypadMultiply"
+        case kVK_ANSI_KeypadPlus: return "keypadPlus"
+        case kVK_ANSI_KeypadClear: return "keypadClear"
+        case kVK_ANSI_KeypadDivide: return "keypadDivide"
+        case kVK_ANSI_KeypadEnter: return "keypadEnter"
+        case kVK_ANSI_KeypadMinus: return "keypadMinus"
+        case kVK_ANSI_KeypadEquals: return "keypadEqual"
+        default: break
+    }
+
+    var currentKeyboard = TISCopyCurrentKeyboardInputSource().takeRetainedValue()
+    var rawLayoutData = TISGetInputSourceProperty(currentKeyboard, kTISPropertyUnicodeKeyLayoutData)
+
+    if rawLayoutData == nil {
+        currentKeyboard = TISCopyCurrentASCIICapableKeyboardLayoutInputSource().takeUnretainedValue()
+        rawLayoutData = TISGetInputSourceProperty(currentKeyboard, kTISPropertyUnicodeKeyLayoutData)
+    }
+
+    // Get the layout
+    let layoutData = unsafeBitCast(rawLayoutData, to: CFData.self)
+    let layout: UnsafePointer<UCKeyboardLayout> = unsafeBitCast(CFDataGetBytePtr(layoutData), to: UnsafePointer<UCKeyboardLayout>.self)
+
+    var deadKeyState: UInt32 = 0
+    var chars = [UniChar](repeating: 0, count: 16)
+    var actualLength = 0
+
+    let error = UCKeyTranslate(
+        layout,
+        keyCode,
+        UInt16(kUCKeyActionDisplay),
+        0, // No modifiers
+        UInt32(LMGetKbdType()),
+        UInt32(kUCKeyTranslateNoDeadKeysMask),
+        &deadKeyState,
+        chars.count,
+        &actualLength,
+        &chars,
+    )
+
+    guard error == noErr else { return nil }
+
+    let str = String(utf16CodeUnits: chars, count: actualLength).lowercased()
+    return switch str {
+        case ".": "period"
+        case ",": "comma"
+        case "[": "leftSquareBracket"
+        case "]": "rightSquareBracket"
+        case "/": "slash"
+        case "\\": "backslash"
+        case "-": "minus"
+        case "=": "equal"
+        case "'": "quote"
+        case "`": "backtick"
+        case ";": "semicolon"
+        case "§": "sectionSign"
+        default: str
+    }
+}

--- a/Sources/AppBundle/config/keysMap.swift
+++ b/Sources/AppBundle/config/keysMap.swift
@@ -45,6 +45,7 @@ private let slash = "slash"
 
 func getKeysPreset(_ layout: KeyMapping.Preset) -> [String: Key] {
     return switch layout {
+        case .automatic: automaticMap()
         case .qwerty: keyNotationToKeyCode
         case .dvorak: dvorakMap
         case .colemak: colemakMap
@@ -163,6 +164,20 @@ let keyNotationToKeyCode: [String: Key] = [
     "up": .upArrow,
     "right": .rightArrow,
 ]
+
+private func automaticMap() -> [String: Key] {
+    var map = [String: Key]()
+
+    for keyCode in 0 ..< 128 {
+        if let str = keycodeToString(UInt16(keyCode)),
+           let key = Key(carbonKeyCode: UInt32(keyCode))
+        {
+            map[str.lowercased()] = key
+        }
+    }
+
+    return map
+}
 
 private let dvorakMap: [String: Key] = keyNotationToKeyCode + [
     leftSquareBracket: .minus,

--- a/Sources/AppBundle/config/parseKeyMapping.swift
+++ b/Sources/AppBundle/config/parseKeyMapping.swift
@@ -9,7 +9,7 @@ private let keyMappingParser: [String: any ParserProtocol<KeyMapping>] = [
 
 struct KeyMapping: ConvenienceCopyable, Equatable, Sendable {
     enum Preset: String, CaseIterable, Sendable {
-        case qwerty, dvorak, colemak
+        case automatic, qwerty, dvorak, colemak
     }
 
     init(
@@ -20,7 +20,7 @@ struct KeyMapping: ConvenienceCopyable, Equatable, Sendable {
         self.rawKeyNotationToKeyCode = rawKeyNotationToKeyCode
     }
 
-    fileprivate var preset: Preset = .qwerty
+    var preset: Preset = .qwerty
     fileprivate var rawKeyNotationToKeyCode: [String: Key] = [:]
 
     func resolve() -> [String: Key] {

--- a/Sources/AppBundle/initAppBundle.swift
+++ b/Sources/AppBundle/initAppBundle.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Common
 import Foundation
+import Carbon
 
 @MainActor public func initAppBundle() {
     initTerminationHandler()
@@ -25,6 +26,19 @@ import Foundation
         try await runSession(.startup, .checkServerIsEnabledOrDie) {
             smartLayoutAtStartup()
             _ = try await config.afterStartupCommand.runCmdSeq(.defaultEnv, .emptyStdin)
+        }
+    }
+
+    DistributedNotificationCenter.default.addObserver(
+        forName: .init(kTISNotifySelectedKeyboardInputSourceChanged as String),
+        object: nil,
+        queue: .main,
+    ) { _ in
+        Task { @MainActor in
+            guard config.keyMapping.preset == .automatic else {
+                return
+            }
+            _ = reloadConfig()
         }
     }
 }

--- a/docs/config-examples/default-config.toml
+++ b/docs/config-examples/default-config.toml
@@ -37,10 +37,10 @@ on-focused-monitor-changed = ['move-mouse monitor-lazy-center']
 # Also see: https://nikitabobko.github.io/AeroSpace/goodies#disable-hide-app
 automatically-unhide-macos-hidden-apps = false
 
-# Possible values: (qwerty|dvorak|colemak)
+# Possible values: (automatic|qwerty|dvorak|colemak)
 # See https://nikitabobko.github.io/AeroSpace/guide#key-mapping
 [key-mapping]
-    preset = 'qwerty'
+    preset = 'automatic'
 
 # Gaps between windows (inner-*) and between monitor edges (outer-*).
 # Possible values:

--- a/docs/guide.adoc
+++ b/docs/guide.adoc
@@ -166,6 +166,7 @@ For the list of available commands see: xref:commands.adoc[]
 === Keyboard layouts and key mapping
 
 By default, key bindings in the config are perceived as `qwerty` layout.
+To have them be perceived based on your currently selected keyboard layout, you can set `key-mapping.preset` to `automatic`.
 
 If you use different layout, different alphabet, or you just want to have a fancy alias for the existing key, you can use `key-mapping.key-notation-to-key-code`.
 


### PR DESCRIPTION
By default, all key bindings in the AeroSpace config get interpreted based on a qwerty layout. When switching keyboard layouts, this means that AeroSpace's keyboard shortcuts don't adjust based on the new location of the key as defined by the keyboard layout.

This usually isn't a big problem, as `key-mapping.key-notation-to-key-code` can be used to adjust the layout. However, when working with a custom keyboard that is remapped on the firmware level (i.e. anything running ZMK), in conjuncion with a keyboard that is remapped in software (i.e. builtin MacBook keyboard), this results in significant issues.

For example, let's consider someone using the Dvorak layout with the `dvorak` preset configured in AeroSpace. Let's assume they have some command bound to `alt-o`. Due to the `key-notation-to-key-code` mapping, AeroSpace starts listening for events concerning the key code 1 (which on qwerty corresponds to 's').

When they press `alt-o` on the builtin MacBook keyboard, they press the physical `s` key, resulting in the key code 1.
However, when they press `alt-o` on their other keyboard that is remapped to Dvorak in the keyboard firmware, the keyboard sends key code 31 (which on qwerty corresponds to 'o') instead. Thus AeroSpace won't run the command.



## PR checklist

- [x] Explain your changes in the relevant commit messages rather than in the PR description. The PR description must not contain more information than the commit messages (except for images and other media).
- [x] Each commit must explain what/why/how in its description. https://cbea.ms/git-commit/
- [x] Don't forget to link the appropriate issues/discussions in commit messages (if applicable).
- [x] Each commit must be an atomic change (a PR may contain several commits). Don't introduce new functional changes together with refactorings in the same commit.
- [x] The GitHub Actions CI must pass (you can fix failures after submitting a PR).

Failure to follow the checklist with no apparent reasons will result in silent PR rejection.
