### PR TITLE
Implement dwindle layout with weight support

### DIFF
--- a/Sources/AppBundle/command/format.swift
+++ b/Sources/AppBundle/command/format.swift
@@ -167,6 +167,8 @@ private func toLayoutString(tc: TilingContainer) -> String {
         case (.tiles, .v): return LayoutCmdArgs.LayoutDescription.v_tiles.rawValue
         case (.accordion, .h): return LayoutCmdArgs.LayoutDescription.h_accordion.rawValue
         case (.accordion, .v): return LayoutCmdArgs.LayoutDescription.v_accordion.rawValue
+        case (.dwindle, .h): return LayoutCmdArgs.LayoutDescription.horizontal.rawValue
+        case (.dwindle, .v): return LayoutCmdArgs.LayoutDescription.vertical.rawValue
     }
 }
 

--- a/Sources/AppBundle/command/impl/BalanceSizesCommand.swift
+++ b/Sources/AppBundle/command/impl/BalanceSizesCommand.swift
@@ -17,7 +17,7 @@ struct BalanceSizesCommand: Command {
 private func balance(_ parent: TilingContainer) {
     for child in parent.children {
         switch parent.layout {
-            case .tiles: child.setWeight(parent.orientation, 1)
+            case .tiles, .dwindle: child.setWeight(parent.orientation, 1)
             case .accordion: break // Do nothing
         }
         if let child = child as? TilingContainer {

--- a/Sources/AppBundle/command/impl/LayoutCommand.swift
+++ b/Sources/AppBundle/command/impl/LayoutCommand.swift
@@ -26,6 +26,8 @@ struct LayoutCommand: Command {
                 return changeTilingLayout(io, targetLayout: .accordion, targetOrientation: nil, window: window)
             case .tiles:
                 return changeTilingLayout(io, targetLayout: .tiles, targetOrientation: nil, window: window)
+            case .dwindle:
+                return changeTilingLayout(io, targetLayout: .dwindle, targetOrientation: nil, window: window)
             case .horizontal:
                 return changeTilingLayout(io, targetLayout: nil, targetOrientation: .h, window: window)
             case .vertical:
@@ -73,6 +75,7 @@ extension Window {
         return switch layout {
             case .accordion:   (parent as? TilingContainer)?.layout == .accordion
             case .tiles:       (parent as? TilingContainer)?.layout == .tiles
+            case .dwindle:     (parent as? TilingContainer)?.layout == .dwindle
             case .horizontal:  (parent as? TilingContainer)?.orientation == .h
             case .vertical:    (parent as? TilingContainer)?.orientation == .v
             case .h_accordion: (parent as? TilingContainer).map { $0.layout == .accordion && $0.orientation == .h } == true

--- a/Sources/AppBundle/command/impl/ResizeCommand.swift
+++ b/Sources/AppBundle/command/impl/ResizeCommand.swift
@@ -9,7 +9,10 @@ struct ResizeCommand: Command { // todo cover with tests
         guard let target = args.resolveTargetOrReportError(env, io) else { return false }
 
         let candidates = target.windowOrNil?.parentsWithSelf
-            .filter { ($0.parent as? TilingContainer)?.layout == .tiles }
+            .filter {
+                let layout = ($0.parent as? TilingContainer)?.layout
+                return layout == .tiles || layout == .dwindle
+            }
             ?? []
 
         let orientation: Orientation?

--- a/Sources/AppBundle/initAppBundle.swift
+++ b/Sources/AppBundle/initAppBundle.swift
@@ -33,6 +33,10 @@ import Foundation
 private func smartLayoutAtStartup() {
     let workspace = focus.workspace
     let root = workspace.rootTilingContainer
+    // Respect user's configured default layout - don't override it with heuristic
+    if root.layout == config.defaultRootContainerLayout {
+        return
+    }
     if root.children.count <= 3 {
         root.layout = .tiles
     } else {

--- a/Sources/AppBundle/mouse/moveWithMouse.swift
+++ b/Sources/AppBundle/mouse/moveWithMouse.swift
@@ -98,7 +98,7 @@ extension CGPoint {
     func findIn(tree: TilingContainer, virtual: Bool) -> Window? {
         let point = self
         let target: TreeNode? = switch tree.layout {
-            case .tiles:
+            case .tiles, .dwindle:
                 tree.children.first(where: {
                     (virtual ? $0.lastAppliedLayoutVirtualRect : $0.lastAppliedLayoutPhysicalRect)?.contains(point) == true
                 })

--- a/Sources/AppBundle/mouse/resizeWithMouse.swift
+++ b/Sources/AppBundle/mouse/resizeWithMouse.swift
@@ -47,10 +47,10 @@ private func resizeWithMouse(_ window: Window) async throws { // todo cover with
         case .tilingContainer:
             guard let rect = try await window.getAxRect() else { return }
             guard let lastAppliedLayoutRect = window.lastAppliedLayoutPhysicalRect else { return }
-            let (lParent, lOwnIndex) = window.closestParent(hasChildrenInDirection: .left, withLayout: .tiles) ?? (nil, nil)
-            let (dParent, dOwnIndex) = window.closestParent(hasChildrenInDirection: .down, withLayout: .tiles) ?? (nil, nil)
-            let (uParent, uOwnIndex) = window.closestParent(hasChildrenInDirection: .up, withLayout: .tiles) ?? (nil, nil)
-            let (rParent, rOwnIndex) = window.closestParent(hasChildrenInDirection: .right, withLayout: .tiles) ?? (nil, nil)
+            let (lParent, lOwnIndex) = window.closestParent(hasChildrenInDirection: .left, withLayout: nil) ?? (nil, nil)
+            let (dParent, dOwnIndex) = window.closestParent(hasChildrenInDirection: .down, withLayout: nil) ?? (nil, nil)
+            let (uParent, uOwnIndex) = window.closestParent(hasChildrenInDirection: .up, withLayout: nil) ?? (nil, nil)
+            let (rParent, rOwnIndex) = window.closestParent(hasChildrenInDirection: .right, withLayout: nil) ?? (nil, nil)
             let table: [(CGFloat, TilingContainer?, Int?, Int?)] = [
                 (lastAppliedLayoutRect.minX - rect.minX, lParent, 0,                        lOwnIndex),               // Horizontal, to the left of the window
                 (rect.maxY - lastAppliedLayoutRect.maxY, dParent, dOwnIndex.map { $0 + 1 }, dParent?.children.count), // Vertical, to the down of the window
@@ -66,7 +66,8 @@ private func resizeWithMouse(_ window: Window) async throws { // todo cover with
                         .prefix(while: { $0 != parent })
                         .filter {
                             let parent = $0.parent as? TilingContainer
-                            return parent?.orientation == orientation && parent?.layout == .tiles
+                            let layout = parent?.layout
+                            return parent?.orientation == orientation && (layout == .tiles || layout == .dwindle)
                         }
                         .forEach { $0.setWeight(orientation, $0.getWeightBeforeResize(orientation) + diff) }
                     for sibling in parent.children[startIndex ..< pastTheEndIndex] {

--- a/Sources/AppBundle/tree/TilingContainer.swift
+++ b/Sources/AppBundle/tree/TilingContainer.swift
@@ -58,6 +58,7 @@ extension TilingContainer {
 enum Layout: String {
     case tiles
     case accordion
+    case dwindle
 }
 
 extension String {

--- a/Sources/AppBundle/tree/TreeNode.swift
+++ b/Sources/AppBundle/tree/TreeNode.swift
@@ -38,8 +38,8 @@ class TreeNode: Equatable, AeroAny {
                 if parent.orientation != targetOrientation {
                     die("You can't change \(targetOrientation) weight of nodes located in \(parent.orientation) container")
                 }
-                if parent.layout != .tiles {
-                    die("Weight can be changed only for nodes whose parent has 'tiles' layout")
+                if parent.layout != .tiles && parent.layout != .dwindle {
+                    die("Weight can be changed only for nodes whose parent has 'tiles' or 'dwindle' layout")
                 }
                 adaptiveWeight = newValue
             default:

--- a/Sources/AppBundleTests/command/MoveCommandTest.swift
+++ b/Sources/AppBundleTests/command/MoveCommandTest.swift
@@ -291,7 +291,7 @@ extension TreeNode {
             case .macosPopupWindowsContainer: .macosPopupWindowsContainer
             case .tilingContainer(let container):
                 switch container.layout {
-                    case .tiles:
+                    case .tiles, .dwindle:
                         container.orientation == .h
                             ? .h_tiles(container.children.map(\.layoutDescription))
                             : .v_tiles(container.children.map(\.layoutDescription))

--- a/Sources/AppBundleTests/config/ConfigTest.swift
+++ b/Sources/AppBundleTests/config/ConfigTest.swift
@@ -170,6 +170,17 @@ final class ConfigTest: XCTestCase {
         }
     }
 
+    func testParseDwindle() {
+        let command = parseCommand("layout dwindle horizontal vertical").cmdOrNil
+        XCTAssertTrue(command is LayoutCommand)
+        assertEquals((command as! LayoutCommand).args.toggleBetween.val, [.dwindle, .horizontal, .vertical])
+
+        guard case .help = parseCommand("layout dwindle -h") else {
+            XCTFail()
+            return
+        }
+    }
+
     func testSplitCommandAndFlattenContainersNormalization() {
         let (_, errors) = parseConfig(
             """

--- a/Sources/Common/cmdArgs/impl/LayoutCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/LayoutCmdArgs.swift
@@ -21,7 +21,7 @@ public struct LayoutCmdArgs: CmdArgs {
     }
 
     public enum LayoutDescription: String, CaseIterable, Equatable, Sendable {
-        case accordion, tiles
+        case accordion, tiles, dwindle
         case horizontal, vertical
         case h_accordion, v_accordion, h_tiles, v_tiles
         case tiling, floating

--- a/Sources/Common/cmdHelpGenerated.swift
+++ b/Sources/Common/cmdHelpGenerated.swift
@@ -58,7 +58,7 @@ let join_with_help_generated = """
     """
 let layout_help_generated = """
     USAGE: layout [-h|--help] [--window-id <window-id>]
-                  (h_tiles|v_tiles|h_accordion|v_accordion|tiles|accordion|horizontal|vertical|tiling|floating)...
+                  (h_tiles|v_tiles|h_accordion|v_accordion|tiles|accordion|dwindle|horizontal|vertical|tiling|floating)...
     """
 let list_apps_help_generated = """
     USAGE: list-apps [-h|--help] [--macos-native-hidden [no]] [--format <output-format>] [--count] [--json]

--- a/docs/aerospace-layout.adoc
+++ b/docs/aerospace-layout.adoc
@@ -10,7 +10,7 @@ include::util/man-attributes.adoc[]
 [verse]
 // tag::synopsis[]
 aerospace layout [-h|--help] [--window-id <window-id>]
-                 (h_tiles|v_tiles|h_accordion|v_accordion|tiles|accordion|horizontal|vertical|tiling|floating)...
+                 (h_tiles|v_tiles|h_accordion|v_accordion|tiles|accordion|dwindle|horizontal|vertical|tiling|floating)...
 
 // end::synopsis[]
 
@@ -23,9 +23,11 @@ aerospace layout [-h|--help] [--window-id <window-id>]
 If several arguments are supplied then finds the first argument that doesn't describe the currently active layout, and applies the layout.
 
 * Change both tiling layout and orientation in one go: `h_tiles|v_tiles|h_accordion|v_accordion`
-* Change tiling layout but preserve orientation: `tiles|accordion`
+* Change tiling layout but preserve orientation: `tiles|accordion|dwindle`
 * Change orientation but preserve layout: `horizontal|vertical`
 * Toggle floating/tiling mode: `tiling|floating`
+
+The `dwindle` layout is a binary tree-based tiling layout inspired by Hyprland. It splits windows based on the container's orientation (horizontal orientation splits vertically, vertical orientation splits horizontally) and respects node weights. This means `resize`, `balance-sizes`, and `horizontal`/`vertical` commands all work with dwindle layout. The orientation alternates at each level of recursion, creating the characteristic dwindle pattern.
 
 // =========================================================== Options
 include::./util/conditional-options-header.adoc[]

--- a/docs/config-examples/default-config.toml
+++ b/docs/config-examples/default-config.toml
@@ -17,7 +17,7 @@ enable-normalization-opposite-orientation-for-nested-containers = true
 # You can set 0 to disable the padding feature
 accordion-padding = 30
 
-# Possible values: tiles|accordion
+# Possible values: tiles|accordion|dwindle
 default-root-container-layout = 'tiles'
 
 # Possible values: horizontal|vertical|auto


### PR DESCRIPTION
Added dwindle layout to provide a Fibonacci-style tiling (Hyprland's default tiling layout) option requested by many users who prefer automatically decreasing window sizes for better focus management.

  - Added dwindle layout option to config and commands
  - Implemented weight-aware binary tree splitting algorithm
  - Fixed smartLayoutAtStartup() to respect config.defaultRootContainerLayout
  - Supports resize, balance-sizes, and orientation commands in dwindle
  - Updated documentation with dwindle layout description
  - Added test coverage for dwindle layout parsing

The implementation uses container orientation and node weights to determine split direction and ratio, with orientation alternating at each recursion level to create the characteristic dwindle pattern.

## PR checklist

- [ ] Explain your changes in the relevant commit messages rather than in the PR description. The PR description must not contain more information than the commit messages (except for images and other media).
- [ ] Each commit must explain what/why/how and motivation in its description. https://cbea.ms/git-commit/
- [ ] Don't forget to link the appropriate issues/discussions in commit messages (if applicable).
- [ ] Each commit must be an atomic change (a PR may contain several commits). Don't introduce new functional changes together with refactorings in the same commit.
- [ ] The GitHub Actions CI must pass (you can fix failures after submitting a PR).

Failure to follow the checklist with no apparent reasons will result in silent PR rejection.
