### PR TITLE
Docs: document --format restrictions when --json is used

### DIFF
--- a/docs/aerospace-list-apps.adoc
+++ b/docs/aerospace-list-apps.adoc
@@ -38,6 +38,8 @@ Incompatible with: `--format`, `--json`
 
 --json:: Output in JSON format.
 Can be used in combination with `--format` to specify which data to include into the json.
+When `--json` is used, only interpolation variables and spaces are allowed in `--format`.
+`%{right-padding}` is not allowed with `--json`.
 Incompatible with `--count`
 
 // =========================================================== Output Format

--- a/docs/aerospace-list-windows.adoc
+++ b/docs/aerospace-list-windows.adoc
@@ -63,6 +63,8 @@ Incompatible with `--format`
 
 --json:: Output in JSON format.
 Can be used in combination with `--format` to specify which data to include into the json.
+When `--json` is used, only interpolation variables and spaces are allowed in `--format`.
+`%{right-padding}` is not allowed with `--json`.
 Incompatible with `--count`
 
 // =========================================================== Output Format


### PR DESCRIPTION
## Summary
- Document that `%{right-padding}` is not allowed in `--format` when `--json` is used
- Document that only interpolation variables and spaces are allowed in `--format` with `--json`
- Updated both `list-windows` and `list-apps` docs

## Context
Running e.g. `aerospace list-windows --all --json --format '%{workspace}%{right-padding}|%{window-id}'` produces an error, but the documentation didn't mention this restriction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)