### PR TITLE
feat: add AEROSPACE_MODE environment variable to on-mode-changed callback

### DIFF
--- a/Sources/AppBundle/command/CmdEnv.swift
+++ b/Sources/AppBundle/command/CmdEnv.swift
@@ -3,6 +3,7 @@ import Common
 struct CmdEnv: ConvenienceCopyable {
     var windowId: UInt32?
     var workspaceName: String?
+    var mode: String?
 
     static let defaultEnv: CmdEnv = .init()
     func withFocus(_ focus: LiveFocus) -> CmdEnv {
@@ -10,6 +11,10 @@ struct CmdEnv: ConvenienceCopyable {
             case .window(let wd): .defaultEnv.copy(\.windowId, wd.windowId)
             case .emptyWorkspace(let ws): .defaultEnv.copy(\.workspaceName, ws.name)
         }
+    }
+    
+    func withMode(_ currentMode: String?) -> CmdEnv {
+        copy(\.mode, currentMode)
     }
 
     @MainActor
@@ -20,6 +25,9 @@ struct CmdEnv: ConvenienceCopyable {
         }
         if let workspaceName {
             result[AEROSPACE_WORKSPACE] = workspaceName.description
+        }
+        if let mode {
+            result["AEROSPACE_MODE"] = mode
         }
         return result
     }

--- a/Sources/AppBundle/config/HotkeyBinding.swift
+++ b/Sources/AppBundle/config/HotkeyBinding.swift
@@ -53,7 +53,7 @@ extension HotKey {
     if oldMode != targetMode && !config.onModeChanged.isEmpty {
         guard let token: RunSessionGuard = .isServerEnabled else { return }
         try await runLightSession(.onModeChanged, token) {
-            _ = try await config.onModeChanged.runCmdSeq(.defaultEnv, .emptyStdin)
+            _ = try await config.onModeChanged.runCmdSeq(.defaultEnv.withMode(targetMode), .emptyStdin)
         }
     }
 }


### PR DESCRIPTION

- Add mode field to CmdEnv struct
- Add withMode() method to set current mode in environment
- Pass AEROSPACE_MODE to on-mode-changed callback handlers

This follows the existing pattern used for AEROSPACE_FOCUSED_WORKSPACE. This feature adds the AEROSPACE_MODE environment variable to enable SketchyBar to display real-time mode feedback.

What was added:
  - Environment Variable Support: When AeroSpace changes modes (via the on-mode-changed callback), it now exports the current mode as an environment variable AEROSPACE_MODE.
  - Implementation Details:
  - Added a mode field to the CmdEnv struct to track the current mode
  - Created a withMode() method to set the mode in the command environment
  - Modified the mode change handler to pass the current mode name via AEROSPACE_MODE
  - Integration Pattern: This follows the existing pattern used for AEROSPACE_FOCUSED_WORKSPACE, making it consistent with how AeroSpace already exposes workspace information.

Use Case for SketchyBar:
With this feature, SketchyBar can now:
  - Read the AEROSPACE_MODE environment variable in the on-mode-changed callback script
  - Display the current AeroSpace mode in the status bar in real-time
  - Update the display immediately whenever the mode changes

Example usage in SketchyBar config:

```bash
# In your on-mode-changed callback script
sketchybar --set aerospace_mode label="$AEROSPACE_MODE"
```
This enables users to have immediate visual feedback about which AeroSpace mode is currently active, improving usability and awareness of the window manager's state.

## PR checklist

- [x] Explain your changes in the relevant commit messages rather than in the PR description. The PR description must not contain more information than the commit messages (except for images and other media).
- [x] Each commit must explain what/why/how and motivation in its description. https://cbea.ms/git-commit/
- [ ] Don't forget to link the appropriate issues/discussions in commit messages (if applicable).
- [x] Each commit must be an atomic change (a PR may contain several commits). Don't introduce new functional changes together with refactorings in the same commit.
- [ ] `./run-tests.sh` exits with non-zero exit code.
- [x] Avoid merge commits, always rebase and force push.

Failure to follow the checklist with no apparent reasons will result in silent PR rejection.
