### PR TITLE
fix: normalize containers after flatten-workspace-tree

### DIFF
--- a/Sources/AppBundle/command/impl/FlattenWorkspaceTreeCommand.swift
+++ b/Sources/AppBundle/command/impl/FlattenWorkspaceTreeCommand.swift
@@ -12,6 +12,7 @@ struct FlattenWorkspaceTreeCommand: Command {
         for window in windows {
             window.bind(to: workspace.rootTilingContainer, adaptiveWeight: 1, index: INDEX_BIND_LAST)
         }
+        workspace.normalizeContainers()
         return true
     }
 }

--- a/Sources/AppBundleTests/command/FlattenWorkspaceTreeCommandTest.swift
+++ b/Sources/AppBundleTests/command/FlattenWorkspaceTreeCommandTest.swift
@@ -19,7 +19,29 @@ final class FlattenWorkspaceTreeCommandTest: XCTestCase {
         assertEquals(workspace.focusWorkspace(), true)
 
         try await FlattenWorkspaceTreeCommand(args: FlattenWorkspaceTreeCmdArgs(rawArgs: [])).run(.defaultEnv, .emptyStdin)
-        workspace.normalizeContainers()
+        // normalizeContainers() is now called inside the command, so no need to call it here.
         assertEquals(workspace.layoutDescription, .workspace([.h_tiles([.window(1), .window(2)]), .window(3)]))
+    }
+
+    func testDeeplyNested() async throws {
+        // Verify flatten fully normalizes a deeply nested tree (no residual containers).
+        let workspace = Workspace.get(byName: name).apply {
+            $0.rootTilingContainer.apply {
+                TestWindow.new(id: 1, parent: $0)
+                TilingContainer.newVTiles(parent: $0, adaptiveWeight: 1).apply {
+                    TestWindow.new(id: 2, parent: $0)
+                    TilingContainer.newHTiles(parent: $0, adaptiveWeight: 1).apply {
+                        TestWindow.new(id: 3, parent: $0)
+                        TestWindow.new(id: 4, parent: $0)
+                    }
+                }
+            }
+        }
+        assertEquals(workspace.focusWorkspace(), true)
+
+        // Before flatten: root → [window(1), v_tiles → [window(2), h_tiles → [window(3), window(4)]]]
+        try await FlattenWorkspaceTreeCommand(args: FlattenWorkspaceTreeCmdArgs(rawArgs: [])).run(.defaultEnv, .emptyStdin)
+        // After flatten: all windows are direct children of root, no residual containers.
+        assertEquals(workspace.layoutDescription, .workspace([.h_tiles([.window(1), .window(2), .window(3), .window(4)])]))
     }
 }


### PR DESCRIPTION
**Discussion:** https://github.com/nikitabobko/AeroSpace/discussions/1955

## Summary

- `flatten-workspace-tree` rebinds all tiling windows to the root container but does not call `normalizeContainers()` afterward, leaving empty/single-child containers in the tree.
- Added `workspace.normalizeContainers()` after the rebind loop in `FlattenWorkspaceTreeCommand.swift`.

## Test plan

- [x] Updated existing `testSimple` — command now normalizes internally, no external call needed
- [x] Added `testDeeplyNested` — verifies a 3-level nested tree is fully flattened with no residual containers
- [x] `./run-tests.sh` passes (108 tests, 0 SwiftFormat changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)