### PR TITLE
Prefer using persistent workspaces as stubs before creating new ones

### DIFF
--- a/Sources/AppBundle/tree/Workspace.swift
+++ b/Sources/AppBundle/tree/Workspace.swift
@@ -24,6 +24,15 @@ private func getStubWorkspace(forPoint point: CGPoint) -> Workspace {
     {
         return candidate
     }
+    if !config.persistentWorkspaces.isEmpty {
+        if let persistentCandidate = Workspace.all.first(where: { workspace in
+            config.persistentWorkspaces.contains(workspace.name)
+                && !workspace.isVisible
+                && workspace.forceAssignedMonitor == nil
+        }) {
+            return persistentCandidate
+        }
+    }
     return (1 ... Int.max).lazy
         .map { Workspace.get(byName: String($0)) }
         .first { $0.isEffectivelyEmpty && !$0.isVisible && !config.persistentWorkspaces.contains($0.name) && $0.forceAssignedMonitor == nil }


### PR DESCRIPTION
## Summary

This PR adjusts the `getStubWorkspace` logic to consider `persistent-workspaces` before falling back to creating new ephemeral workspaces. When a monitor needs a stub workspace (for example, after moving a workspace to another monitor), AeroSpace will now try to reuse a suitable persistent workspace if one is available.

And, thanks for you great job!

## Details

Previously, `getStubWorkspace(forPoint:)` used the following strategy:

1. Try to reuse the previously visible workspace for this monitor
2. Otherwise, pick any invisible workspace whose `workspaceMonitor` matches the target monitor.
3. Otherwise, create/select a new workspace with a numeric name (`1`, `2`, …)

This PR inserts an additional step between (2) and (3):

1. ...
2. ...
3. If `persistent-workspaces` is configured, try to pick a suitable persistent workspace as the stub.
4. ...

Ideally, I hoped we could find a workspace that isn’t assigned to any monitor. However, since all workspaces currently have a `workspaceMonitor` (at least assigned to `mainMonitor`), implementing that would require a major refactor — we’d need to make this variable optional and update all related code.

So, I decided to relax the condition: if we can find an invisible persistent workspace, that would still be better than using a numeric one, since I’m only using alpha workspaces.

If such a persistent workspace exists, it is used as the stub workspace for the monitor. If not, the logic falls back to the existing step (3) and creates/selects a new ephemeral numeric workspace as before.


## PR checklist

- [x] Explain your changes in the relevant commit messages rather than in the PR description. The PR description must not contain more information than the commit messages (except for images and other media).
- [x] Each commit must explain what/why/how and motivation in its description. https://cbea.ms/git-commit/
- [x] Don't forget to link the appropriate issues/discussions in commit messages (if applicable).
- [x] Each commit must be an atomic change (a PR may contain several commits). Don't introduce new functional changes together with refactorings in the same commit.
- [x] The GitHub Actions CI must pass (you can fix failures after submitting a PR).

Failure to follow the checklist with no apparent reasons will result in silent PR rejection.
