### PR TITLE
[Feature] Alias for combinations (#224)

### DIFF
--- a/Sources/AppBundle/config/Mode.swift
+++ b/Sources/AppBundle/config/Mode.swift
@@ -10,7 +10,7 @@ struct Mode: ConvenienceCopyable, Equatable, Sendable {
     static let zero = Mode(name: nil, bindings: [:])
 }
 
-func parseModes(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError], _ mapping: [String: Key]) -> [String: Mode] {
+func parseModes(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError], _ mapping: [String: KeyOrModifier]) -> [String: Mode] {
     guard let rawTable = raw.table else {
         errors += [expectedActualTypeError(expected: .table, actual: raw.type, backtrace)]
         return [:]
@@ -25,7 +25,7 @@ func parseModes(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ error
     return result
 }
 
-func parseMode(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError], _ mapping: [String: Key]) -> Mode {
+func parseMode(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError], _ mapping: [String: KeyOrModifier]) -> Mode {
     guard let rawTable: TOMLTable = raw.table else {
         errors += [expectedActualTypeError(expected: .table, actual: raw.type, backtrace)]
         return .zero

--- a/Sources/AppBundle/config/parseKeyMapping.swift
+++ b/Sources/AppBundle/config/parseKeyMapping.swift
@@ -1,10 +1,16 @@
+import AppKit
 import Common
 import HotKey
 import TOMLKit
 
+enum KeyOrModifier: Equatable, Sendable {
+    case key(Key)
+    case modifiers(NSEvent.ModifierFlags)
+}
+
 private let keyMappingParser: [String: any ParserProtocol<KeyMapping>] = [
     "preset": Parser(\.preset, parsePreset),
-    "key-notation-to-key-code": Parser(\.rawKeyNotationToKeyCode, parseKeyNotationToKeyCode),
+    "key-notation-to-key-code": Parser(\.rawKeyNotationToKeyOrModifier, parseKeyNotationToKeyOrModifier),
 ]
 
 struct KeyMapping: ConvenienceCopyable, Equatable, Sendable {
@@ -14,17 +20,18 @@ struct KeyMapping: ConvenienceCopyable, Equatable, Sendable {
 
     init(
         preset: Preset = .qwerty,
-        rawKeyNotationToKeyCode: [String: Key] = [:]
+        rawKeyNotationToKeyOrModifier: [String: KeyOrModifier] = [:]
     ) {
         self.preset = preset
-        self.rawKeyNotationToKeyCode = rawKeyNotationToKeyCode
+        self.rawKeyNotationToKeyOrModifier = rawKeyNotationToKeyOrModifier
     }
 
     fileprivate var preset: Preset = .qwerty
-    fileprivate var rawKeyNotationToKeyCode: [String: Key] = [:]
+    fileprivate var rawKeyNotationToKeyOrModifier: [String: KeyOrModifier] = [:]
 
-    func resolve() -> [String: Key] {
-        getKeysPreset(preset) + rawKeyNotationToKeyCode
+    func resolve() -> [String: KeyOrModifier] {
+        let presetKeys = getKeysPreset(preset).mapValues { KeyOrModifier.key($0) }
+        return presetKeys + rawKeyNotationToKeyOrModifier
     }
 }
 
@@ -36,20 +43,30 @@ private func parsePreset(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace
     parseString(raw, backtrace).flatMap { parseEnum($0, KeyMapping.Preset.self).toParsedToml(backtrace) }
 }
 
-private func parseKeyNotationToKeyCode(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError]) -> [String: Key] {
-    var result: [String: Key] = [:]
+private func parseKeyNotationToKeyOrModifier(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError]) -> [String: KeyOrModifier] {
+    var result: [String: KeyOrModifier] = [:]
     guard let table = raw.table else {
         errors.append(expectedActualTypeError(expected: .table, actual: raw.type, backtrace))
         return result
     }
+
     for (key, value): (String, TOMLValueConvertible) in table {
         if isValidKeyNotation(key) {
             let backtrace = backtrace + .key(key)
-            if let value = parseString(value, backtrace).getOrNil(appendErrorTo: &errors) {
-                if let value = keyNotationToKeyCode[value] {
-                    result[key] = value
-                } else {
-                    errors.append(.semantic(backtrace, "'\(value)' is invalid key code"))
+            if let valueString = parseString(value, backtrace).getOrNil(appendErrorTo: &errors) {
+                if let (modifiers, parsedKey) = parseValueComponents(valueString, backtrace, &errors) {
+                    if !modifiers.isEmpty && parsedKey != nil {
+                        errors.append(.semantic(backtrace, "'\(valueString)' contains both keys and modifiers, which is not supported. Use either a single key (e.g., 'a') or modifier combination (e.g., 'ctrl-alt-shift-cmd')"))
+                        continue
+                    }
+
+                    if let parsedKey {
+                        result[key] = .key(parsedKey)
+                    } else if !modifiers.isEmpty {
+                        result[key] = .modifiers(modifiers)
+                    } else {
+                        errors.append(.semantic(backtrace, "'\(valueString)' is not a valid key"))
+                    }
                 }
             }
         } else {
@@ -61,4 +78,27 @@ private func parseKeyNotationToKeyCode(_ raw: TOMLValueConvertible, _ backtrace:
 
 private func isValidKeyNotation(_ str: String) -> Bool {
     str.rangeOfCharacter(from: .whitespacesAndNewlines) == nil && !str.contains("-")
+}
+
+private func parseValueComponents(_ valueString: String, _ backtrace: TomlBacktrace, _ errors: inout [TomlParseError]) -> (modifiers: NSEvent.ModifierFlags, key: Key?)? {
+    let parts = valueString.split(separator: "-").map(String.init)
+    var modifiers: NSEvent.ModifierFlags = []
+    var key: Key? = nil
+
+    for part in parts {
+        if let modifier = modifiersMap[part] {
+            modifiers.insert(modifier)
+        } else if let parsedKey = keyNotationToKeyCode[part] {
+            if key != nil {
+                errors.append(.semantic(backtrace, "'\(valueString)' contains multiple keys, only one key is allowed"))
+                return nil
+            }
+            key = parsedKey
+        } else {
+            errors.append(.semantic(backtrace, "'\(part)' is invalid key code"))
+            return nil
+        }
+    }
+
+    return (modifiers: modifiers, key: key)
 }

--- a/docs/guide.adoc
+++ b/docs/guide.adoc
@@ -167,7 +167,7 @@ For the list of available commands see: xref:commands.adoc[]
 
 By default, key bindings in the config are perceived as `qwerty` layout.
 
-If you use different layout, different alphabet, or you just want to have a fancy alias for the existing key, you can use `key-mapping.key-notation-to-key-code`.
+If you use different layout, different alphabet, or you just want to have a fancy alias for the existing key or modifier combination, you can use `key-mapping.key-notation-to-key-code`.
 
 [source,toml]
 ----
@@ -175,8 +175,19 @@ If you use different layout, different alphabet, or you just want to have a fanc
 [key-mapping.key-notation-to-key-code]
     unicorn = 'u'
 
+    # Alias modifiers
+    hyper = 'ctrl-alt-shift-cmd'
+
+    # Mixing keys and modifiers is not supported
+    # invalid = 'ctrl-a'            
+
 [mode.main.binding]
+    # Use key aliases
     alt-unicorn = 'workspace wonderland' # (⁀ᗢ⁀)
+
+    # Use modifier aliases
+    hyper-h = 'focus left'
+    hyper-j = 'focus down'
 ----
 
 * For `dvorak` and `colemak` users, AeroSpace offers preconfigured presets.


### PR DESCRIPTION
Extends `[key-mapping.key-notation-to-key-code]` to support defining aliases for modifier combinations (e.g., hyper key).

Example config:
```toml
[key-mapping.key-notation-to-key-code]
hyper = 'ctrl-alt-shift-cmd'

[mode.main.binding]
hyper-c = 'workspace c'
```

Mixing modifiers and keys in a single alias is not supported. Invalid combinations are checked and result in configuration error messages.

Change introduces `KeyOrModifier` enum to represent either single keys or modifier combinations.

Implements: https://github.com/nikitabobko/AeroSpace/issues/224
Related: https://github.com/nikitabobko/AeroSpace/pull/389
Related: https://github.com/nikitabobko/AeroSpace/pull/1223

## PR checklist

- [x] Explain your changes in the relevant commit messages rather than in the PR description. The PR description must not contain more information than the commit messages (except for images and other media).
- [x] Each commit must explain what/why/how in its description. https://cbea.ms/git-commit/
- [x] Don't forget to link the appropriate issues/discussions in commit messages (if applicable).
- [x] Each commit must be an atomic change (a PR may contain several commits). Don't introduce new functional changes together with refactorings in the same commit.
- [x] The GitHub Actions CI must pass (you can fix failures after submitting a PR).

Failure to follow the checklist with no apparent reasons will result in silent PR rejection.
