### PR TITLE
Implement #1687 - Add %{all} format variables to lists queries

### DIFF
--- a/Sources/AppBundleTests/command/ListAppsTest.swift
+++ b/Sources/AppBundleTests/command/ListAppsTest.swift
@@ -9,5 +9,9 @@ final class ListAppsTest: XCTestCase {
         assertNotNil(parseCommand("list-apps --format %{app-bundle-id}").cmdOrNil)
         assertNotNil(parseCommand("list-apps --count").cmdOrNil)
         assertEquals(parseCommand("list-apps --format %{app-bundle-id} --count").errorOrNil, "ERROR: Conflicting options: --count, --format")
-    }
+        assertEquals(parseCommand("list-apps --format '%{all}'").errorOrNil, "'%{all}' format option requires --json flag")
+        assertNil(parseCommand("list-apps --format '%{all}' --json").errorOrNil)
+        assertEquals(parseCommand("list-apps --format '%{all} %{app-name}'").errorOrNil, "'%{all}' format option must be used alone and cannot be combined with other variables")
+        assertEquals(parseCommand("list-apps --format '%{app-bundle-id} %{all}'").errorOrNil, "'%{all}' format option must be used alone and cannot be combined with other variables")
+        assertNil(parseCommand("list-apps --format ' %{all} ' --json").errorOrNil) }
 }

--- a/Sources/AppBundleTests/command/ListAppsTest.swift
+++ b/Sources/AppBundleTests/command/ListAppsTest.swift
@@ -13,5 +13,6 @@ final class ListAppsTest: XCTestCase {
         assertNil(parseCommand("list-apps --format '%{all}' --json").errorOrNil)
         assertEquals(parseCommand("list-apps --format '%{all} %{app-name}'").errorOrNil, "'%{all}' format option must be used alone and cannot be combined with other variables")
         assertEquals(parseCommand("list-apps --format '%{app-bundle-id} %{all}'").errorOrNil, "'%{all}' format option must be used alone and cannot be combined with other variables")
-        assertNil(parseCommand("list-apps --format ' %{all} ' --json").errorOrNil) }
+        assertNil(parseCommand("list-apps --format ' %{all} ' --json").errorOrNil)
+    }
 }

--- a/Sources/AppBundleTests/command/ListMonitorsTest.swift
+++ b/Sources/AppBundleTests/command/ListMonitorsTest.swift
@@ -12,5 +12,6 @@ final class ListMonitorsTest: XCTestCase {
         assertNil(parseCommand("list-monitors --format '%{all}' --json").errorOrNil)
         assertEquals(parseCommand("list-monitors --format '%{all} %{monitor-id}'").errorOrNil, "'%{all}' format option must be used alone and cannot be combined with other variables")
         assertEquals(parseCommand("list-monitors --format '%{monitor-name} %{all}'").errorOrNil, "'%{all}' format option must be used alone and cannot be combined with other variables")
-        assertNil(parseCommand("list-monitors --format ' %{all} ' --json").errorOrNil) }
+        assertNil(parseCommand("list-monitors --format ' %{all} ' --json").errorOrNil)
+    }
 }

--- a/Sources/AppBundleTests/command/ListMonitorsTest.swift
+++ b/Sources/AppBundleTests/command/ListMonitorsTest.swift
@@ -8,5 +8,9 @@ final class ListMonitorsTest: XCTestCase {
         testParseCommandSucc("list-monitors --focused", ListMonitorsCmdArgs(rawArgs: []).copy(\.focused, true))
         testParseCommandSucc("list-monitors --count", ListMonitorsCmdArgs(rawArgs: []).copy(\.outputOnlyCount, true))
         assertEquals(parseCommand("list-monitors --format %{monitor-id} --count").errorOrNil, "ERROR: Conflicting options: --count, --format")
-    }
+        assertEquals(parseCommand("list-monitors --format '%{all}'").errorOrNil, "'%{all}' format option requires --json flag")
+        assertNil(parseCommand("list-monitors --format '%{all}' --json").errorOrNil)
+        assertEquals(parseCommand("list-monitors --format '%{all} %{monitor-id}'").errorOrNil, "'%{all}' format option must be used alone and cannot be combined with other variables")
+        assertEquals(parseCommand("list-monitors --format '%{monitor-name} %{all}'").errorOrNil, "'%{all}' format option must be used alone and cannot be combined with other variables")
+        assertNil(parseCommand("list-monitors --format ' %{all} ' --json").errorOrNil) }
 }

--- a/Sources/AppBundleTests/command/ListWindowsTest.swift
+++ b/Sources/AppBundleTests/command/ListWindowsTest.swift
@@ -73,4 +73,20 @@ final class ListWindowsTest: XCTestCase {
             assertEquals(windows.format([.interVar("window-id"), .interVar("right-padding"), .literal(" | "), .interVar("window-title")]), .success(["2  | title1", "10 | title2"]))
         }
     }
+
+    func testAllFormatVariable() {
+        // Test that %{all} without --json fails at parsing level
+        assertEquals(parseCommand("list-windows --all --format '%{all}'").errorOrNil, "'%{all}' format option requires --json flag")
+
+        // Test that %{all} with JSON succeeds at parsing level
+        assertNil(parseCommand("list-windows --all --format '%{all}' --json").errorOrNil)
+
+        // Test that %{all} mixed with other variables fails
+        assertEquals(parseCommand("list-windows --all --json --format '%{all} %{window-id}'").errorOrNil, "'%{all}' format option must be used alone and cannot be combined with other variables")
+        assertEquals(parseCommand("list-windows --all --json --format '%{window-title} %{all}'").errorOrNil, "'%{all}' format option must be used alone and cannot be combined with other variables")
+        assertEquals(parseCommand("list-windows --all --json --format '%{all}     %{window-title}'").errorOrNil, "'%{all}' format option must be used alone and cannot be combined with other variables")
+
+        // Test that %{all} with only spaces is allowed
+        assertNil(parseCommand("list-windows --all --format ' %{all} ' --json").errorOrNil)
+    }
 }

--- a/Sources/AppBundleTests/command/ListWorkspacesTest.swift
+++ b/Sources/AppBundleTests/command/ListWorkspacesTest.swift
@@ -16,5 +16,9 @@ final class ListWorkspacesTest: XCTestCase {
         assertEquals(parseCommand("list-workspaces --all --format %{workspace} --count").errorOrNil, "ERROR: Conflicting options: --count, --format")
         assertEquals(parseCommand("list-workspaces --empty").errorOrNil, "Mandatory option is not specified (--all|--focused|--monitor)")
         assertEquals(parseCommand("list-workspaces --all --focused --monitor mouse").errorOrNil, "ERROR: Conflicting options: --all, --focused, --monitor")
-    }
+        assertEquals(parseCommand("list-workspaces --all --format '%{all}'").errorOrNil, "'%{all}' format option requires --json flag")
+        assertNotNil(parseCommand("list-workspaces --all --format '%{all}' --json").cmdOrNil)
+        assertEquals(parseCommand("list-workspaces --all --format '%{all} %{workspace}'").errorOrNil, "'%{all}' format option must be used alone and cannot be combined with other variables")
+        assertEquals(parseCommand("list-workspaces --all --format '%{is-focused} %{all}'").errorOrNil, "'%{all}' format option must be used alone and cannot be combined with other variables")
+        assertNotNil(parseCommand("list-workspaces --all --format ' %{all} ' --json").cmdOrNil) }
 }

--- a/Sources/AppBundleTests/command/ListWorkspacesTest.swift
+++ b/Sources/AppBundleTests/command/ListWorkspacesTest.swift
@@ -20,5 +20,6 @@ final class ListWorkspacesTest: XCTestCase {
         assertNotNil(parseCommand("list-workspaces --all --format '%{all}' --json").cmdOrNil)
         assertEquals(parseCommand("list-workspaces --all --format '%{all} %{workspace}'").errorOrNil, "'%{all}' format option must be used alone and cannot be combined with other variables")
         assertEquals(parseCommand("list-workspaces --all --format '%{is-focused} %{all}'").errorOrNil, "'%{all}' format option must be used alone and cannot be combined with other variables")
-        assertNotNil(parseCommand("list-workspaces --all --format ' %{all} ' --json").cmdOrNil) }
+        assertNotNil(parseCommand("list-workspaces --all --format ' %{all} ' --json").cmdOrNil)
+    }
 }

--- a/Sources/Common/cmdArgs/impl/ListAppsCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/ListAppsCmdArgs.swift
@@ -28,19 +28,31 @@ public struct ListAppsCmdArgs: CmdArgs {
 
 extension ListAppsCmdArgs {
     public var format: [StringInterToken] {
-        _format.isEmpty
-            ? [
+        if _format.isEmpty {
+            return [
                 .interVar("app-pid"), .interVar("right-padding"), .literal(" | "),
                 .interVar("app-bundle-id"), .interVar("right-padding"), .literal(" | "),
                 .interVar("app-name"),
             ]
-            : _format
+        }
+        if _format.contains(.interVar(PlainInterVar.all.rawValue)) {
+            return AeroObjKind.app.getFormatWithAllVariable()
+        }
+        return _format
     }
 }
 
 public func parseListAppsCmdArgs(_ args: StrArrSlice) -> ParsedCmd<ListAppsCmdArgs> {
     parseSpecificCmdArgs(ListAppsCmdArgs(rawArgs: args), args)
-        .flatMap { if $0.json, let msg = getErrorIfFormatIsIncompatibleWithJson($0._format) { .failure(msg) } else { .cmd($0) } }
+        .flatMap { parsed in
+            if parsed.json, let msg = getErrorIfFormatIsIncompatibleWithJson(parsed._format) {
+                return .failure(msg)
+            }
+            if let msg = getErrorIfAllFormatVariableIsInvalid(json: parsed.json, format: parsed._format) {
+                return .failure(msg)
+            }
+            return .cmd(parsed)
+        }
 }
 
 func getErrorIfFormatIsIncompatibleWithJson(_ format: [StringInterToken]) -> String? {

--- a/Sources/Common/cmdArgs/impl/ListMonitorsCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/ListMonitorsCmdArgs.swift
@@ -30,16 +30,28 @@ public struct ListMonitorsCmdArgs: CmdArgs {
 
 extension ListMonitorsCmdArgs {
     public var format: [StringInterToken] {
-        _format.isEmpty
-            ? [
+        if _format.isEmpty {
+            return [
                 .interVar("monitor-id"), .interVar("right-padding"), .literal(" | "),
                 .interVar("monitor-name"),
             ]
-            : _format
+        }
+        if _format.contains(.interVar(PlainInterVar.all.rawValue)) {
+            return AeroObjKind.monitor.getFormatWithAllVariable()
+        }
+        return _format
     }
 }
 
 public func parseListMonitorsCmdArgs(_ args: StrArrSlice) -> ParsedCmd<ListMonitorsCmdArgs> {
     parseSpecificCmdArgs(ListMonitorsCmdArgs(rawArgs: args), args)
-        .flatMap { if $0.json, let msg = getErrorIfFormatIsIncompatibleWithJson($0._format) { .failure(msg) } else { .cmd($0) } }
+        .flatMap { parsed in
+            if parsed.json, let msg = getErrorIfFormatIsIncompatibleWithJson(parsed._format) {
+                return .failure(msg)
+            }
+            if let msg = getErrorIfAllFormatVariableIsInvalid(json: parsed.json, format: parsed._format) {
+                return .failure(msg)
+            }
+            return .cmd(parsed)
+        }
 }

--- a/Sources/Common/cmdArgs/impl/ListWindowsCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/ListWindowsCmdArgs.swift
@@ -212,8 +212,6 @@ public enum AeroObjKind: CaseIterable, Sendable {
     case window, workspace, app, monitor
 
     public func getFormatWithAllVariable() -> [StringInterToken] {
-
-
         return getAvailableInterVars(for: self)
             .map(StringInterToken.interVar)
             .filter {

--- a/docs/aerospace-list-apps.adoc
+++ b/docs/aerospace-list-apps.adoc
@@ -60,6 +60,7 @@ The following variables can be used inside `<output-format>`:
 %{right-padding}:: A special variable which expands with a minimum number of spaces required to form a right padding in the appropriate column
 %{newline}:: Unicode U+000A newline symbol `\n`
 %{tab}:: Unicode U+0009 tab symbol `\t`
+%{all}:: Includes all available variables. Can only be used with `--json` flag
 
 // end::body[]
 

--- a/docs/aerospace-list-monitors.adoc
+++ b/docs/aerospace-list-monitors.adoc
@@ -65,6 +65,7 @@ The following variables can be used inside `<output-format>`:
 %{right-padding}:: A special variable which expands with a minimum number of spaces required to form a right padding in the appropriate column
 %{newline}:: Unicode U+000A newline symbol `\n`
 %{tab}:: Unicode U+0009 tab symbol `\t`
+%{all}:: Includes all available variables. Can only be used with `--json` flag
 
 // end::body[]
 

--- a/docs/aerospace-list-windows.adoc
+++ b/docs/aerospace-list-windows.adoc
@@ -101,6 +101,7 @@ The following variables can be used inside `<output-format>`:
 %{right-padding}:: A special variable which expands with a minimum number of spaces required to form a right padding in the appropriate column
 %{newline}:: Unicode U+000A newline symbol `\n`
 %{tab}:: Unicode U+0009 tab symbol `\t`
+%{all}:: Includes all available variables. Can only be used with `--json` flag
 
 // end::body[]
 

--- a/docs/aerospace-list-workspaces.adoc
+++ b/docs/aerospace-list-workspaces.adoc
@@ -82,6 +82,7 @@ The following variables can be used inside `<output-format>`:
 %{right-padding}:: A special variable which expands with a minimum number of spaces required to form a right padding in the appropriate column
 %{newline}:: Unicode U+000A newline symbol `\n`
 %{tab}:: Unicode U+0009 tab symbol `\t`
+%{all}:: Includes all available variables. Can only be used with `--json` flag
 
 // end::body[]
 


### PR DESCRIPTION
Add %{all} format variable support to commands listing Aerospace objects :
* `list-windows`
* `list-workspaces`
* `list-apps`
* `list-monitors`

Includes relevant tests and doc.

More details in commit description.