### PR TITLE
Add i3-style auto-tiling and master-stack command

### DIFF
--- a/Sources/AppBundle/command/cmdManifest.swift
+++ b/Sources/AppBundle/command/cmdManifest.swift
@@ -44,6 +44,8 @@ extension CmdArgs {
                 command = ListWindowsCommand(args: self as! ListWindowsCmdArgs)
             case .listWorkspaces:
                 command = ListWorkspacesCommand(args: self as! ListWorkspacesCmdArgs)
+            case .masterStack:
+                command = MasterStackCommand(args: self as! MasterStackCmdArgs)
             case .macosNativeFullscreen:
                 command = MacosNativeFullscreenCommand(args: self as! MacosNativeFullscreenCmdArgs)
             case .macosNativeMinimize:

--- a/Sources/AppBundle/command/impl/MasterStackCommand.swift
+++ b/Sources/AppBundle/command/impl/MasterStackCommand.swift
@@ -1,0 +1,87 @@
+import AppKit
+import Common
+
+struct MasterStackCommand: Command {
+    let args: MasterStackCmdArgs
+    /*conforms*/ let shouldResetClosedWindowsCache: Bool = true
+
+    func run(_ env: CmdEnv, _ io: CmdIo) -> Bool {
+        guard let target = args.resolveTargetOrReportError(env, io) else { return false }
+        let workspace = target.workspace
+        let root = workspace.rootTilingContainer
+
+        let allWindows = root.allLeafWindowsRecursive
+        guard allWindows.count >= 2 else { return true }
+
+        let master: Window
+        if args.cycle {
+            // Use stable window ID order so cycling visits all windows
+            let sortedById = allWindows.sorted { $0.windowId < $1.windowId }
+            // Current master is the first leaf in the tree (DFS)
+            guard let currentMaster = allWindows.first else { return true }
+            let currentIndex = sortedById.firstIndex(of: currentMaster) ?? 0
+            let nextIndex = (currentIndex + 1) % sortedById.count
+            master = sortedById[nextIndex]
+        } else {
+            guard let focusedWindow = target.windowOrNil else {
+                return io.err(noWindowIsFocused)
+            }
+            master = focusedWindow
+        }
+
+        // Step 1: Flatten all windows to root (same as flatten-workspace-tree)
+        for window in allWindows {
+            window.bind(to: root, adaptiveWeight: 1, index: INDEX_BIND_LAST)
+        }
+        root.changeOrientation(.h)
+
+        // Step 2: Collect non-master windows
+        var others: [Window] = []
+        for window in root.allLeafWindowsRecursive where window !== master {
+            others.append(window)
+        }
+
+        // Step 3: Move master to index 0 with weight 7
+        master.bind(to: root, adaptiveWeight: 7, index: 0)
+
+        // Step 4: Create stack container and build spiral
+        if others.count == 1 {
+            others[0].bind(to: root, adaptiveWeight: 3, index: 1)
+        } else {
+            let stackContainer = TilingContainer(
+                parent: root,
+                adaptiveWeight: 3,
+                .v,
+                .tiles,
+                index: 1,
+            )
+            buildSpiral(windows: others, parent: stackContainer, startOrientation: .h)
+        }
+
+        // Focus the master window
+        if args.cycle {
+            _ = master.focusWindow()
+        }
+
+        return true
+    }
+
+    @MainActor private func buildSpiral(windows: [Window], parent: TilingContainer, startOrientation: Orientation) {
+        if windows.count == 1 {
+            windows[0].bind(to: parent, adaptiveWeight: WEIGHT_AUTO, index: INDEX_BIND_LAST)
+        } else if windows.count == 2 {
+            windows[0].bind(to: parent, adaptiveWeight: 1, index: 0)
+            windows[1].bind(to: parent, adaptiveWeight: 1, index: 1)
+        } else {
+            windows[0].bind(to: parent, adaptiveWeight: 1, index: 0)
+            let sub = TilingContainer(
+                parent: parent,
+                adaptiveWeight: 1,
+                startOrientation,
+                .tiles,
+                index: 1,
+            )
+            buildSpiral(windows: Array(windows.dropFirst()), parent: sub, startOrientation: startOrientation.opposite)
+        }
+    }
+}

--- a/Sources/AppBundle/config/Config.swift
+++ b/Sources/AppBundle/config/Config.swift
@@ -46,6 +46,7 @@ struct Config: ConvenienceCopyable {
     var automaticallyUnhideMacosHiddenApps: Bool = false
     var accordionPadding: Int = 30
     var enableNormalizationOppositeOrientationForNestedContainers: Bool = true
+    var autoTile: Bool = false
     var persistentWorkspaces: OrderedSet<String> = []
     var execOnWorkspaceChange: [String] = [] // todo deprecate
     var keyMapping = KeyMapping()

--- a/Sources/AppBundle/config/parseConfig.swift
+++ b/Sources/AppBundle/config/parseConfig.swift
@@ -106,6 +106,8 @@ private let configParser: [String: any ParserProtocol<Config>] = [
     "enable-normalization-flatten-containers": Parser(\.enableNormalizationFlattenContainers, parseBool),
     "enable-normalization-opposite-orientation-for-nested-containers": Parser(\.enableNormalizationOppositeOrientationForNestedContainers, parseBool),
 
+    "auto-tile": Parser(\.autoTile, parseBool),
+
     "default-root-container-layout": Parser(\.defaultRootContainerLayout, parseLayout),
     "default-root-container-orientation": Parser(\.defaultRootContainerOrientation, parseDefaultContainerOrientation),
 

--- a/Sources/AppBundle/tree/MacWindow.swift
+++ b/Sources/AppBundle/tree/MacWindow.swift
@@ -227,6 +227,25 @@ private func unbindAndGetBindingDataForNewTilingWindow(_ workspace: Workspace, w
     window?.unbindFromParent() // It's important to unbind to get correct data from below
     let mruWindow = workspace.mostRecentWindowRecursive
     if let mruWindow, let tilingParent = mruWindow.parent as? TilingContainer {
+        if config.autoTile, let mruRect = mruWindow.lastAppliedLayoutVirtualRect {
+            let desiredOrientation: Orientation = mruRect.width >= mruRect.height ? .h : .v
+            if desiredOrientation != tilingParent.orientation {
+                let mruBinding = mruWindow.unbindFromParent()
+                let subContainer = TilingContainer(
+                    parent: tilingParent,
+                    adaptiveWeight: mruBinding.adaptiveWeight,
+                    desiredOrientation,
+                    .tiles,
+                    index: mruBinding.index,
+                )
+                mruWindow.bind(to: subContainer, adaptiveWeight: WEIGHT_AUTO, index: 0)
+                return BindingData(
+                    parent: subContainer,
+                    adaptiveWeight: WEIGHT_AUTO,
+                    index: 1,
+                )
+            }
+        }
         return BindingData(
             parent: tilingParent,
             adaptiveWeight: WEIGHT_AUTO,

--- a/Sources/Common/cmdArgs/cmdArgsManifest.swift
+++ b/Sources/Common/cmdArgs/cmdArgsManifest.swift
@@ -21,6 +21,7 @@ public enum CmdKind: String, CaseIterable, Equatable, Sendable {
     case listMonitors = "list-monitors"
     case listWindows = "list-windows"
     case listWorkspaces = "list-workspaces"
+    case masterStack = "master-stack"
     case macosNativeFullscreen = "macos-native-fullscreen"
     case macosNativeMinimize = "macos-native-minimize"
     case mode
@@ -84,6 +85,8 @@ func initSubcommands() -> [String: any SubCommandParserProtocol] {
                 result[kind.rawValue] = SubCommandParser(parseListWindowsCmdArgs)
             case .listWorkspaces:
                 result[kind.rawValue] = SubCommandParser(parseListWorkspacesCmdArgs)
+            case .masterStack:
+                result[kind.rawValue] = SubCommandParser(MasterStackCmdArgs.init)
             case .macosNativeFullscreen:
                 result[kind.rawValue] = SubCommandParser(parseMacosNativeFullscreenCmdArgs)
             case .macosNativeMinimize:

--- a/Sources/Common/cmdArgs/impl/MasterStackCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/MasterStackCmdArgs.swift
@@ -1,0 +1,15 @@
+public struct MasterStackCmdArgs: CmdArgs {
+    /*conforms*/ public var commonState: CmdArgsCommonState
+    public var cycle: Bool = false
+    public init(rawArgs: StrArrSlice) { self.commonState = .init(rawArgs) }
+    public static let parser: CmdParser<Self> = cmdParser(
+        kind: .masterStack,
+        allowInConfig: true,
+        help: master_stack_help_generated,
+        flags: [
+            "--workspace": optionalWorkspaceFlag(),
+            "--cycle": trueBoolFlag(\.cycle),
+        ],
+        posArgs: [],
+    )
+}

--- a/Sources/Common/cmdHelpGenerated.swift
+++ b/Sources/Common/cmdHelpGenerated.swift
@@ -85,6 +85,9 @@ let list_workspaces_help_generated = """
        OR: list-workspaces [-h|--help] --all [--format <output-format>] [--count] [--json]
        OR: list-workspaces [-h|--help] --focused [--format <output-format>] [--count] [--json]
     """
+let master_stack_help_generated = """
+    USAGE: master-stack [-h|--help] [--workspace <workspace>]
+    """
 let macos_native_fullscreen_help_generated = """
     USAGE: macos-native-fullscreen [-h|--help] [--window-id <window-id>]
        OR: macos-native-fullscreen [-h|--help] [--window-id <window-id>] [--fail-if-noop] on

--- a/docs/config-examples/default-config.toml
+++ b/docs/config-examples/default-config.toml
@@ -20,6 +20,12 @@ auto-reload-config = false
 enable-normalization-flatten-containers = true
 enable-normalization-opposite-orientation-for-nested-containers = true
 
+# i3-like auto-tiling (spiral/dwindle layout).
+# When enabled, new windows automatically alternate between horizontal and vertical
+# splits based on the focused window's dimensions, creating a spiral layout.
+# Fallback value (if you omit the key): auto-tile = false
+auto-tile = false
+
 # See: https://nikitabobko.github.io/AeroSpace/guide#layouts
 # The 'accordion-padding' specifies the size of accordion padding
 # You can set 0 to disable the padding feature


### PR DESCRIPTION
## Summary

- Add `auto-tile` config option (default `false`) that automatically alternates split direction based on the MRU window's aspect ratio when placing new windows, producing a spiral/dwindle layout similar to i3/sway autotiling
- Add `master-stack` command that rearranges the focused workspace into a master+spiral layout: focused window at ~70% width on the left, remaining windows spiral-tiled on the right
- `master-stack --cycle` rotates which window is the master, cycling through all windows by stable window ID order

## How auto-tile works

When a new window is placed next to the MRU window, the MRU window's layout rect is checked:
- **Wider than tall** -> horizontal split (new window goes right)
- **Taller than wide** -> vertical split (new window goes below)

A sub-container is only created when the desired orientation **differs** from the parent container's orientation. This naturally produces a spiral:

```
1 window:  [A]
2 windows: [A | B]              (A wider -> H, parent H, same -> flat)
3 windows: [A | V[B / C]]      (B taller -> V, parent H, diff -> sub-container)
4 windows: [A | V[B / H[C|D]]] (C wider -> H, parent V, diff -> sub-container)
```

Compatible with both existing normalizations (flatten-containers and opposite-orientation).

## Configuration

```toml
# Enable i3-style auto-tiling (spiral/dwindle layout)
auto-tile = true
```

## Usage examples

```toml
[mode.main.binding]
    # Arrange focused window as master (70%) with rest spiral-tiled
    alt-enter = 'master-stack'
    # Cycle through windows as master
    alt-space = 'master-stack --cycle'
```

## Changes

| File | Change |
|------|--------|
| `Config.swift` | Add `autoTile: Bool` field |
| `parseConfig.swift` | Add `auto-tile` parser entry |
| `MacWindow.swift` | Auto-tile logic in `unbindAndGetBindingDataForNewTilingWindow` |
| `default-config.toml` | Document the new option |
| `MasterStackCommand.swift` | New command implementation |
| `MasterStackCmdArgs.swift` | Command args with `--cycle` flag |
| `cmdArgsManifest.swift` | Register command |
| `cmdManifest.swift` | Register command |
| `cmdHelpGenerated.swift` | Help text |

## Test plan

- [ ] `swift build` compiles cleanly
- [ ] `auto-tile = false` preserves current flat behavior
- [ ] `auto-tile = true`: open 4+ windows on a workspace, verify spiral layout forms
- [ ] Closing a window in the spiral correctly simplifies the tree (flatten normalization)
- [ ] `master-stack` makes focused window ~70% with rest spiral-tiled
- [ ] `master-stack --cycle` visits all windows in order
