### PR TITLE
[Feature] Alias for combinations (#224)

### DIFF
--- a/Sources/AppBundle/config/HotkeyBinding.swift
+++ b/Sources/AppBundle/config/HotkeyBinding.swift
@@ -76,7 +76,7 @@ struct HotkeyBinding: Equatable, Sendable {
     }
 }
 
-func parseBindings(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError], _ mapping: [String: Key]) -> [String: HotkeyBinding] {
+func parseBindings(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError], _ mapping: [String: KeyOrModifier]) -> [String: HotkeyBinding] {
     guard let rawTable = raw.table else {
         errors += [expectedActualTypeError(expected: .table, actual: raw.type, backtrace)]
         return [:]
@@ -101,15 +101,31 @@ func parseBindings(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ er
     return result
 }
 
-func parseBinding(_ raw: String, _ backtrace: TomlBacktrace, _ mapping: [String: Key]) -> ParsedToml<(NSEvent.ModifierFlags, Key)> {
+func parseBinding(_ raw: String, _ backtrace: TomlBacktrace, _ mapping: [String: KeyOrModifier]) -> ParsedToml<(NSEvent.ModifierFlags, Key)> {
     let rawKeys = raw.split(separator: "-")
     let modifiers: ParsedToml<NSEvent.ModifierFlags> = rawKeys.dropLast()
-        .mapAllOrFailure {
-            modifiersMap[String($0)].orFailure(.semantic(backtrace, "Can't parse modifiers in '\(raw)' binding"))
-        }
+        .mapAllOrFailure { modifierSlice in
+                let modifier = String(modifierSlice)
+                if let keyOrModifier = mapping[modifier],
+                   case .modifiers(let flags) = keyOrModifier {
+                    return .success(flags)
+                }
+                return modifiersMap[modifier].orFailure(
+                    .semantic(backtrace, "Can't parse modifiers in '\(raw)' binding")
+                )
+            }
         .map { NSEvent.ModifierFlags($0) }
-    let key: ParsedToml<Key> = rawKeys.last.flatMap { mapping[String($0)] }
-        .orFailure(.semantic(backtrace, "Can't parse the key in '\(raw)' binding"))
+
+    let key: ParsedToml<Key> = rawKeys.last.flatMap { keySlice in
+        let key = String(keySlice)
+        if let keyOrModifier = mapping[key],
+           case .key(let mappedKey) = keyOrModifier {
+            return mappedKey
+        }
+        return keyNotationToKeyCode[key]
+    }
+    .orFailure(.semantic(backtrace, "Can't parse the key in '\(raw)' binding"))
+
     return modifiers.flatMap { modifiers -> ParsedToml<(NSEvent.ModifierFlags, Key)> in
         key.flatMap { key -> ParsedToml<(NSEvent.ModifierFlags, Key)> in
             .success((modifiers, key))

--- a/Sources/AppBundle/config/Mode.swift
+++ b/Sources/AppBundle/config/Mode.swift
@@ -10,7 +10,7 @@ struct Mode: ConvenienceCopyable, Equatable, Sendable {
     static let zero = Mode(name: nil, bindings: [:])
 }
 
-func parseModes(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError], _ mapping: [String: Key]) -> [String: Mode] {
+func parseModes(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError], _ mapping: [String: KeyOrModifier]) -> [String: Mode] {
     guard let rawTable = raw.table else {
         errors += [expectedActualTypeError(expected: .table, actual: raw.type, backtrace)]
         return [:]
@@ -25,7 +25,7 @@ func parseModes(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ error
     return result
 }
 
-func parseMode(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError], _ mapping: [String: Key]) -> Mode {
+func parseMode(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError], _ mapping: [String: KeyOrModifier]) -> Mode {
     guard let rawTable: TOMLTable = raw.table else {
         errors += [expectedActualTypeError(expected: .table, actual: raw.type, backtrace)]
         return .zero

--- a/Sources/AppBundle/config/parseKeyMapping.swift
+++ b/Sources/AppBundle/config/parseKeyMapping.swift
@@ -1,10 +1,16 @@
+import AppKit
 import Common
 import HotKey
 import TOMLKit
 
+enum KeyOrModifier: Equatable, Sendable {
+    case key(Key)
+    case modifiers(NSEvent.ModifierFlags)
+}
+
 private let keyMappingParser: [String: any ParserProtocol<KeyMapping>] = [
     "preset": Parser(\.preset, parsePreset),
-    "key-notation-to-key-code": Parser(\.rawKeyNotationToKeyCode, parseKeyNotationToKeyCode),
+    "key-notation-to-key-code": Parser(\.rawKeyNotationToKeyOrModifier, parseKeyNotationToKeyOrModifier),
 ]
 
 struct KeyMapping: ConvenienceCopyable, Equatable, Sendable {
@@ -14,18 +20,20 @@ struct KeyMapping: ConvenienceCopyable, Equatable, Sendable {
 
     init(
         preset: Preset = .qwerty,
-        rawKeyNotationToKeyCode: [String: Key] = [:]
+        rawKeyNotationToKeyOrModifier: [String: KeyOrModifier] = [:]
     ) {
         self.preset = preset
-        self.rawKeyNotationToKeyCode = rawKeyNotationToKeyCode
+        self.rawKeyNotationToKeyOrModifier = rawKeyNotationToKeyOrModifier
     }
 
     fileprivate var preset: Preset = .qwerty
-    fileprivate var rawKeyNotationToKeyCode: [String: Key] = [:]
+    fileprivate var rawKeyNotationToKeyOrModifier: [String: KeyOrModifier] = [:]
 
-    func resolve() -> [String: Key] {
-        getKeysPreset(preset) + rawKeyNotationToKeyCode
+    func resolve() -> [String: KeyOrModifier] {
+        let presetKeys = getKeysPreset(preset).mapValues { KeyOrModifier.key($0) }
+        return presetKeys + rawKeyNotationToKeyOrModifier
     }
+
 }
 
 func parseKeyMapping(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError]) -> KeyMapping {
@@ -36,20 +44,30 @@ private func parsePreset(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace
     parseString(raw, backtrace).flatMap { parseEnum($0, KeyMapping.Preset.self).toParsedToml(backtrace) }
 }
 
-private func parseKeyNotationToKeyCode(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError]) -> [String: Key] {
-    var result: [String: Key] = [:]
+private func parseKeyNotationToKeyOrModifier(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError]) -> [String: KeyOrModifier] {
+    var result: [String: KeyOrModifier] = [:]
     guard let table = raw.table else {
         errors.append(expectedActualTypeError(expected: .table, actual: raw.type, backtrace))
         return result
     }
+
     for (key, value): (String, TOMLValueConvertible) in table {
         if isValidKeyNotation(key) {
             let backtrace = backtrace + .key(key)
-            if let value = parseString(value, backtrace).getOrNil(appendErrorTo: &errors) {
-                if let value = keyNotationToKeyCode[value] {
-                    result[key] = value
-                } else {
-                    errors.append(.semantic(backtrace, "'\(value)' is invalid key code"))
+            if let valueString = parseString(value, backtrace).getOrNil(appendErrorTo: &errors) {
+                if let (modifiers, parsedKey) = parseValueComponents(valueString, backtrace, &errors) {
+                    if !modifiers.isEmpty && parsedKey != nil {
+                        errors.append(.semantic(backtrace, "'\(valueString)' contains both keys and modifiers, which is not supported. Use either a single key (e.g., 'a') or modifier combination (e.g., 'ctrl-alt-shift-cmd')"))
+                        continue
+                    }
+
+                    if let parsedKey = parsedKey {
+                        result[key] = .key(parsedKey)
+                    } else if !modifiers.isEmpty {
+                        result[key] = .modifiers(modifiers)
+                    } else {
+                        errors.append(.semantic(backtrace, "'\(valueString)' is not a valid key"))
+                    }
                 }
             }
         } else {
@@ -61,4 +79,27 @@ private func parseKeyNotationToKeyCode(_ raw: TOMLValueConvertible, _ backtrace:
 
 private func isValidKeyNotation(_ str: String) -> Bool {
     str.rangeOfCharacter(from: .whitespacesAndNewlines) == nil && !str.contains("-")
+}
+
+private func parseValueComponents(_ valueString: String, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError]) -> (modifiers: NSEvent.ModifierFlags, key: Key?)? {
+    let parts = valueString.split(separator: "-").map(String.init)
+    var modifiers: NSEvent.ModifierFlags = []
+    var key: Key? = nil
+
+    for part in parts {
+        if let modifier = modifiersMap[part] {
+            modifiers.insert(modifier)
+        } else if let parsedKey = keyNotationToKeyCode[part] {
+            if key != nil {
+                errors.append(.semantic(backtrace, "'\(valueString)' contains multiple keys, only one key is allowed"))
+                return nil
+            }
+            key = parsedKey
+        } else {
+            errors.append(.semantic(backtrace, "'\(part)' is invalid key code"))
+            return nil
+        }
+    }
+
+    return (modifiers: modifiers, key: key)
 }

--- a/Sources/AppBundleTests/config/ConfigTest.swift
+++ b/Sources/AppBundleTests/config/ConfigTest.swift
@@ -363,9 +363,9 @@ final class ConfigTest: XCTestCase {
             """,
         )
         assertEquals(errors.descriptions, [])
-        assertEquals(config.keyMapping, KeyMapping(preset: .qwerty, rawKeyNotationToKeyCode: [
-            "q": .q,
-            "unicorn": .u,
+        assertEquals(config.keyMapping, KeyMapping(preset: .qwerty, rawKeyNotationToKeyOrModifier: [
+            "q": .key(.q),
+            "unicorn": .key(.u),
         ]))
         let binding = HotkeyBinding(.option, .u, [WorkspaceCommand(args: WorkspaceCmdArgs(target: .direct(.parse("unicorn").getOrDie())))])
         assertEquals(config.modes[mainModeId]?.bindings, [binding.descriptionWithKeyCode: binding])
@@ -379,7 +379,7 @@ final class ConfigTest: XCTestCase {
         )
         assertEquals(errors1.descriptions, [
             "key-mapping.key-notation-to-key-code: ' f' is invalid key notation",
-            "key-mapping.key-notation-to-key-code.q: 'qw' is invalid key code",
+            "key-mapping.key-notation-to-key-code.q: 'qw' is not a valid key or modifier in 'qw'",
         ])
 
         let (dvorakConfig, dvorakErrors) = parseConfig(
@@ -388,15 +388,69 @@ final class ConfigTest: XCTestCase {
             """,
         )
         assertEquals(dvorakErrors, [])
-        assertEquals(dvorakConfig.keyMapping, KeyMapping(preset: .dvorak, rawKeyNotationToKeyCode: [:]))
-        assertEquals(dvorakConfig.keyMapping.resolve()["quote"], .q)
+        assertEquals(dvorakConfig.keyMapping, KeyMapping(preset: .dvorak, rawKeyNotationToKeyOrModifier: [:]))
+        assertEquals(dvorakConfig.keyMapping.resolve()["quote"], .key(.q))
         let (colemakConfig, colemakErrors) = parseConfig(
             """
             key-mapping.preset = 'colemak'
             """,
         )
         assertEquals(colemakErrors, [])
-        assertEquals(colemakConfig.keyMapping, KeyMapping(preset: .colemak, rawKeyNotationToKeyCode: [:]))
-        assertEquals(colemakConfig.keyMapping.resolve()["f"], .e)
+        assertEquals(colemakConfig.keyMapping, KeyMapping(preset: .colemak, rawKeyNotationToKeyOrModifier: [:]))
+        assertEquals(colemakConfig.keyMapping.resolve()["f"], .key(.e))
+    }
+
+    func testParseKeyModifierAlias() {
+        let (config, errors) = parseConfig(
+            """
+            [key-mapping.key-notation-to-key-code]
+                hyper = 'ctrl-alt-shift-cmd'
+
+            [mode.main.binding]
+                hyper-h = 'focus left'
+            """,
+        )
+        assertEquals(errors.descriptions, [])
+
+        // Verify that the modifier aliases are correctly resolved
+        let hyperFlags: NSEvent.ModifierFlags = [.control, .option, .shift, .command]
+        assertEquals(config.keyMapping.resolve()["hyper"], .modifiers(hyperFlags))
+
+        // Verify that the hyper bindings are correctly parsed with expanded modifiers
+        let hyperHBinding = HotkeyBinding(hyperFlags, .h, [FocusCommand.new(direction: .left)])
+        assertEquals(config.modes[mainModeId]?.bindings[hyperHBinding.descriptionWithKeyCode], hyperHBinding)
+    }
+
+    func testKeyValidationValidCombinations() {
+        let (config, errors) = parseConfig(
+            """
+            [key-mapping.key-notation-to-key-code]
+                mykey = 'a'
+                mymod = 'ctrl-alt'
+
+            [mode.main.binding]
+                shift-mykey = 'focus left'
+                mymod-c = 'focus right'
+            """,
+        )
+        assertEquals(errors.descriptions, [])
+        assertEquals(config.keyMapping.resolve()["mykey"], .key(.a))
+        assertEquals(config.keyMapping.resolve()["mymod"], .modifiers([.control, .option]))
+    }
+
+    func testKeyValidationInvalidCombinations() {
+        let (_, errors) = parseConfig(
+            """
+            [key-mapping.key-notation-to-key-code]
+                badkey = 'ctrl-a'
+                multikey = 'a-b'
+                unknown = 'badkey'
+            """,
+        )
+        assertEquals(errors.descriptions.sorted(), [
+            "key-mapping.key-notation-to-key-code.badkey: 'ctrl-a' contains both keys and modifiers, which is not supported. Use either a single key (e.g., 'a') or modifier combination (e.g., 'ctrl-alt-shift-cmd')",
+            "key-mapping.key-notation-to-key-code.multikey: 'a-b' contains multiple keys, only one key is allowed",
+            "key-mapping.key-notation-to-key-code.unknown: 'badkey' is not a valid key or modifier in 'badkey'",
+        ])
     }
 }

--- a/docs/guide.adoc
+++ b/docs/guide.adoc
@@ -167,16 +167,28 @@ For the list of available commands see: xref:commands.adoc[]
 
 By default, key bindings in the config are perceived as `qwerty` layout.
 
-If you use different layout, different alphabet, or you just want to have a fancy alias for the existing key, you can use `key-mapping.key-notation-to-key-code`.
+If you use different layout, different alphabet, or you just want to have a fancy alias for the existing key or modifier combination, you can use `key-mapping.key-notation-to-key-code`.
 
 [source,toml]
 ----
 # Define my fancy unicorn key notation
 [key-mapping.key-notation-to-key-code]
+
     unicorn = 'u'
 
+    # Alias modifiers
+    hyper = 'ctrl-alt-shift-cmd'
+
+    # Mixing keys and modifiers is not supported
+    # invalid = 'ctrl-a'            
+
 [mode.main.binding]
+    # Use key aliases
     alt-unicorn = 'workspace wonderland' # (⁀ᗢ⁀)
+
+    # Use modifier aliases
+    hyper-h = 'focus left'
+    hyper-j = 'focus down'
 ----
 
 * For `dvorak` and `colemak` users, AeroSpace offers preconfigured presets.


### PR DESCRIPTION
Adds modifier support for aliases. Unlocks use cases such as defining an alias for a 'hyper' key.

```toml
[key-mapping.key-notation-to-key-code]
hyper = 'ctrl-alt-shift-cmd'

[mode.main.binding]
hyper-c = 'workspace c'
```

Mixing modifiers and keys in a single alias is not supported. Invalid combinations are checked and result in configuration error messages.

Implements: https://github.com/nikitabobko/AeroSpace/issues/224
Related: https://github.com/nikitabobko/AeroSpace/pull/389
Related: https://github.com/nikitabobko/AeroSpace/pull/1223

## PR checklist

- [ ] Explain your changes in the relevant commit messages rather than in the PR description. The PR description must not contain more information than the commit messages (except for images and other media).
- [ ] Each commit must explain what/why/how in its description. https://cbea.ms/git-commit/
- [ ] Don't forget to link the appropriate issues/discussions in commit messages (if applicable).
- [ ] Each commit must be an atomic change (a PR may contain several commits). Don't introduce new functional changes together with refactorings in the same commit.
- [ ] The GitHub Actions CI must pass (you can fix failures after submitting a PR).

Failure to follow the checklist with no apparent reasons will result in silent PR rejection.
