### PR TITLE
list-windows: add --sort option

### DIFF
--- a/Sources/AppBundle/command/impl/ListWindowsCommand.swift
+++ b/Sources/AppBundle/command/impl/ListWindowsCommand.swift
@@ -49,7 +49,25 @@ struct ListWindowsCommand: Command {
                 _list.append((window, try await window.title))
             }
             _list = _list.filter { $0.window.isBound }
-            _list = _list.sortedBy([{ $0.window.app.name ?? "" }, \.title])
+            _list = _list.sorted { lhs, rhs in
+                for criterion in args.sort {
+                    switch criterion {
+                        case .recent:
+                            // Sort by lastFocusedAt descending (most recent first)
+                            if lhs.window.lastFocusedAt > rhs.window.lastFocusedAt { return true }
+                            if lhs.window.lastFocusedAt < rhs.window.lastFocusedAt { return false }
+                        case .appName:
+                            let lhsName = lhs.window.app.name ?? ""
+                            let rhsName = rhs.window.app.name ?? ""
+                            if lhsName < rhsName { return true }
+                            if lhsName > rhsName { return false }
+                        case .windowTitle:
+                            if lhs.title < rhs.title { return true }
+                            if lhs.title > rhs.title { return false }
+                    }
+                }
+                return false
+            }
 
             let list = _list.map { AeroObj.window(window: $0.window, title: $0.title) }
             if args.json {

--- a/Sources/AppBundle/focus.swift
+++ b/Sources/AppBundle/focus.swift
@@ -49,6 +49,9 @@ struct FrozenFocus: AeroAny, Equatable, Sendable {
     }
 }
 
+// Global counter for tracking window focus order (monotonically increasing)
+@MainActor var windowFocusSequence: UInt64 = 0
+
 @MainActor private var _focus: FrozenFocus = {
     let monitor = mainMonitor
     return FrozenFocus(windowId: nil, workspaceName: monitor.activeWorkspace.name, monitorId: monitor.monitorId ?? 0)
@@ -72,6 +75,11 @@ struct FrozenFocus: AeroAny, Equatable, Sendable {
     let status = newFocus.workspace.workspaceMonitor.setActiveWorkspace(newFocus.workspace)
 
     newFocus.windowOrNil?.markAsMostRecentChild()
+    // Update global focus sequence for recent window tracking
+    if let window = newFocus.windowOrNil {
+        windowFocusSequence += 1
+        window.lastFocusedAt = windowFocusSequence
+    }
     return status
 }
 extension Window {

--- a/Sources/AppBundle/tree/Window.swift
+++ b/Sources/AppBundle/tree/Window.swift
@@ -8,6 +8,7 @@ open class Window: TreeNode, Hashable {
     var isFullscreen: Bool = false
     var noOuterGapsInFullscreen: Bool = false
     var layoutReason: LayoutReason = .standard
+    var lastFocusedAt: UInt64 = 0 // Monotonically increasing value, 0 means never focused
 
     @MainActor
     init(id: UInt32, _ app: any AbstractApp, lastFloatingSize: CGSize?, parent: NonLeafTreeNodeObject, adaptiveWeight: CGFloat, index: Int) {

--- a/Sources/Common/cmdArgs/impl/ListWindowsCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/ListWindowsCmdArgs.swift
@@ -23,6 +23,7 @@ public struct ListWindowsCmdArgs: CmdArgs {
             "--format": formatParser(\._format, for: .window),
             "--count": trueBoolFlag(\.outputOnlyCount),
             "--json": trueBoolFlag(\.json),
+            "--sort": SubArgParser(\.sort, parseSortOptions),
         ],
         posArgs: [],
         conflictingOptions: [
@@ -36,6 +37,7 @@ public struct ListWindowsCmdArgs: CmdArgs {
     fileprivate var all: Bool = false // ALIAS
 
     public var filteringOptions = FilteringOptions()
+    public var sort: [SortOption] = [.appName, .windowTitle]
     public var _format: [StringInterToken] = []
     public var outputOnlyCount: Bool = false
     public var json: Bool = false
@@ -119,10 +121,35 @@ private func parseWorkspaces(input: SubArgParserInput) -> ParsedCliArgs<[Workspa
     return .succ(workspaces, advanceBy: workspaces.count)
 }
 
+private func parseSortOptions(input: SubArgParserInput) -> ParsedCliArgs<[SortOption]> {
+    if let arg = input.nonFlagArgOrNil() {
+        let sortStrings = arg.split(separator: ",")
+        var sortOptions: [SortOption] = []
+        for (index, sortStr) in sortStrings.enumerated() {
+            if let option = SortOption(rawValue: String(sortStr)) {
+                sortOptions.append(option)
+            } else {
+                let validValues = SortOption.allCases.map { $0.rawValue }.joined(separator: ", ")
+                return .fail("Invalid sort option '\(sortStr)'. Valid options: \(validValues)", advanceBy: index + 1)
+            }
+        }
+        return .succ(sortOptions, advanceBy: 1)
+    } else {
+        let validValues = SortOption.allCases.map { $0.rawValue }.joined(separator: ", ")
+        return .fail("'--sort' requires a value. Valid options: \(validValues)", advanceBy: 0)
+    }
+}
+
 public enum WorkspaceFilter: Equatable, Sendable {
     case focused
     case visible
     case name(WorkspaceName)
+}
+
+public enum SortOption: String, Equatable, Sendable, CaseIterable {
+    case recent = "recent"
+    case appName = "app-name"
+    case windowTitle = "window-title"
 }
 
 public enum FormatVar: Equatable {

--- a/Sources/Common/cmdHelpGenerated.swift
+++ b/Sources/Common/cmdHelpGenerated.swift
@@ -76,9 +76,9 @@ let list_windows_help_generated = """
     USAGE: list-windows [-h|--help] (--workspace <workspace>...|--monitor <monitor>...)
                         [--monitor <monitor>...] [--workspace <workspace>...]
                         [--pid <pid>] [--app-bundle-id <app-bundle-id>] [--format <output-format>]
-                        [--count] [--json]
-       OR: list-windows [-h|--help] --all [--format <output-format>] [--count] [--json]
-       OR: list-windows [-h|--help] --focused [--format <output-format>] [--count] [--json]
+                        [--count] [--json] [--sort <sort-option>...]
+       OR: list-windows [-h|--help] --all [--format <output-format>] [--count] [--json] [--sort <sort-option>...]
+       OR: list-windows [-h|--help] --focused [--format <output-format>] [--count] [--json] [--sort <sort-option>...]
     """
 let list_workspaces_help_generated = """
     USAGE: list-workspaces [-h|--help] --monitor <monitor>... [--visible [no]] [--empty [no]] [--format <output-format>] [--count] [--json]

--- a/docs/aerospace-list-windows.adoc
+++ b/docs/aerospace-list-windows.adoc
@@ -12,9 +12,9 @@ include::util/man-attributes.adoc[]
 aerospace list-windows [-h|--help] (--workspace <workspace>...|--monitor <monitor>...)
                        [--monitor <monitor>...] [--workspace <workspace>...]
                        [--pid <pid>] [--app-bundle-id <app-bundle-id>] [--format <output-format>]
-                       [--count] [--json]
-aerospace list-windows [-h|--help] --all [--format <output-format>] [--count] [--json]
-aerospace list-windows [-h|--help] --focused [--format <output-format>] [--count] [--json]
+                       [--count] [--json] [--sort <sort-option>...]
+aerospace list-windows [-h|--help] --all [--format <output-format>] [--count] [--json] [--sort <sort-option>...]
+aerospace list-windows [-h|--help] --focused [--format <output-format>] [--count] [--json] [--sort <sort-option>...]
 
 // end::synopsis[]
 
@@ -54,6 +54,18 @@ include::util/monitor-option.adoc[]
 Filter results to only print windows that belong to the Application with specified https://developer.apple.com/documentation/appstoreconnectapi/bundle_ids[Bundle ID]
 +
 Deprecated (but still supported) flag name: `--app-id`
+
+--sort <sort-option>...::
+Sort the output by the specified criteria.
+`<sort-option>...` is a space-separated list of sort options.
++
+Possible values: +
++
+. `recent` - Sort by most recently focused
+. `app-name` - Sort by application name
+. `window-title` - Sort by window title
++
+If not specified, the default sort order is: `app-name window-title`
 
 --format <output-format>:: Specify output format. See "Output Format" section for more details.
 Incompatible with `--count`


### PR DESCRIPTION
Introduce a new `--sort` flag for the `list-windows` command. Supported values are `recent`, `app-name`, and `window-title`, and multiple values may be specified as a comma-separated list.

For backward compatibility, the default sort order is `app-name,window-title`. Using `--sort recent` sorts windows by most recently focused.

Although there was no comments in the discussion, this was motivated by https://github.com/nikitabobko/AeroSpace/discussions/1890.

## PR checklist

- [x] Explain your changes in the relevant commit messages rather than in the PR description. The PR description must not contain more information than the commit messages (except for images and other media).
- [x] Each commit must explain what/why/how and motivation in its description. https://cbea.ms/git-commit/
- [x] Don't forget to link the appropriate issues/discussions in commit messages (if applicable).
- [x] Each commit must be an atomic change (a PR may contain several commits). Don't introduce new functional changes together with refactorings in the same commit.
- [x] `./run-tests.sh` exits with non-zero exit code.
- [x] Avoid merge commits, always rebase and force push.

Failure to follow the checklist with no apparent reasons will result in silent PR rejection.
