### PR TITLE
Fix focus jumping when same-app floating windows closes

### DIFF
--- a/Sources/AppBundle/tree/MacWindow.swift
+++ b/Sources/AppBundle/tree/MacWindow.swift
@@ -93,6 +93,17 @@ final class MacWindow: Window {
         {
             switch parent.cases {
                 case .tilingContainer, .workspace, .macosHiddenAppsWindowsContainer, .macosFullscreenWindowsContainer:
+                    // Skip focus recalculation if the destroyed window is a dialog/floating window
+                    // belonging to the same app as the currently focused window.
+                    // This prevents focus from jumping away when child frames (e.g., Emacs posframes,
+                    // completion popups) are destroyed.
+                    // https://github.com/nikitabobko/AeroSpace/issues/776
+                    if focus.windowOrNil?.app.pid == app.pid && parent is Workspace {
+                        // The destroyed window was a floating window (dialog) from the same app.
+                        // Don't recalculate focus - let the app handle it internally.
+                        break
+                    }
+
                     let deadWindowFocus = deadWindowWorkspace.toLiveFocus()
                     _ = setFocus(to: deadWindowFocus)
                     // Guard against "Apple Reminders popup" bug: https://github.com/nikitabobko/AeroSpace/issues/201


### PR DESCRIPTION
## Summary

Skip focus recalculation when a floating window (dialog) is destroyed if it belongs to the same app as the currently focused window.

This fixes Emacs child frames (posframes, completion popups, etc.) causing focus to jump to another application when they close.

## References

Fixes #776
Fixes #1220

## PR checklist

- [x] Explain your changes in the relevant commit messages rather than in the PR description. The PR description must not contain more information than the commit messages (except for images and other media).
- [x] Each commit must explain what/why/how and motivation in its description. https://cbea.ms/git-commit/
- [x] Don't forget to link the appropriate issues/discussions in commit messages (if applicable).
- [x] Each commit must be an atomic change (a PR may contain several commits). Don't introduce new functional changes together with refactorings in the same commit.
- [x] `./run-tests.sh` exits with non-zero exit code.
- [x] Avoid merge commits, always rebase and force push.

Failure to follow the checklist with no apparent reasons will result in silent PR rejection.
