### PR TITLE
move-workspace-to-monitor: Fetch previous workspace before moving

### DIFF
--- a/Sources/AppBundle/command/impl/MoveWorkspaceToMonitorCommand.swift
+++ b/Sources/AppBundle/command/impl/MoveWorkspaceToMonitorCommand.swift
@@ -15,8 +15,8 @@ struct MoveWorkspaceToMonitorCommand: Command {
                 if targetMonitor.monitorId == prevMonitor.monitorId {
                     return true
                 }
+                let stubWorkspace = getStubWorkspace(for: prevMonitor)
                 if targetMonitor.setActiveWorkspace(focusedWorkspace) {
-                    let stubWorkspace = getStubWorkspace(for: prevMonitor)
                     check(
                         prevMonitor.setActiveWorkspace(stubWorkspace),
                         "getStubWorkspace generated incompatible stub workspace (\(stubWorkspace)) for the monitor (\(prevMonitor)",


### PR DESCRIPTION
Otherwise the previous workspace will be the workspace that just moved, causing the "is not visible check" in `getStubWorkspace` to fail. As a result, the moving workspace is always replaced by the first non-empty workspace on that monitor, which is not intuitive.

## PR checklist

- [x] Explain your changes in the relevant commit messages rather than in the PR description. The PR description must not contain more information than the commit messages (except for images and other media).
- [x] Each commit must explain what/why/how and motivation in its description. https://cbea.ms/git-commit/
- [x] Don't forget to link the appropriate issues/discussions in commit messages (if applicable).
- [x] Each commit must be an atomic change (a PR may contain several commits). Don't introduce new functional changes together with refactorings in the same commit.
- [x] `./run-tests.sh` exits with non-zero exit code.
- [x] Avoid merge commits, always rebase and force push.
