### PR TITLE
Add app-specific modes with inheritance

### DIFF
--- a/Sources/AppBundle/command/impl/ModeCommand.swift
+++ b/Sources/AppBundle/command/impl/ModeCommand.swift
@@ -6,7 +6,21 @@ struct ModeCommand: Command {
     /*conforms*/ let shouldResetClosedWindowsCache = false
 
     func run(_ env: CmdEnv, _ io: CmdIo) async throws -> BinaryExitCode {
-        try await activateMode(args.targetMode.val)
+        let targetMode = args.targetMode.val
+
+        if isAutoMode(targetMode) {
+            isManualModeOverride = false
+            if targetMode == mainModeId {
+                if let appMode = lastAutoAppMode {
+                    try await activateMode(appMode)
+                    return .succ
+                }
+            }
+        } else {
+            isManualModeOverride = true
+        }
+
+        try await activateMode(targetMode)
         return .succ
     }
 }

--- a/Sources/AppBundle/config/Config.swift
+++ b/Sources/AppBundle/config/Config.swift
@@ -58,6 +58,7 @@ struct Config: ConvenienceCopyable {
     var gaps: Gaps = .zero
     var workspaceToMonitorForceAssignment: [String: [MonitorDescription]] = [:]
     var modes: [String: Mode] = [:]
+    var appModes: [String: String] = [:]
     var onWindowDetected: [WindowDetectedCallback] = []
     var onModeChanged: [any Command] = []
 }

--- a/Sources/AppBundle/config/HotkeyBinding.swift
+++ b/Sources/AppBundle/config/HotkeyBinding.swift
@@ -26,6 +26,15 @@ extension HotKey {
 }
 
 @MainActor var activeMode: String? = mainModeId
+@MainActor var isManualModeOverride: Bool = false
+@MainActor var lastAutoAppMode: String? = nil
+
+@MainActor func isAutoMode(_ modeName: String?) -> Bool {
+    guard let name = modeName else { return true }
+    if name == mainModeId { return true }
+    return config.modes[name]?.app != nil
+}
+
 @MainActor func activateMode(_ targetMode: String?) async throws {
     let targetBindings = targetMode.flatMap { config.modes[$0] }?.bindings ?? [:]
     for binding in targetBindings.values where !hotkeys.keys.contains(binding.descriptionWithKeyCode) {

--- a/Sources/AppBundle/config/Mode.swift
+++ b/Sources/AppBundle/config/Mode.swift
@@ -1,42 +1,116 @@
 import Common
 import HotKey
+import OrderedCollections
 
 struct Mode: ConvenienceCopyable, Equatable, Sendable {
-    var bindings: [String: HotkeyBinding]
+    var inherits: String? = nil
+    var app: String? = nil
+    var unbind: [String] = []
+    var bindings: [String: HotkeyBinding] = [:]
 
-    static let zero = Mode(bindings: [:])
+    static let zero = Mode()
 }
 
-func parseModes(_ raw: Json, _ backtrace: ConfigBacktrace, _ errors: inout [ConfigParseError], _ mapping: [String: Key]) -> [String: Mode] {
+func parseModes(_ raw: Json, _ backtrace: ConfigBacktrace, _ errors: inout [ConfigParseError], _ mapping: [String: Key]) -> ([String: Mode], [String: String]) {
     guard let rawTable = raw.asDictOrNil else {
         errors += [expectedActualTypeError(expected: .table, actual: raw.tomlType, backtrace)]
-        return [:]
+        return ([:], [:])
     }
     var result: [String: Mode] = [:]
+
     for (key, value) in rawTable {
         result[key] = parseMode(value, backtrace + .key(key), &errors, mapping)
     }
+
     if !result.keys.contains(mainModeId) {
         errors += [.semantic(backtrace, "Please specify '\(mainModeId)' mode")]
     }
-    return result
+
+    var modesWithInheritanceErrors: Set<String> = []
+    for (modeName, mode) in result {
+        if mode.inherits != nil {
+            if !validateInheritanceChain(modeName, result, backtrace, &errors) {
+                modesWithInheritanceErrors.insert(modeName)
+            }
+        }
+    }
+
+    flattenModeBindings(&result, skipping: modesWithInheritanceErrors)
+
+    var appModes: [String: String] = [:]
+    for (modeName, mode) in result {
+        if let bundleId = mode.app {
+            appModes[bundleId] = modeName
+        }
+    }
+
+    return (result, appModes)
+}
+
+private func validateInheritanceChain(_ modeName: String, _ modes: [String: Mode], _ backtrace: ConfigBacktrace, _ errors: inout [ConfigParseError]) -> Bool {
+    var visited: OrderedSet<String> = []
+    var current: String? = modeName
+
+    while let name = current {
+        if visited.contains(name) {
+            let chain = visited.joined(separator: " -> ")
+            errors += [.semantic(backtrace + .key(modeName), "Circular inheritance detected: \(chain) -> \(name)")]
+            return false
+        }
+        visited.append(name)
+        current = modes[name]?.inherits
+
+        if let parent = current, modes[parent] == nil {
+            errors += [.semantic(backtrace + .key(modeName), "Mode '\(modeName)' inherits from undefined mode '\(parent)'")]
+            return false
+        }
+    }
+    return true
+}
+
+private func flattenModeBindings(_ modes: inout [String: Mode], skipping: Set<String> = []) {
+    var resolvedCache: [String: [String: HotkeyBinding]] = [:]
+
+    var resolvedBindings: [String: [String: HotkeyBinding]] = [:]
+    for modeName in modes.keys where !skipping.contains(modeName) {
+        resolvedBindings[modeName] = resolveBindings(modeName, modes, &resolvedCache)
+    }
+
+    for (modeName, bindings) in resolvedBindings {
+        modes[modeName]?.bindings = bindings
+    }
+}
+
+private func resolveBindings(_ modeName: String, _ modes: [String: Mode], _ cache: inout [String: [String: HotkeyBinding]]) -> [String: HotkeyBinding] {
+    if let cached = cache[modeName] {
+        return cached
+    }
+
+    guard let mode = modes[modeName] else { return [:] }
+
+    var resolved: [String: HotkeyBinding] = [:]
+    if let parentName = mode.inherits {
+        resolved = resolveBindings(parentName, modes, &cache)
+    }
+
+    for key in mode.unbind {
+        resolved.removeValue(forKey: key)
+    }
+
+    for (key, binding) in mode.bindings {
+        resolved[key] = binding
+    }
+
+    cache[modeName] = resolved
+    return resolved
 }
 
 func parseMode(_ raw: Json, _ backtrace: ConfigBacktrace, _ errors: inout [ConfigParseError], _ mapping: [String: Key]) -> Mode {
-    guard let rawTable: Json.JsonDict = raw.asDictOrNil else {
-        errors += [expectedActualTypeError(expected: .table, actual: raw.tomlType, backtrace)]
-        return .zero
-    }
-
-    var result: Mode = .zero
-    for (key, value) in rawTable {
-        let backtrace = backtrace + .key(key)
-        switch key {
-            case "binding":
-                result.bindings = parseBindings(value, backtrace, &errors, mapping)
-            default:
-                errors += [unknownKeyError(backtrace)]
-        }
-    }
-    return result
+    let modeParser: [String: any ParserProtocol<Mode>] = [
+        "binding": Parser(\.bindings) { raw, backtrace, errors in parseBindings(raw, backtrace, &errors, mapping) },
+        "inherits": Parser(\.inherits) { parseString($0, $1).map(String?.some) },
+        "app": Parser(\.app) { parseString($0, $1).map(String?.some) },
+        "unbind": Parser(\.unbind, parseArrayOfStrings),
+    ]
+    return parseTable(raw, .zero, modeParser, backtrace, &errors)
 }

--- a/Sources/AppBundle/config/parseConfig.swift
+++ b/Sources/AppBundle/config/parseConfig.swift
@@ -227,8 +227,10 @@ func tomlAnyToParsedConfigRecursive(any: Any, _ backtrace: ConfigBacktrace) -> P
     }
 
     // Parse modeConfigRootKey after keyMappingConfigRootKey
-    if let modes = rawTable[modeConfigRootKey].flatMap({ parseModes($0, .rootKey(modeConfigRootKey), &errors, config.keyMapping.resolve()) }) {
+    if let rawModes = rawTable[modeConfigRootKey] {
+        let (modes, appModes) = parseModes(rawModes, .rootKey(modeConfigRootKey), &errors, config.keyMapping.resolve())
         config.modes = modes
+        config.appModes = appModes
     }
 
     if config.configVersion <= 1 {
@@ -353,7 +355,7 @@ private func parsePersistentWorkspaces(_ raw: Json, _ backtrace: ConfigBacktrace
         }
 }
 
-private func parseArrayOfStrings(_ raw: Json, _ backtrace: ConfigBacktrace) -> ParsedConfig<[String]> {
+func parseArrayOfStrings(_ raw: Json, _ backtrace: ConfigBacktrace) -> ParsedConfig<[String]> {
     parseTomlArray(raw, backtrace)
         .flatMap { arr in
             arr.enumerated().mapAllOrFailure { (index, elem) in

--- a/Sources/AppBundle/focus.swift
+++ b/Sources/AppBundle/focus.swift
@@ -173,12 +173,28 @@ extension Workspace {
         windowId: focus.windowOrNil?.windowId,
         workspace: focus.workspace.name,
     ))
+    updateAutoModeForFocusedApp(focus)
     if config.onFocusChanged.isEmpty { return }
     guard let token: RunSessionGuard = .isServerEnabled else { return }
     // todo potential optimization: don't run runSession if we are already in runSession
     Task {
         try await runLightSession(.onFocusChanged, token) {
             _ = try await config.onFocusChanged.runCmdSeq(.defaultEnv.withFocus(focus), .emptyStdin)
+        }
+    }
+}
+
+@MainActor private func updateAutoModeForFocusedApp(_ focus: LiveFocus) {
+    let bundleId = focus.windowOrNil?.app.rawAppBundleId
+    let targetAutoMode: String? = bundleId.flatMap { config.appModes[$0] }
+    lastAutoAppMode = targetAutoMode
+
+    if !isManualModeOverride {
+        let effectiveMode = targetAutoMode ?? mainModeId
+        if activeMode != effectiveMode {
+            Task {
+                try? await activateMode(effectiveMode)
+            }
         }
     }
 }

--- a/Sources/AppBundleTests/command/ListModesTest.swift
+++ b/Sources/AppBundleTests/command/ListModesTest.swift
@@ -19,9 +19,9 @@ final class ListModesTest: XCTestCase {
     @MainActor
     func testListModesOutput() async throws {
         config.modes = [
-            "main": Mode(bindings: [:]),
-            "service": Mode(bindings: [:]),
-            "resize": Mode(bindings: [:]),
+            "main": Mode(),
+            "service": Mode(),
+            "resize": Mode(),
         ]
 
         let defaultResult = try await ListModesCommand(args: ListModesCmdArgs(rawArgs: [])).run(.defaultEnv, .emptyStdin)

--- a/Sources/AppBundleTests/config/ConfigTest.swift
+++ b/Sources/AppBundleTests/config/ConfigTest.swift
@@ -91,6 +91,166 @@ final class ConfigTest: XCTestCase {
         )
     }
 
+    func testParseModeInheritance() {
+        let (config, errors) = parseConfig(
+            """
+            [mode.main.binding]
+                alt-h = 'focus left'
+            [mode.resize]
+                inherits = 'main'
+            [mode.resize.binding]
+                h = 'resize width -50'
+            """,
+        )
+        assertEquals(errors, [])
+        assertEquals(config.modes["resize"]?.inherits, "main")
+        // After flattening, resize should have both bindings
+        // Debug: print binding keys to understand format
+        let resizeBindingKeys = config.modes["resize"]?.bindings.keys.sorted() ?? []
+        let mainBindingKeys = config.modes[mainModeId]?.bindings.keys.sorted() ?? []
+        // The binding keys should contain inherited bindings from main
+        XCTAssertEqual(resizeBindingKeys.count, 2, "Expected 2 bindings, got \(resizeBindingKeys)")
+        XCTAssertEqual(mainBindingKeys.count, 1, "Expected 1 main binding, got \(mainBindingKeys)")
+    }
+
+    func testCircularInheritanceError() {
+        let (_, errors) = parseConfig(
+            """
+            [mode.main.binding]
+            [mode.a]
+                inherits = 'b'
+            [mode.a.binding]
+            [mode.b]
+                inherits = 'a'
+            [mode.b.binding]
+            """,
+        )
+        XCTAssertTrue(errors.contains { $0.contains("Circular inheritance") })
+    }
+
+    func testUndefinedParentModeError() {
+        let (_, errors) = parseConfig(
+            """
+            [mode.main.binding]
+            [mode.resize]
+                inherits = 'nonexistent'
+            [mode.resize.binding]
+            """,
+        )
+        XCTAssertTrue(errors.contains { $0.contains("undefined mode") })
+    }
+
+    func testParseAppModes() {
+        let (config, errors) = parseConfig(
+            """
+            [mode.main.binding]
+                alt-h = 'focus left'
+            [mode.firefox]
+                app = 'org.mozilla.firefox'
+                inherits = 'main'
+            [mode.firefox.binding]
+                ctrl-t = 'exec-and-forget echo test'
+            """,
+        )
+        assertEquals(errors, [])
+        assertEquals(config.appModes["org.mozilla.firefox"], "firefox")
+        XCTAssertNotNil(config.modes["firefox"])
+        assertEquals(config.modes["firefox"]?.app, "org.mozilla.firefox")
+        // Should have 2 bindings: inherited alt-h from main + its own ctrl-t
+        XCTAssertEqual(config.modes["firefox"]?.bindings.count, 2)
+    }
+
+    func testInheritanceBindingOverride() {
+        let (config, errors) = parseConfig(
+            """
+            [mode.main.binding]
+                alt-h = 'focus left'
+            [mode.vim]
+                inherits = 'main'
+            [mode.vim.binding]
+                alt-h = 'focus right'
+            """,
+        )
+        assertEquals(errors, [])
+        // vim should have exactly 1 binding (alt-h overrides parent's alt-h)
+        XCTAssertEqual(config.modes["vim"]?.bindings.count, 1)
+        // Get the binding (using the key from main's binding which should be the same)
+        let mainBinding = config.modes[mainModeId]?.bindings.values.first
+        let vimBindingKey = mainBinding?.descriptionWithKeyCode ?? ""
+        let binding = config.modes["vim"]?.bindings[vimBindingKey]
+        // Should have child's command (focus right), not parent's (focus left)
+        XCTAssertNotNil(binding)
+        XCTAssertTrue(binding?.commands.first is FocusCommand)
+        let focusCmd = binding?.commands.first as? FocusCommand
+        // Verify it's focus right (child) not focus left (parent)
+        assertEquals(focusCmd?.args.cardinalOrDfsDirection, .direction(.right))
+    }
+
+    func testDeepInheritanceChain() {
+        let (config, errors) = parseConfig(
+            """
+            [mode.main.binding]
+                alt-h = 'focus left'
+            [mode.base]
+                inherits = 'main'
+            [mode.base.binding]
+                alt-j = 'focus down'
+            [mode.child]
+                inherits = 'base'
+            [mode.child.binding]
+                alt-k = 'focus up'
+            """,
+        )
+        assertEquals(errors, [])
+        // child should have all three bindings
+        XCTAssertEqual(config.modes["child"]?.bindings.count, 3)
+        // base should have 2 bindings (main's + its own)
+        XCTAssertEqual(config.modes["base"]?.bindings.count, 2)
+    }
+
+    func testUnbindRemovesInheritedBindings() {
+        let (config, errors) = parseConfig(
+            """
+            [mode.main.binding]
+                alt-h = 'focus left'
+                alt-j = 'focus down'
+                alt-k = 'focus up'
+                alt-l = 'focus right'
+            [mode.emacs]
+                inherits = 'main'
+                unbind = ['alt-h', 'alt-j', 'alt-k', 'alt-l']
+            [mode.emacs.binding]
+                ctrl-x = 'exec-and-forget echo test'
+            """,
+        )
+        assertEquals(errors, [])
+        // main should have 4 bindings
+        XCTAssertEqual(config.modes[mainModeId]?.bindings.count, 4)
+        // emacs should have only 1 binding (ctrl-x), all alt-* removed
+        XCTAssertEqual(config.modes["emacs"]?.bindings.count, 1)
+        // Verify the remaining binding is ctrl-x, not any of the unbound ones
+        let bindingKeys = config.modes["emacs"]?.bindings.keys.map { $0 } ?? []
+        XCTAssertTrue(bindingKeys.allSatisfy { !$0.contains("alt") })
+    }
+
+    func testUnbindPartialRemoval() {
+        let (config, errors) = parseConfig(
+            """
+            [mode.main.binding]
+                alt-h = 'focus left'
+                alt-j = 'focus down'
+                alt-k = 'focus up'
+            [mode.vim]
+                inherits = 'main'
+                unbind = ['alt-h']
+            [mode.vim.binding]
+            """,
+        )
+        assertEquals(errors, [])
+        // vim should have 2 bindings (alt-j and alt-k, but not alt-h)
+        XCTAssertEqual(config.modes["vim"]?.bindings.count, 2)
+    }
+
     func testModesMustContainDefaultModeError() {
         let (config, errors) = parseConfig(
             """

--- a/Sources/AppBundleTests/testUtil.swift
+++ b/Sources/AppBundleTests/testUtil.swift
@@ -22,7 +22,7 @@ func setUpWorkspacesForTests() {
     config.defaultRootContainerOrientation = .horizontal // Make default layout predictable
 
     // Don't create any bindings and workspaces for tests
-    config.modes = [mainModeId: Mode(bindings: [:])]
+    config.modes = [mainModeId: Mode()]
     config.persistentWorkspaces = []
 
     for workspace in Workspace.all {


### PR DESCRIPTION
## Summary

Add support for app-specific keyboard modes that automatically activate when a specific application is focused.

Closes #1454
Closes #412

## How it works

App-specific modes are regular modes with three new optional properties:

- **`app`** - Bundle ID that triggers automatic mode switching when that app is focused
- **`inherits`** - Parent mode to inherit bindings from (avoids duplicating all your main bindings)
- **`unbind`** - List of inherited bindings to remove (lets keys pass through to the app)

```toml
[mode.emacs]
    app = 'org.gnu.Emacs'
    inherits = 'main'
    unbind = ['alt-h', 'alt-j', 'alt-k', 'alt-l']

[mode.emacs.binding]
    alt-x = 'exec-and-forget echo emacs-specific'
```

### Automatic mode switching

- When an app with a matching bundle ID is focused, AeroSpace switches to that mode
- When focus moves to an app without a matching mode, AeroSpace returns to `main`
- Manual mode switches (e.g., `mode service`) override auto-switching until returning to `main`

### Inheritance

Modes can inherit bindings from a parent mode. The child mode gets all parent bindings, and can:
- Override specific bindings by redefining them
- Remove specific bindings using `unbind`
- Add new bindings

Inheritance chains are supported (e.g., `child` inherits from `base` which inherits from `main`). Circular inheritance is detected and reported as a config error.

## New config options

| Property | Type | Description |
|----------|------|-------------|
| `mode.<name>.app` | string | Bundle ID that triggers this mode |
| `mode.<name>.inherits` | string | Parent mode to inherit bindings from |
| `mode.<name>.unbind` | array | List of inherited bindings to remove |

## Examples

### Pass keys through to Emacs
```toml
[mode.emacs]
    app = 'org.gnu.Emacs'
    inherits = 'main'
    unbind = ['alt-h', 'alt-j', 'alt-k', 'alt-l']
```

### Add Finder-specific binding
```toml
[mode.finder]
    app = 'com.apple.finder'
    inherits = 'main'

[mode.finder.binding]
    ctrl-n = 'exec-and-forget open ~/Downloads'
```