### PR TITLE
layout command: return success on noop when layout already matches

### DIFF
--- a/Sources/AppBundle/command/impl/LayoutCommand.swift
+++ b/Sources/AppBundle/command/impl/LayoutCommand.swift
@@ -12,7 +12,7 @@ struct LayoutCommand: Command {
         }
         let targetDescription = args.toggleBetween.val.first(where: { !window.matchesDescription($0) })
             ?? args.toggleBetween.val.first.orDie()
-        if window.matchesDescription(targetDescription) { return false }
+        if window.matchesDescription(targetDescription) { return true }
         switch targetDescription {
             case .h_accordion:
                 return changeTilingLayout(io, targetLayout: .accordion, targetOrientation: .h, window: window)

--- a/Sources/AppBundleTests/command/LayoutCommandTest.swift
+++ b/Sources/AppBundleTests/command/LayoutCommandTest.swift
@@ -1,0 +1,30 @@
+@testable import AppBundle
+import Common
+import XCTest
+
+@MainActor
+final class LayoutCommandTest: XCTestCase {
+    override func setUp() async throws { setUpWorkspacesForTests() }
+
+    func testChangeLayout() async throws {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            assertEquals(TestWindow.new(id: 2, parent: $0).focusWindow(), true)
+        }
+        // Root defaults to h_tiles. Change to v_tiles.
+        let result = try await LayoutCommand(args: LayoutCmdArgs(rawArgs: [], toggleBetween: [.v_tiles])).run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode, 0)
+        assertEquals(root.layoutDescription, .v_tiles([.window(1), .window(2)]))
+    }
+
+    func testNoopReturnsTrueWhenLayoutAlreadyMatches() async throws {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            assertEquals(TestWindow.new(id: 2, parent: $0).focusWindow(), true)
+        }
+        // Root defaults to h_tiles. Setting h_tiles again should succeed (noop).
+        let result = try await LayoutCommand(args: LayoutCmdArgs(rawArgs: [], toggleBetween: [.h_tiles])).run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode, 0)
+        assertEquals(root.layoutDescription, .h_tiles([.window(1), .window(2)]))
+    }
+}


### PR DESCRIPTION
**Discussion:** https://github.com/nikitabobko/AeroSpace/discussions/1956

## Summary

- The `layout` command returns `false` (exit code 1) when the layout is already set to the requested value, even though the desired state is already achieved.
- Changed `return false` to `return true` on the noop path (line 15 of `LayoutCommand.swift`), consistent with how the `tiling` case already returns `true` for noops (line 41).

## Test plan

- [x] Added `LayoutCommandTest.swift` with 2 tests:
  - `testChangeLayout` — verifies layout actually changes and returns exit code 0
  - `testNoopReturnsTrueWhenLayoutAlreadyMatches` — verifies the noop case returns exit code 0
- [x] `./run-tests.sh` passes (108 tests, 0 SwiftFormat changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)