### PR TITLE
fix: prevent floating windows from getting stuck in corner after work…

### DIFF
--- a/Sources/AppBundle/tree/MacWindow.swift
+++ b/Sources/AppBundle/tree/MacWindow.swift
@@ -131,9 +131,16 @@ final class MacWindow: Window {
             guard let windowRect = try await getAxRect() else { return }
             let topLeftCorner = windowRect.topLeftCorner
             let monitorRect = windowRect.center.monitorApproximation.rect // Similar to layoutFloatingWindow. Non idempotent
-            let absolutePoint = topLeftCorner - monitorRect.topLeftCorner
-            prevUnhiddenProportionalPositionInsideWorkspaceRect =
-                CGPoint(x: absolutePoint.x / monitorRect.width, y: absolutePoint.y / monitorRect.height)
+            // Only record the window's position if it is actually inside the visible monitor
+            // area. If the window is already outside (i.e. stuck at a corner from a previous
+            // broken hide/unhide cycle), skipping the save prevents permanently anchoring the
+            // window to the corner on the next unhideFromCorner() call.
+            // See: https://github.com/nikitabobko/AeroSpace/discussions/1875
+            if nodeMonitor.visibleRect.contains(topLeftCorner) {
+                let absolutePoint = topLeftCorner - monitorRect.topLeftCorner
+                prevUnhiddenProportionalPositionInsideWorkspaceRect =
+                    CGPoint(x: absolutePoint.x / monitorRect.width, y: absolutePoint.y / monitorRect.height)
+            }
         }
         let p: CGPoint
         switch corner {


### PR DESCRIPTION
…space switch

When AeroSpace hides windows from inactive workspaces, it moves them to a screen corner and saves their previous position so they can be restored later (unhideFromCorner). A race condition with AX notifications could cause the following broken cycle:

1. hideInCorner() saves the normal position, moves window to corner
2. unhideFromCorner() restores it, clears prevUnhiddenProportionalPosition
3. A spurious AX event triggers unhideFromCorner() again — no-op since prevUnhiddenProportionalPosition is already nil, window stays in place
4. Next workspace switch calls hideInCorner() again — isHiddenInCorner is false (nil check) — so it saves the *current* position, which is already the corner position
5. unhideFromCorner() then restores the window to the corner → stuck forever

Fix: in hideInCorner(), only record the window's position when its top-left corner is actually inside the monitor's visible rect. If it's already outside (stuck in a corner from a previous broken cycle), skip saving to avoid permanently anchoring it to the corner.

Fixes: https://github.com/nikitabobko/AeroSpace/discussions/1875


