### PR TITLE
Add Vim-like focus history navigation (back/forward)

### DIFF
--- a/Sources/AppBundle/command/impl/FocusBackAndForthCommand.swift
+++ b/Sources/AppBundle/command/impl/FocusBackAndForthCommand.swift
@@ -9,7 +9,7 @@ struct FocusBackAndForthCommand: Command {
         if let prevFocus {
             return setFocus(to: prevFocus)
         } else {
-            return io.err("Prev window has been closed")
+            return io.err("No previous window in focus history")
         }
     }
 }

--- a/Sources/AppBundle/command/impl/FocusCommand.swift
+++ b/Sources/AppBundle/command/impl/FocusCommand.swift
@@ -55,6 +55,18 @@ struct FocusCommand: Command {
                     }
                 }
                 return windows[targetIndex].focusWindow()
+            case .historyBack:
+                if let targetFocus = focusHistoryBack() {
+                    return setFocus(to: targetFocus)
+                } else {
+                    return io.err("Already at the beginning of focus history")
+                }
+            case .historyForward:
+                if let targetFocus = focusHistoryForward() {
+                    return setFocus(to: targetFocus)
+                } else {
+                    return io.err("Already at the end of focus history")
+                }
         }
     }
 }

--- a/Sources/AppBundleTests/command/FocusCommandTest.swift
+++ b/Sources/AppBundleTests/command/FocusCommandTest.swift
@@ -239,6 +239,150 @@ final class FocusCommandTest: XCTestCase {
         assertEquals(try await FocusCommand(args: args).run(.defaultEnv, .emptyStdin).exitCode, 0)
         assertEquals(focus.windowOrNil?.windowId, 1)
     }
+
+    func testFocusHistoryBackForward() async throws {
+        let workspace = Workspace.get(byName: name)
+        var w1: Window!
+        var w2: Window!
+        var w3: Window!
+        workspace.rootTilingContainer.apply {
+            w1 = TestWindow.new(id: 1, parent: $0)
+            w2 = TestWindow.new(id: 2, parent: $0)
+            w3 = TestWindow.new(id: 3, parent: $0)
+        }
+
+        // Build focus history: w1 -> w2 -> w3
+        assertEquals(w1.focusWindow(), true)
+        checkOnFocusChangedCallbacks()
+        assertEquals(w2.focusWindow(), true)
+        checkOnFocusChangedCallbacks()
+        assertEquals(w3.focusWindow(), true)
+        checkOnFocusChangedCallbacks()
+
+        assertEquals(focus.windowOrNil?.windowId, 3)
+
+        // Go back to w2
+        assertEquals(try await FocusCommand.new(historyNavigation: .back).run(.defaultEnv, .emptyStdin).exitCode, 0)
+        assertEquals(focus.windowOrNil?.windowId, 2)
+
+        // Go back to w1
+        assertEquals(try await FocusCommand.new(historyNavigation: .back).run(.defaultEnv, .emptyStdin).exitCode, 0)
+        assertEquals(focus.windowOrNil?.windowId, 1)
+
+        // Go forward to w2
+        assertEquals(try await FocusCommand.new(historyNavigation: .forward).run(.defaultEnv, .emptyStdin).exitCode, 0)
+        assertEquals(focus.windowOrNil?.windowId, 2)
+
+        // Go forward to w3
+        assertEquals(try await FocusCommand.new(historyNavigation: .forward).run(.defaultEnv, .emptyStdin).exitCode, 0)
+        assertEquals(focus.windowOrNil?.windowId, 3)
+
+        // Forward at end should fail
+        assertEquals(try await FocusCommand.new(historyNavigation: .forward).run(.defaultEnv, .emptyStdin).exitCode, 1)
+        assertEquals(focus.windowOrNil?.windowId, 3)
+    }
+
+    func testFocusHistoryTruncation() async throws {
+        let workspace = Workspace.get(byName: name)
+        var w1: Window!
+        var w2: Window!
+        var w3: Window!
+        var w4: Window!
+        workspace.rootTilingContainer.apply {
+            w1 = TestWindow.new(id: 1, parent: $0)
+            w2 = TestWindow.new(id: 2, parent: $0)
+            w3 = TestWindow.new(id: 3, parent: $0)
+            w4 = TestWindow.new(id: 4, parent: $0)
+        }
+
+        // Build focus history: w1 -> w2 -> w3
+        assertEquals(w1.focusWindow(), true)
+        checkOnFocusChangedCallbacks()
+        assertEquals(w2.focusWindow(), true)
+        checkOnFocusChangedCallbacks()
+        assertEquals(w3.focusWindow(), true)
+        checkOnFocusChangedCallbacks()
+
+        // Go back to w2
+        assertEquals(try await FocusCommand.new(historyNavigation: .back).run(.defaultEnv, .emptyStdin).exitCode, 0)
+        assertEquals(focus.windowOrNil?.windowId, 2)
+
+        // Focus new window w4 (should truncate forward history)
+        assertEquals(w4.focusWindow(), true)
+        checkOnFocusChangedCallbacks()
+        assertEquals(focus.windowOrNil?.windowId, 4)
+
+        // Forward should now fail (w3 was truncated from history)
+        assertEquals(try await FocusCommand.new(historyNavigation: .forward).run(.defaultEnv, .emptyStdin).exitCode, 1)
+        assertEquals(focus.windowOrNil?.windowId, 4)
+
+        // But back should work and go to w2
+        assertEquals(try await FocusCommand.new(historyNavigation: .back).run(.defaultEnv, .emptyStdin).exitCode, 0)
+        assertEquals(focus.windowOrNil?.windowId, 2)
+    }
+
+    func testFocusHistoryAtBeginning() async throws {
+        let workspace = Workspace.get(byName: name)
+        var w1: Window!
+        workspace.rootTilingContainer.apply {
+            w1 = TestWindow.new(id: 1, parent: $0)
+        }
+
+        assertEquals(w1.focusWindow(), true)
+        checkOnFocusChangedCallbacks()
+        assertEquals(focus.windowOrNil?.windowId, 1)
+
+        // Back at beginning should fail
+        assertEquals(try await FocusCommand.new(historyNavigation: .back).run(.defaultEnv, .emptyStdin).exitCode, 1)
+        assertEquals(focus.windowOrNil?.windowId, 1)
+    }
+
+    func testFocusHistorySkipsClosedWindows() async throws {
+        let workspace = Workspace.get(byName: name)
+        var w1: Window!
+        var w2: Window!
+        var w3: Window!
+        var w4: Window!
+        workspace.rootTilingContainer.apply {
+            w1 = TestWindow.new(id: 1, parent: $0)
+            w2 = TestWindow.new(id: 2, parent: $0)
+            w3 = TestWindow.new(id: 3, parent: $0)
+            w4 = TestWindow.new(id: 4, parent: $0)
+        }
+
+        // Build focus history: w1 -> w2 -> w3 -> w4
+        // Start with w1 to establish initial focus, then cycle through
+        assertEquals(w1.focusWindow(), true)
+        checkOnFocusChangedCallbacks()
+        assertEquals(w2.focusWindow(), true)
+        checkOnFocusChangedCallbacks()
+        assertEquals(w3.focusWindow(), true)
+        checkOnFocusChangedCallbacks()
+        assertEquals(w4.focusWindow(), true)
+        checkOnFocusChangedCallbacks()
+
+        assertEquals(focus.windowOrNil?.windowId, 4)
+
+        // Close w3 (a middle window in history)
+        w3.closeAxWindow()
+
+        // Go back should skip w3 and go directly to w2
+        assertEquals(try await FocusCommand.new(historyNavigation: .back).run(.defaultEnv, .emptyStdin).exitCode, 0)
+        assertEquals(focus.windowOrNil?.windowId, 2)
+
+        // Go forward should skip w3 and go directly to w4
+        assertEquals(try await FocusCommand.new(historyNavigation: .forward).run(.defaultEnv, .emptyStdin).exitCode, 0)
+        assertEquals(focus.windowOrNil?.windowId, 4)
+    }
+
+    func testFocusHistoryParsing() {
+        testParseCommandSucc("focus back", FocusCmdArgs(rawArgs: [], historyNavigation: .back))
+        testParseCommandSucc("focus forward", FocusCmdArgs(rawArgs: [], historyNavigation: .forward))
+
+        // back/forward should be incompatible with other flags
+        XCTAssertTrue(parseCommand("focus --ignore-floating back").errorOrNil?.contains("incompatible") == true)
+        XCTAssertTrue(parseCommand("focus --boundaries workspace back").errorOrNil?.contains("incompatible") == true)
+    }
 }
 
 extension FocusCommand {
@@ -247,5 +391,8 @@ extension FocusCommand {
     }
     static func new(dfsRelative: DfsNextPrev) -> FocusCommand {
         FocusCommand(args: FocusCmdArgs(rawArgs: [], cardinalOrDfsDirection: .dfsRelative(dfsRelative)))
+    }
+    static func new(historyNavigation: HistoryNavigation) -> FocusCommand {
+        FocusCommand(args: FocusCmdArgs(rawArgs: [], historyNavigation: historyNavigation))
     }
 }

--- a/Sources/AppBundleTests/testUtil.swift
+++ b/Sources/AppBundleTests/testUtil.swift
@@ -38,6 +38,8 @@ func setUpWorkspacesForTests() {
 
     TestApp.shared.focusedWindow = nil
     TestApp.shared.windows = []
+
+    resetFocusHistoryForTests()
 }
 
 extension ParsedCmd {

--- a/Sources/Common/cmdArgs/impl/FocusCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/FocusCmdArgs.swift
@@ -12,14 +12,38 @@ public struct FocusCmdArgs: CmdArgs {
             "--window-id": SubArgParser(\.windowId, upcastSubArgParserFun(parseUInt32SubArg)),
             "--dfs-index": SubArgParser(\.dfsIndex, upcastSubArgParserFun(parseUInt32SubArg)),
         ],
-        posArgs: [ArgParser(\.cardinalOrDfsDirection, upcastArgParserFun(parseCardinalOrDfsDirection))],
+        posArgs: [ArgParser(\.cardinalDfsOrHistory, upcastArgParserFun(parseCardinalDfsOrHistory))],
     )
 
     public var rawBoundaries: Boundaries? = nil // todo cover boundaries wrapping with tests
     public var rawBoundariesAction: WhenBoundariesCrossed? = nil
     public var dfsIndex: UInt32? = nil
-    public var cardinalOrDfsDirection: CardinalOrDfsDirection? = nil
+    public var cardinalDfsOrHistory: CardinalDfsOrHistory? = nil
     public var floatingAsTiling: Bool = true
+
+    // Compatibility accessor for existing code
+    public var cardinalOrDfsDirection: CardinalOrDfsDirection? {
+        get {
+            switch cardinalDfsOrHistory {
+                case .cardinalOrDfs(let dir): return dir
+                case .history, nil: return nil
+            }
+        }
+        set {
+            if let dir = newValue {
+                cardinalDfsOrHistory = .cardinalOrDfs(dir)
+            } else {
+                cardinalDfsOrHistory = nil
+            }
+        }
+    }
+
+    public var historyNavigation: HistoryNavigation? {
+        switch cardinalDfsOrHistory {
+            case .history(let nav): return nav
+            case .cardinalOrDfs, nil: return nil
+        }
+    }
 
     public init(rawArgs: StrArrSlice, cardinalOrDfsDirection: CardinalOrDfsDirection) {
         self.commonState = .init(rawArgs)
@@ -36,6 +60,11 @@ public struct FocusCmdArgs: CmdArgs {
         self.dfsIndex = dfsIndex
     }
 
+    public init(rawArgs: StrArrSlice, historyNavigation: HistoryNavigation) {
+        self.commonState = .init(rawArgs)
+        self.cardinalDfsOrHistory = .history(historyNavigation)
+    }
+
     public enum Boundaries: String, CaseIterable, Equatable, Sendable {
         case workspace
         case allMonitorsOuterFrame = "all-monitors-outer-frame"
@@ -48,11 +77,50 @@ public struct FocusCmdArgs: CmdArgs {
     }
 }
 
+public enum HistoryNavigation: String, CaseIterable, Equatable, Sendable {
+    case back
+    case forward
+}
+
+public enum CardinalDfsOrHistory: Equatable, Sendable {
+    case cardinalOrDfs(CardinalOrDfsDirection)
+    case history(HistoryNavigation)
+}
+
+extension CardinalDfsOrHistory: CaseIterable {
+    public static var allCases: [CardinalDfsOrHistory] {
+        CardinalOrDfsDirection.allCases.map { .cardinalOrDfs($0) } + HistoryNavigation.allCases.map { .history($0) }
+    }
+}
+
+extension CardinalDfsOrHistory: RawRepresentable {
+    public typealias RawValue = String
+
+    public init?(rawValue: RawValue) {
+        if let dir = CardinalOrDfsDirection(rawValue: rawValue) {
+            self = .cardinalOrDfs(dir)
+        } else if let nav = HistoryNavigation(rawValue: rawValue) {
+            self = .history(nav)
+        } else {
+            return nil
+        }
+    }
+
+    public var rawValue: RawValue {
+        switch self {
+            case .cardinalOrDfs(let dir): dir.rawValue
+            case .history(let nav): nav.rawValue
+        }
+    }
+}
+
 public enum FocusCmdTarget {
     case direction(CardinalDirection)
     case windowId(UInt32)
     case dfsIndex(UInt32)
     case dfsRelative(DfsNextPrev)
+    case historyBack
+    case historyForward
 
     var isDfsRelative: Bool {
         if case .dfsRelative = self {
@@ -61,10 +129,23 @@ public enum FocusCmdTarget {
             return false
         }
     }
+
+    var isHistory: Bool {
+        switch self {
+            case .historyBack, .historyForward: true
+            default: false
+        }
+    }
 }
 
 extension FocusCmdArgs {
     public var target: FocusCmdTarget {
+        if let historyNavigation {
+            return switch historyNavigation {
+                case .back: .historyBack
+                case .forward: .historyForward
+            }
+        }
         if let cardinalOrDfsDirection {
             return switch cardinalOrDfsDirection {
                 case .direction(let dir): .direction(dir)
@@ -91,8 +172,8 @@ public func parseFocusCmdArgs(_ args: StrArrSlice) -> ParsedCmd<FocusCmdArgs> {
                 ? .failure("\(raw.boundaries.rawValue) and \(raw.boundariesAction.rawValue) is an invalid combination of values")
                 : .cmd(raw)
         }
-        .filter("Mandatory argument is missing. \(CardinalOrDfsDirection.unionLiteral), --window-id or --dfs-index is required") {
-            $0.cardinalOrDfsDirection != nil || $0.windowId != nil || $0.dfsIndex != nil
+        .filter("Mandatory argument is missing. \(CardinalDfsOrHistory.unionLiteral), --window-id or --dfs-index is required") {
+            $0.cardinalDfsOrHistory != nil || $0.windowId != nil || $0.dfsIndex != nil
         }
         .filter("--window-id is incompatible with other options") {
             $0.windowId == nil || $0 == FocusCmdArgs(rawArgs: args, windowId: $0.windowId.orDie())
@@ -102,6 +183,9 @@ public func parseFocusCmdArgs(_ args: StrArrSlice) -> ParsedCmd<FocusCmdArgs> {
         }
         .filter("(dfs-next|dfs-prev) only supports --boundaries workspace") {
             $0.target.isDfsRelative.implies($0.boundaries == .workspace)
+        }
+        .filter("(back|forward) is incompatible with other options") {
+            !$0.target.isHistory || ($0.rawBoundaries == nil && $0.rawBoundariesAction == nil && $0.floatingAsTiling == true)
         }
 }
 
@@ -119,4 +203,8 @@ private func parseBoundaries(i: SubArgParserInput) -> ParsedCliArgs<FocusCmdArgs
     } else {
         return .fail("<boundary> is mandatory", advanceBy: 0)
     }
+}
+
+func parseCardinalDfsOrHistory(i: ArgParserInput) -> ParsedCliArgs<CardinalDfsOrHistory> {
+    .init(parseEnum(i.arg, CardinalDfsOrHistory.self), advanceBy: 1)
 }

--- a/Sources/Common/cmdHelpGenerated.swift
+++ b/Sources/Common/cmdHelpGenerated.swift
@@ -47,6 +47,7 @@ let focus_help_generated = """
                  (dfs-next|dfs-prev)
        OR: focus [-h|--help] --window-id <window-id>
        OR: focus [-h|--help] --dfs-index <dfs-index>
+       OR: focus [-h|--help] (back|forward)
     """
 let fullscreen_help_generated = """
     USAGE: fullscreen [-h|--help]     [--window-id <window-id>] [--no-outer-gaps]

--- a/docs/aerospace-focus.adoc
+++ b/docs/aerospace-focus.adoc
@@ -17,6 +17,7 @@ aerospace focus [-h|--help] [--ignore-floating]
                 (dfs-next|dfs-prev)
 aerospace focus [-h|--help] --window-id <window-id>
 aerospace focus [-h|--help] --dfs-index <dfs-index>
+aerospace focus [-h|--help] (back|forward)
 
 // end::synopsis[]
 
@@ -70,6 +71,15 @@ Set focus to the nearest window in the given direction.
 (dfs-next|dfs-prev)::
 Set focus to the window before or after the current window in the depth-first order (top-to-bottom and left-to-right) of windows in the current workspace tree.
 In this mode, `--boundaries` must be `workspace` (the default) and `--boundaries-action` can be set to one of `(stop|fail|wrap-around-the-workspace)`.
+
+(back|forward)::
+Navigate focus history, similar to Vim's Ctrl-O (back) and Ctrl-I (forward).
+`focus back` moves to the previously focused window in the history stack.
+`focus forward` moves forward in the history stack after navigating back.
+History is recorded automatically when focus changes.
+When you focus a new window while in the middle of history, the forward history is truncated (Vim-like behavior).
+Closed windows are automatically skipped.
+This mode is incompatible with other flags like `--ignore-floating`, `--boundaries`, or `--boundaries-action`.
 
 // end::body[]
 


### PR DESCRIPTION
Implements Vim-like focus history navigation (focus back/focus forward) and makes focus-back-and-forth resilient to closed windows by using the shared history stack.

Closes #1024