### PR TITLE
Default corner

### DIFF
--- a/Sources/AppBundle/config/Config.swift
+++ b/Sources/AppBundle/config/Config.swift
@@ -56,9 +56,16 @@ struct Config: ConvenienceCopyable {
     var modes: [String: Mode] = [:]
     var onWindowDetected: [WindowDetectedCallback] = []
 
+    var defaultOptimalHideCorner: OptimalHideCorner = .bottomRightCorner
+
     var preservedWorkspaceNames: [String] = []
 }
 
 enum DefaultContainerOrientation: String {
     case horizontal, vertical, auto
+}
+
+enum OptimalHideCorner: String {
+    case bottomLeftCorner = "bottom-left"
+    case bottomRightCorner = "bottom-right"
 }

--- a/Sources/AppBundle/config/parseConfig.swift
+++ b/Sources/AppBundle/config/parseConfig.swift
@@ -113,6 +113,7 @@ private let configParser: [String: any ParserProtocol<Config>] = [
     "gaps": Parser(\.gaps, parseGaps),
     "workspace-to-monitor-force-assignment": Parser(\.workspaceToMonitorForceAssignment, parseWorkspaceToMonitorAssignment),
     "on-window-detected": Parser(\.onWindowDetected, parseOnWindowDetectedArray),
+    "default-hide-corner": Parser(\.defaultOptimalHideCorner, parseOptimalHideCorner),
 
     // Deprecated
     "non-empty-workspaces-root-containers-layout-on-startup": Parser(\._nonEmptyWorkspacesRootContainersLayoutOnStartup, parseStartupRootContainerLayout),
@@ -299,6 +300,13 @@ private func parseDefaultContainerOrientation(_ raw: TOMLValueConvertible, _ bac
     parseString(raw, backtrace).flatMap {
         DefaultContainerOrientation(rawValue: $0)
             .orFailure(.semantic(backtrace, "Can't parse default container orientation '\($0)'"))
+    }
+}
+
+private func parseOptimalHideCorner(_ raw: TOMLValueConvertible, _ backtrace: TomlBacktrace) -> ParsedToml<OptimalHideCorner> {
+    parseString(raw, backtrace).flatMap {
+        OptimalHideCorner(rawValue: $0)
+            .orFailure(.semantic(backtrace, "Can't parse default hide corner '\($0)'. Possible values: bottom-left, bottom-right"))
     }
 }
 

--- a/Sources/AppBundleTests/config/ConfigTest.swift
+++ b/Sources/AppBundleTests/config/ConfigTest.swift
@@ -399,4 +399,78 @@ final class ConfigTest: XCTestCase {
         assertEquals(colemakConfig.keyMapping, KeyMapping(preset: .colemak, rawKeyNotationToKeyCode: [:]))
         assertEquals(colemakConfig.keyMapping.resolve()["f"], .e)
     }
+
+    func testParseDefaultHideCorner() {
+        let (config1, errors1) = parseConfig(
+            """
+            default-hide-corner = 'bottom-left'
+            """,
+        )
+        assertEquals(errors1, [])
+        assertEquals(config1.defaultOptimalHideCorner, .bottomLeftCorner)
+
+        let (config2, errors2) = parseConfig(
+            """
+            default-hide-corner = 'bottom-right'
+            """,
+        )
+        assertEquals(errors2, [])
+        assertEquals(config2.defaultOptimalHideCorner, .bottomRightCorner)
+
+        // Test default value
+        let (config3, errors3) = parseConfig("")
+        assertEquals(errors3, [])
+        assertEquals(config3.defaultOptimalHideCorner, .bottomRightCorner)
+
+        // Test invalid value
+        let (config4, errors4) = parseConfig(
+            """
+            default-hide-corner = 'invalid-value'
+            """,
+        )
+        assertEquals(
+            errors4.descriptions,
+            ["default-hide-corner: Can't parse default hide corner 'invalid-value'. Possible values: bottom-left, bottom-right"],
+        )
+        assertEquals(config4.defaultOptimalHideCorner, .bottomRightCorner) // Should fallback to default
+
+        // Test type mismatch
+        let (config5, errors5) = parseConfig(
+            """
+            default-hide-corner = true
+            """,
+        )
+        assertEquals(
+            errors5.descriptions,
+            ["default-hide-corner: Expected type is 'string'. But actual type is 'bool'"],
+        )
+        assertEquals(config5.defaultOptimalHideCorner, .bottomRightCorner) // Should fallback to default
+    }
+
+    func testDefaultHideCornerInFullConfig() {
+        // Test that default-hide-corner works correctly in a realistic config scenario
+        let (config, errors) = parseConfig(
+            """
+            default-hide-corner = 'bottom-left'
+            accordion-padding = 30
+            start-at-login = false
+
+            [mode.main.binding]
+                alt-1 = 'workspace 1'
+            """,
+        )
+        assertEquals(errors, [])
+        assertEquals(config.defaultOptimalHideCorner, .bottomLeftCorner)
+        assertEquals(config.accordionPadding, 30)
+        assertEquals(config.startAtLogin, false)
+
+        // Verify it can be changed
+        let (config2, errors2) = parseConfig(
+            """
+            default-hide-corner = 'bottom-right'
+            """,
+        )
+        assertEquals(errors2, [])
+        assertEquals(config2.defaultOptimalHideCorner, .bottomRightCorner)
+    }
 }

--- a/docs/config-examples/default-config.toml
+++ b/docs/config-examples/default-config.toml
@@ -25,6 +25,11 @@ default-root-container-layout = 'tiles'
 #               tall monitor (anything higher than wide) gets vertical orientation
 default-root-container-orientation = 'auto'
 
+# Possible values: bottom-left|bottom-right
+# Specifies the default corner where windows from invisible workspaces are hidden
+# See: https://nikitabobko.github.io/AeroSpace/guide#emulation-of-virtual-workspaces
+default-hide-corner = 'bottom-right'
+
 # Mouse follows focus when focused monitor changes
 # Drop it from your config, if you don't like this behavior
 # See https://nikitabobko.github.io/AeroSpace/guide#on-focus-changed-callbacks

--- a/docs/guide.adoc
+++ b/docs/guide.adoc
@@ -369,8 +369,12 @@ Native macOS Spaces have a lot of problems
 * Apple doesn't provide public API to communicate with Spaces (create/delete/reorder/switch Space and move windows between Spaces)
 
 Since Spaces are so hard to deal with, AeroSpace reimplements Spaces and calls them "Workspaces".
-The idea is that if the workspace isn’t active then all of its windows are placed outside the visible area of the screen, in the bottom right or left corner.
+The idea is that if the workspace isn't active then all of its windows are placed outside the visible area of the screen, in the bottom right or left corner.
 Once you switch back to the workspace, (e.g. by the means of xref:commands.adoc#workspace[workspace] command, or `cmd + tab`) windows are placed back to the visible area of the screen.
+
+You can configure which corner is used by default for hiding windows using the `default-hide-corner` configuration option.
+Possible values are `bottom-left` and `bottom-right`. The default is `bottom-right`.
+AeroSpace automatically selects the optimal corner for each monitor based on monitor arrangement, but falls back to the configured default when the optimal corner cannot be determined.
 
 When you quit the AeroSpace or when the AeroSpace detects that it's about to crash, AeroSpace will place all windows back to the visible area of the screen.
 


### PR DESCRIPTION
Hi,

This project is really amazing and helping me a lot.
I am having a configuration like this:

<img width="245" height="151" alt="image" src="https://github.com/user-attachments/assets/a20d0921-c2b0-4459-a791-7ad308df3436" />

but with the default right corner it does not behave as expected. I wanted a quick fix, I manage to have this working locally and it is a lot better.
I am willing to help refine the logic to auto set the default hide corner but in the meantime this is really helping and might help others.

## PR checklist

- [X] Explain your changes in the relevant commit messages rather than in the PR description. The PR description must not contain more information than the commit messages (except for images and other media).
- [X] Each commit must explain what/why/how and motivation in its description. https://cbea.ms/git-commit/
- [X] Don't forget to link the appropriate issues/discussions in commit messages (if applicable).
- [X] Each commit must be an atomic change (a PR may contain several commits). Don't introduce new functional changes together with refactorings in the same commit.
- [ ] The GitHub Actions CI must pass (you can fix failures after submitting a PR).

Failure to follow the checklist with no apparent reasons will result in silent PR rejection.
