### PR TITLE
Fix for macos native tabs changing window ID

### DIFF
--- a/Sources/AppBundle/tree/MacApp.swift
+++ b/Sources/AppBundle/tree/MacApp.swift
@@ -290,7 +290,17 @@ final class MacApp: AbstractApp {
                 }
             }
 
-            for (id, window) in axApp.threadGuarded.get(Ax.windowsAttr) ?? [] {
+            let allWindows = axApp.threadGuarded.get(Ax.windowsAttr) ?? []
+            let currentWindowIds = Set(allWindows.map { $0.0 })
+
+            // Remove windows that are no longer in the AX windows list
+            // This handles macOS native tabs where the window ID changes when tabs are created/switched
+            for (id, window) in alive where !currentWindowIds.contains(id) {
+                dead[id] = window
+            }
+            alive = alive.filter { currentWindowIds.contains($0.key) }
+
+            for (id, window) in allWindows {
                 try job.checkCancellation()
                 try alive.getOrRegisterAxWindow(windowId: id, window, nsApp, job)
             }


### PR DESCRIPTION
I think this fixes #68

After a bit of fiddling, it looks like the issue is that macos changes the window id when tab is created/changed. So I think the fix is to just remove the old window id when it changes.

I've done some testing with the dev build and it seems to work well.

Definitely open to feedback as I have little context on this codebase :)

