### PR TITLE
add list-windows --sort-by

### DIFF
--- a/Sources/AppBundle/command/impl/ListWindowsCommand.swift
+++ b/Sources/AppBundle/command/impl/ListWindowsCommand.swift
@@ -49,12 +49,12 @@ struct ListWindowsCommand: Command {
                 _list.append((window, try await window.title))
             }
             _list = _list.filter { $0.window.isBound }
-            
+
             switch args.sortBy {
-            case .none:
-                _list = _list.sortedBy([{ $0.window.app.name ?? "" }, \.title])
-            case .some(.dfsIndex):
-                break // Keep DFS order (natural tree traversal)
+                case .none:
+                    _list = _list.sortedBy([{ $0.window.app.name ?? "" }, \.title])
+                case .some(.dfsIndex):
+                    break // Keep DFS order (natural tree traversal)
             }
 
             let list = _list.map { AeroObj.window(window: $0.window, title: $0.title) }

--- a/Sources/AppBundle/command/impl/ListWindowsCommand.swift
+++ b/Sources/AppBundle/command/impl/ListWindowsCommand.swift
@@ -49,7 +49,13 @@ struct ListWindowsCommand: Command {
                 _list.append((window, try await window.title))
             }
             _list = _list.filter { $0.window.isBound }
-            _list = _list.sortedBy([{ $0.window.app.name ?? "" }, \.title])
+            
+            switch args.sortBy {
+            case .none:
+                _list = _list.sortedBy([{ $0.window.app.name ?? "" }, \.title])
+            case .dfsIndex:
+                break
+            }
 
             let list = _list.map { AeroObj.window(window: $0.window, title: $0.title) }
             if args.json {

--- a/Sources/AppBundle/command/impl/ListWindowsCommand.swift
+++ b/Sources/AppBundle/command/impl/ListWindowsCommand.swift
@@ -53,8 +53,8 @@ struct ListWindowsCommand: Command {
             switch args.sortBy {
             case .none:
                 _list = _list.sortedBy([{ $0.window.app.name ?? "" }, \.title])
-            case .dfsIndex:
-                break
+            case .some(.dfsIndex):
+                break // Keep DFS order (natural tree traversal)
             }
 
             let list = _list.map { AeroObj.window(window: $0.window, title: $0.title) }

--- a/Sources/AppBundle/focus.swift
+++ b/Sources/AppBundle/focus.swift
@@ -102,7 +102,7 @@ extension Workspace {
 }
 
 @MainActor private var _lastKnownFocus: FrozenFocus = _focus
-@MainActor private var _lastKnownWorkspaceDfsSignatures: [String: String] = [:] 
+@MainActor private var _lastKnownWorkspaceDfsSignatures: [String: String] = [:]
 
 // Used by workspace-back-and-forth
 @MainActor var _prevFocusedWorkspaceName: String? = nil {

--- a/Sources/AppBundle/focus.swift
+++ b/Sources/AppBundle/focus.swift
@@ -102,6 +102,7 @@ extension Workspace {
 }
 
 @MainActor private var _lastKnownFocus: FrozenFocus = _focus
+@MainActor private var _lastKnownWorkspaceDfsSignatures: [String: String] = [:] 
 
 // Used by workspace-back-and-forth
 @MainActor var _prevFocusedWorkspaceName: String? = nil {
@@ -151,6 +152,16 @@ extension Workspace {
     }
     if hasFocusedMonitorChanged {
         onFocusedMonitorChanged(focus)
+    }
+
+    for workspace in Workspace.all {
+        let currentSignature = workspace.getDfsSignature()
+        let lastSignature = _lastKnownWorkspaceDfsSignatures[workspace.name]
+        if currentSignature != lastSignature {
+            _lastKnownWorkspaceDfsSignatures[workspace.name] = currentSignature
+            onWorkspaceChanged(workspace.name, workspace.name)
+            break
+        }
     }
 }
 

--- a/Sources/AppBundle/tree/normalizeContainers.swift
+++ b/Sources/AppBundle/tree/normalizeContainers.swift
@@ -5,6 +5,10 @@ extension Workspace {
             rootTilingContainer.normalizeOppositeOrientationForNestedContainers()
         }
     }
+
+    @MainActor func getDfsSignature() -> String {
+        return rootTilingContainer.getDfsSignatureRecursive()
+    }
 }
 
 extension TilingContainer {
@@ -28,5 +32,19 @@ extension TilingContainer {
                 unbindFromParent()
             }
         }
+    }
+
+    @MainActor fileprivate func getDfsSignatureRecursive() -> String {
+        let childrenSig = children.map { child in
+            if let window = child as? Window {
+                return "W:\(window.windowId)"
+            } else if let container = child as? TilingContainer {
+                return container.getDfsSignatureRecursive()
+            } else {
+                return "?"
+            }
+        }.joined(separator: ",")
+        let orientation = orientation == .h ? "h" : "v"
+        return "C[\(orientation)](\(childrenSig))"
     }
 }

--- a/Sources/AppBundleTests/command/ListWindowsTest.swift
+++ b/Sources/AppBundleTests/command/ListWindowsTest.swift
@@ -31,6 +31,11 @@ final class ListWindowsTest: XCTestCase {
         assertEquals(parseCommand("list-windows --all --format '%{right-padding}' --json").errorOrNil, "%{right-padding} interpolation variable is not allowed when --json is used")
         assertEquals(parseCommand("list-windows --all --format '%{window-title} |' --json").errorOrNil, "Only interpolation variables and spaces are allowed in \'--format\' when \'--json\' is used")
         assertNil(parseCommand("list-windows --all --format '%{window-title}' --json").errorOrNil)
+        
+        // --sort-by
+        assertEquals(parseCommand("list-windows --all --sort-by invalid").errorOrNil, "ERROR: Failed to convert 'invalid' to 'WindowSortField'")
+        assertNil(parseCommand("list-windows --all --sort-by dfs-index").errorOrNil)
+        assertEquals(parseCommand("list-windows --all --count --sort-by dfs-index").errorOrNil, "ERROR: Conflicting options: --count, --sort-by")
     }
 
     func testInterpolationVariablesConsistency() {

--- a/Sources/AppBundleTests/command/ListWindowsTest.swift
+++ b/Sources/AppBundleTests/command/ListWindowsTest.swift
@@ -31,7 +31,7 @@ final class ListWindowsTest: XCTestCase {
         assertEquals(parseCommand("list-windows --all --format '%{right-padding}' --json").errorOrNil, "%{right-padding} interpolation variable is not allowed when --json is used")
         assertEquals(parseCommand("list-windows --all --format '%{window-title} |' --json").errorOrNil, "Only interpolation variables and spaces are allowed in \'--format\' when \'--json\' is used")
         assertNil(parseCommand("list-windows --all --format '%{window-title}' --json").errorOrNil)
-        
+
         // --sort-by
         assertEquals(parseCommand("list-windows --all --sort-by invalid").errorOrNil, "ERROR: Failed to convert 'invalid' to 'WindowSortField'")
         assertNil(parseCommand("list-windows --all --sort-by dfs-index").errorOrNil)

--- a/Sources/AppBundleTests/tree/DfsSignatureTest.swift
+++ b/Sources/AppBundleTests/tree/DfsSignatureTest.swift
@@ -1,0 +1,150 @@
+@testable import AppBundle
+import XCTest
+
+@MainActor
+final class DfsSignatureTest: XCTestCase {
+    override func setUp() async throws {
+        setUpWorkspacesForTests()
+    }
+
+    func testGetDfsSignature_emptyWorkspace() {
+        let workspace = Workspace.get(byName: "test")
+
+        let signature = workspace.getDfsSignature()
+
+        XCTAssertEqual(signature, "C[h]()")
+    }
+
+    func testGetDfsSignature_singleWindow() {
+        let workspace = Workspace.get(byName: "test")
+        TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+
+        let signature = workspace.getDfsSignature()
+
+        XCTAssertEqual(signature, "C[h](W:1)")
+    }
+
+    func testGetDfsSignature_twoWindowsHorizontal() {
+        let workspace = Workspace.get(byName: "test")
+        TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+        TestWindow.new(id: 2, parent: workspace.rootTilingContainer)
+
+        let signature = workspace.getDfsSignature()
+
+        XCTAssertEqual(signature, "C[h](W:1,W:2)")
+    }
+
+    func testGetDfsSignature_twoWindowsVertical() {
+        let workspace = Workspace.get(byName: "test")
+        workspace.rootTilingContainer.changeOrientation(.v)
+        TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+        TestWindow.new(id: 2, parent: workspace.rootTilingContainer)
+
+        let signature = workspace.getDfsSignature()
+
+        XCTAssertEqual(signature, "C[v](W:1,W:2)")
+    }
+
+    func testGetDfsSignature_nestedContainers() {
+        let workspace = Workspace.get(byName: "test")
+        TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+        let verticalContainer = TilingContainer.newVTiles(
+            parent: workspace.rootTilingContainer,
+            adaptiveWeight: 1
+        )
+        TestWindow.new(id: 2, parent: verticalContainer)
+        TestWindow.new(id: 3, parent: verticalContainer)
+
+        let signature = workspace.getDfsSignature()
+
+        XCTAssertEqual(signature, "C[h](W:1,C[v](W:2,W:3))")
+    }
+
+    func testDfsSignature_changesWhenWindowAdded() {
+        let workspace = Workspace.get(byName: "test")
+        TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+        
+        let signatureBefore = workspace.getDfsSignature()
+        XCTAssertEqual(signatureBefore, "C[h](W:1)")
+        
+        TestWindow.new(id: 2, parent: workspace.rootTilingContainer)
+
+        let signatureAfter = workspace.getDfsSignature()
+        XCTAssertEqual(signatureAfter, "C[h](W:1,W:2)")
+        XCTAssertNotEqual(signatureBefore, signatureAfter)
+    }
+
+    func testDfsSignature_changesWhenWindowRemoved() {
+        let workspace = Workspace.get(byName: "test")
+        TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+        let window2 = TestWindow.new(id: 2, parent: workspace.rootTilingContainer)
+        
+        let signatureBefore = workspace.getDfsSignature()
+        XCTAssertEqual(signatureBefore, "C[h](W:1,W:2)")
+        
+        window2.unbindFromParent()
+        let signatureAfter = workspace.getDfsSignature()
+        XCTAssertEqual(signatureAfter, "C[h](W:1)")
+        XCTAssertNotEqual(signatureBefore, signatureAfter)
+    }
+
+    func testDfsSignature_changesWhenWindowOrderChanges() {
+        let workspace = Workspace.get(byName: "test")
+        let window1 = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+        TestWindow.new(id: 2, parent: workspace.rootTilingContainer)
+        
+        let signatureBefore = workspace.getDfsSignature()
+        XCTAssertEqual(signatureBefore, "C[h](W:1,W:2)")
+        
+        window1.unbindFromParent()
+        window1.bind(to: workspace.rootTilingContainer, adaptiveWeight: 1, index: INDEX_BIND_LAST)
+        let signatureAfter = workspace.getDfsSignature()
+        XCTAssertEqual(signatureAfter, "C[h](W:2,W:1)")
+        XCTAssertNotEqual(signatureBefore, signatureAfter)
+    }
+
+    func testGetDfsSignature_threeWindows() {
+        let workspace = Workspace.get(byName: "test")
+        TestWindow.new(id: 100, parent: workspace.rootTilingContainer)
+        TestWindow.new(id: 200, parent: workspace.rootTilingContainer)
+        TestWindow.new(id: 300, parent: workspace.rootTilingContainer)
+        
+        let signature = workspace.getDfsSignature()
+        
+        XCTAssertEqual(signature, "C[h](W:100,W:200,W:300)")
+    }
+
+    func testGetDfsSignature_complexNested() {
+        let workspace = Workspace.get(byName: "test")
+        TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+        let verticalContainer = TilingContainer.newVTiles(
+            parent: workspace.rootTilingContainer,
+            adaptiveWeight: 1
+        )
+        TestWindow.new(id: 2, parent: verticalContainer)
+        let horizontalContainer = TilingContainer.newHTiles(
+            parent: verticalContainer,
+            adaptiveWeight: 1
+        )
+        TestWindow.new(id: 3, parent: horizontalContainer)
+        TestWindow.new(id: 4, parent: horizontalContainer)
+        
+        let signature = workspace.getDfsSignature()
+        
+        XCTAssertEqual(signature, "C[h](W:1,C[v](W:2,C[h](W:3,W:4)))")
+    }
+
+    func testDfsSignature_changesWhenOrientationChanges() {
+        let workspace = Workspace.get(byName: "test")
+        TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+        TestWindow.new(id: 2, parent: workspace.rootTilingContainer)
+        
+        let signatureBefore = workspace.getDfsSignature()
+        XCTAssertEqual(signatureBefore, "C[h](W:1,W:2)")
+        
+        workspace.rootTilingContainer.changeOrientation(.v)
+        let signatureAfter = workspace.getDfsSignature()
+        XCTAssertEqual(signatureAfter, "C[v](W:1,W:2)")
+        XCTAssertNotEqual(signatureBefore, signatureAfter)
+    }
+}

--- a/Sources/AppBundleTests/tree/DfsSignatureTest.swift
+++ b/Sources/AppBundleTests/tree/DfsSignatureTest.swift
@@ -50,7 +50,7 @@ final class DfsSignatureTest: XCTestCase {
         TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
         let verticalContainer = TilingContainer.newVTiles(
             parent: workspace.rootTilingContainer,
-            adaptiveWeight: 1
+            adaptiveWeight: 1,
         )
         TestWindow.new(id: 2, parent: verticalContainer)
         TestWindow.new(id: 3, parent: verticalContainer)
@@ -63,10 +63,10 @@ final class DfsSignatureTest: XCTestCase {
     func testDfsSignature_changesWhenWindowAdded() {
         let workspace = Workspace.get(byName: "test")
         TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
-        
+
         let signatureBefore = workspace.getDfsSignature()
         XCTAssertEqual(signatureBefore, "C[h](W:1)")
-        
+
         TestWindow.new(id: 2, parent: workspace.rootTilingContainer)
 
         let signatureAfter = workspace.getDfsSignature()
@@ -78,10 +78,10 @@ final class DfsSignatureTest: XCTestCase {
         let workspace = Workspace.get(byName: "test")
         TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
         let window2 = TestWindow.new(id: 2, parent: workspace.rootTilingContainer)
-        
+
         let signatureBefore = workspace.getDfsSignature()
         XCTAssertEqual(signatureBefore, "C[h](W:1,W:2)")
-        
+
         window2.unbindFromParent()
         let signatureAfter = workspace.getDfsSignature()
         XCTAssertEqual(signatureAfter, "C[h](W:1)")
@@ -92,10 +92,10 @@ final class DfsSignatureTest: XCTestCase {
         let workspace = Workspace.get(byName: "test")
         let window1 = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
         TestWindow.new(id: 2, parent: workspace.rootTilingContainer)
-        
+
         let signatureBefore = workspace.getDfsSignature()
         XCTAssertEqual(signatureBefore, "C[h](W:1,W:2)")
-        
+
         window1.unbindFromParent()
         window1.bind(to: workspace.rootTilingContainer, adaptiveWeight: 1, index: INDEX_BIND_LAST)
         let signatureAfter = workspace.getDfsSignature()
@@ -108,9 +108,9 @@ final class DfsSignatureTest: XCTestCase {
         TestWindow.new(id: 100, parent: workspace.rootTilingContainer)
         TestWindow.new(id: 200, parent: workspace.rootTilingContainer)
         TestWindow.new(id: 300, parent: workspace.rootTilingContainer)
-        
+
         let signature = workspace.getDfsSignature()
-        
+
         XCTAssertEqual(signature, "C[h](W:100,W:200,W:300)")
     }
 
@@ -119,18 +119,18 @@ final class DfsSignatureTest: XCTestCase {
         TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
         let verticalContainer = TilingContainer.newVTiles(
             parent: workspace.rootTilingContainer,
-            adaptiveWeight: 1
+            adaptiveWeight: 1,
         )
         TestWindow.new(id: 2, parent: verticalContainer)
         let horizontalContainer = TilingContainer.newHTiles(
             parent: verticalContainer,
-            adaptiveWeight: 1
+            adaptiveWeight: 1,
         )
         TestWindow.new(id: 3, parent: horizontalContainer)
         TestWindow.new(id: 4, parent: horizontalContainer)
-        
+
         let signature = workspace.getDfsSignature()
-        
+
         XCTAssertEqual(signature, "C[h](W:1,C[v](W:2,C[h](W:3,W:4)))")
     }
 
@@ -138,10 +138,10 @@ final class DfsSignatureTest: XCTestCase {
         let workspace = Workspace.get(byName: "test")
         TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
         TestWindow.new(id: 2, parent: workspace.rootTilingContainer)
-        
+
         let signatureBefore = workspace.getDfsSignature()
         XCTAssertEqual(signatureBefore, "C[h](W:1,W:2)")
-        
+
         workspace.rootTilingContainer.changeOrientation(.v)
         let signatureAfter = workspace.getDfsSignature()
         XCTAssertEqual(signatureAfter, "C[v](W:1,W:2)")

--- a/Sources/Common/cmdArgs/impl/ListWindowsCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/ListWindowsCmdArgs.swift
@@ -134,11 +134,6 @@ public enum WorkspaceFilter: Equatable, Sendable {
 
 public enum WindowSortField: String, Equatable, Sendable {
     case dfsIndex = "dfs-index"
-    case windowId = "window-id"
-    case windowTitle = "window-title"
-    case appName = "app-name"
-    case appBundleId = "app-bundle-id"
-    case appPid = "app-pid"
 }
 
 public enum FormatVar: Equatable {

--- a/Sources/Common/cmdArgs/impl/ListWindowsCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/ListWindowsCmdArgs.swift
@@ -23,6 +23,7 @@ public struct ListWindowsCmdArgs: CmdArgs {
             "--format": formatParser(\._format, for: .window),
             "--count": trueBoolFlag(\.outputOnlyCount),
             "--json": trueBoolFlag(\.json),
+            "--sort-by": singleValueSubArgParser(\.sortBy, "<sort-field>", parseWindowSortField),
         ],
         posArgs: [],
         conflictingOptions: [
@@ -30,6 +31,7 @@ public struct ListWindowsCmdArgs: CmdArgs {
             ["--all", "--focused", "--monitor"],
             ["--count", "--format"],
             ["--count", "--json"],
+            ["--count", "--sort-by"],
         ],
     )
 
@@ -39,6 +41,7 @@ public struct ListWindowsCmdArgs: CmdArgs {
     public var _format: [StringInterToken] = []
     public var outputOnlyCount: Bool = false
     public var json: Bool = false
+    public var sortBy: WindowSortField? = nil
 
     public struct FilteringOptions: ConvenienceCopyable, Equatable, Sendable {
         public var monitors: [MonitorId] = []
@@ -77,6 +80,10 @@ public func parseListWindowsCmdArgs(_ args: StrArrSlice) -> ParsedCmd<ListWindow
             raw.all ? raw.copy(\.filteringOptions.monitors, [.all]).copy(\.all, false) : raw // Normalize alias
         }
         .flatMap { if $0.json, let msg = getErrorIfFormatIsIncompatibleWithJson($0._format) { .failure(msg) } else { .cmd($0) } }
+}
+
+private func parseWindowSortField(_ input: String) -> WindowSortField? {
+    WindowSortField(rawValue: input)
 }
 
 func formatParser<T: ConvenienceCopyable>(
@@ -123,6 +130,15 @@ public enum WorkspaceFilter: Equatable, Sendable {
     case focused
     case visible
     case name(WorkspaceName)
+}
+
+public enum WindowSortField: String, Equatable, Sendable {
+    case dfsIndex = "dfs-index"
+    case windowId = "window-id"
+    case windowTitle = "window-title"
+    case appName = "app-name"
+    case appBundleId = "app-bundle-id"
+    case appPid = "app-pid"
 }
 
 public enum FormatVar: Equatable {

--- a/Sources/Common/cmdHelpGenerated.swift
+++ b/Sources/Common/cmdHelpGenerated.swift
@@ -76,9 +76,9 @@ let list_windows_help_generated = """
     USAGE: list-windows [-h|--help] (--workspace <workspace>...|--monitor <monitor>...)
                         [--monitor <monitor>...] [--workspace <workspace>...]
                         [--pid <pid>] [--app-bundle-id <app-bundle-id>] [--format <output-format>]
-                        [--count] [--json]
-       OR: list-windows [-h|--help] --all [--format <output-format>] [--count] [--json]
-       OR: list-windows [-h|--help] --focused [--format <output-format>] [--count] [--json]
+                        [--sort-by <sort-field>] [--count] [--json]
+       OR: list-windows [-h|--help] --all [--format <output-format>] [--sort-by <sort-field>] [--count] [--json]
+       OR: list-windows [-h|--help] --focused [--format <output-format>] [--sort-by <sort-field>] [--count] [--json]
     """
 let list_workspaces_help_generated = """
     USAGE: list-workspaces [-h|--help] --monitor <monitor>... [--visible [no]] [--empty [no]] [--format <output-format>] [--count] [--json]

--- a/Sources/Common/cmdHelpGenerated.swift
+++ b/Sources/Common/cmdHelpGenerated.swift
@@ -77,8 +77,10 @@ let list_windows_help_generated = """
                         [--monitor <monitor>...] [--workspace <workspace>...]
                         [--pid <pid>] [--app-bundle-id <app-bundle-id>] [--format <output-format>]
                         [--sort-by <sort-field>] [--count] [--json]
-       OR: list-windows [-h|--help] --all [--format <output-format>] [--sort-by <sort-field>] [--count] [--json]
-       OR: list-windows [-h|--help] --focused [--format <output-format>] [--sort-by <sort-field>] [--count] [--json]
+       OR: list-windows [-h|--help] --all [--format <output-format>] [--sort-by <sort-field>]
+                        [--count] [--json]
+       OR: list-windows [-h|--help] --focused [--format <output-format>] [--sort-by <sort-field>]
+                        [--count] [--json]
     """
 let list_workspaces_help_generated = """
     USAGE: list-workspaces [-h|--help] --monitor <monitor>... [--visible [no]] [--empty [no]] [--format <output-format>] [--count] [--json]

--- a/docs/aerospace-list-windows.adoc
+++ b/docs/aerospace-list-windows.adoc
@@ -12,9 +12,11 @@ include::util/man-attributes.adoc[]
 aerospace list-windows [-h|--help] (--workspace <workspace>...|--monitor <monitor>...)
                        [--monitor <monitor>...] [--workspace <workspace>...]
                        [--pid <pid>] [--app-bundle-id <app-bundle-id>] [--format <output-format>]
+                       [--sort-by <sort-field>] [--count] [--json]
+aerospace list-windows [-h|--help] --all [--format <output-format>] [--sort-by <sort-field>]
                        [--count] [--json]
-aerospace list-windows [-h|--help] --all [--format <output-format>] [--count] [--json]
-aerospace list-windows [-h|--help] --focused [--format <output-format>] [--count] [--json]
+aerospace list-windows [-h|--help] --focused [--format <output-format>] [--sort-by <sort-field>]
+                       [--count] [--json]
 
 // end::synopsis[]
 
@@ -54,6 +56,21 @@ include::util/monitor-option.adoc[]
 Filter results to only print windows that belong to the Application with specified https://developer.apple.com/documentation/appstoreconnectapi/bundle_ids[Bundle ID]
 +
 Deprecated (but still supported) flag name: `--app-id`
+
+--sort-by <sort-field>::
+Sort windows by the specified field. +
++
+Possible values: +
++
+. `dfs-index` - Preserve depth-first search traversal order in the window tree (maintains tiling structure order)
+. `window-id` - Sort by window ID numerically
+. `window-title` - Sort by window title alphabetically
+. `app-name` - Sort by application name only
+. `app-bundle-id` - Sort by application bundle identifier
+. `app-pid` - Sort by application process ID
++
+If not specified, windows are sorted by application name first, then by window title (default behavior). +
+Incompatible with `--count`
 
 --format <output-format>:: Specify output format. See "Output Format" section for more details.
 Incompatible with `--count`

--- a/docs/aerospace-list-windows.adoc
+++ b/docs/aerospace-list-windows.adoc
@@ -63,11 +63,6 @@ Sort windows by the specified field. +
 Possible values: +
 +
 . `dfs-index` - Preserve depth-first search traversal order in the window tree (maintains tiling structure order)
-. `window-id` - Sort by window ID numerically
-. `window-title` - Sort by window title alphabetically
-. `app-name` - Sort by application name only
-. `app-bundle-id` - Sort by application bundle identifier
-. `app-pid` - Sort by application process ID
 +
 If not specified, windows are sorted by application name first, then by window title (default behavior). +
 Incompatible with `--count`

--- a/docs/guide.adoc
+++ b/docs/guide.adoc
@@ -585,7 +585,11 @@ Changing the focus within these callbacks is a bad idea anyway, and the way it's
 [#exec-on-workspace-change-callback]
 === 'exec-on-workspace-change' callback
 
-`exec-on-workspace-change` callback allows to run arbitrary process when focused workspace changes.
+`exec-on-workspace-change` callback allows to run arbitrary process when:
+
+1. The focused workspace changes (user switches to a different workspace), or
+2. The window tree structure (depth-first search order) changes within any workspace
+
 It may be useful for integrating with bars.
 
 [source,toml]


### PR DESCRIPTION
 Add `--sort-by dfs-index` flag to `list-windows` command
Addresses [issue #491](https://github.com/nikitabobko/AeroSpace/issues/491).
 Non-Breaking Change ✅
- Default sorting unchanged (alphabetical by app name and title)
- Opt-in flag: `--sort-by dfs-index` preserves DFS traversal order
- Consistent with existing `focus --dfs-index` command ([PR #464](https://github.com/nikitabobko/AeroSpace/pull/464))
 Features

**1. `--sort-by dfs-index` flag**
- Preserves DFS order from `allLeafWindowsRecursive`
- Works with `--format` and `--json`
- Incompatible with `--count`

**2. DFS structure change detection**
- Triggers `exec-on-workspace-change` when window tree structure changes
- Enables dynamic workspace monitoring (e.g., status bars)
- `AEROSPACE_FOCUSED_WORKSPACE == AEROSPACE_PREV_WORKSPACE` indicates DFS change (not workspace switch)