### PR TITLE
Add focus-follows-mouse 

### DIFF
--- a/Sources/AppBundle/GlobalObserver.swift
+++ b/Sources/AppBundle/GlobalObserver.swift
@@ -75,5 +75,7 @@ enum GlobalObserver {
                 }
             }
         }
+
+        installFocusFollowsMouseMonitor()
     }
 }

--- a/Sources/AppBundle/command/impl/ReloadConfigCommand.swift
+++ b/Sources/AppBundle/command/impl/ReloadConfigCommand.swift
@@ -34,6 +34,7 @@ struct ReloadConfigCommand: Command {
                 configUrl = url
                 try await activateMode(activeMode)
                 syncStartAtLogin()
+                installFocusFollowsMouseMonitor()
                 MessageModel.shared.message = nil
             }
             result = true

--- a/Sources/AppBundle/config/Config.swift
+++ b/Sources/AppBundle/config/Config.swift
@@ -44,6 +44,7 @@ struct Config: ConvenienceCopyable {
     var startAtLogin: Bool = false
     var autoReloadConfig: Bool = false
     var automaticallyUnhideMacosHiddenApps: Bool = false
+    var focusFollowsMouse: Bool = false
     var accordionPadding: Int = 30
     var enableNormalizationOppositeOrientationForNestedContainers: Bool = true
     var persistentWorkspaces: OrderedSet<String> = []

--- a/Sources/AppBundle/config/parseConfig.swift
+++ b/Sources/AppBundle/config/parseConfig.swift
@@ -112,6 +112,7 @@ private let configParser: [String: any ParserProtocol<Config>] = [
     "start-at-login": Parser(\.startAtLogin, parseBool),
     "auto-reload-config": Parser(\.autoReloadConfig, parseBool),
     "automatically-unhide-macos-hidden-apps": Parser(\.automaticallyUnhideMacosHiddenApps, parseBool),
+    "focus-follows-mouse": Parser(\.focusFollowsMouse, parseBool),
     "accordion-padding": Parser(\.accordionPadding, parseInt),
     persistentWorkspacesKey: Parser(\.persistentWorkspaces, parsePersistentWorkspaces),
     "exec-on-workspace-change": Parser(\.execOnWorkspaceChange, parseArrayOfStrings),

--- a/Sources/AppBundle/mouse/focusFollowsMouse.swift
+++ b/Sources/AppBundle/mouse/focusFollowsMouse.swift
@@ -1,0 +1,66 @@
+import AppKit
+import Common
+import CoreGraphics
+
+@MainActor private var focusFollowsMouseMonitor: Any? = nil
+@MainActor private var focusFollowsMouseTask: Task<(), any Error>? = nil
+
+@MainActor
+func installFocusFollowsMouseMonitor() {
+    if let monitor = focusFollowsMouseMonitor {
+        NSEvent.removeMonitor(monitor)
+        focusFollowsMouseMonitor = nil
+    }
+    focusFollowsMouseTask?.cancel()
+    focusFollowsMouseTask = nil
+
+    if !config.focusFollowsMouse { return }
+
+    focusFollowsMouseMonitor = NSEvent.addGlobalMonitorForEvents(matching: .mouseMoved) { _ in
+        Task { @MainActor in
+            handleMouseMoveForFocusFollows()
+        }
+    }
+}
+
+/// CGWindowListCopyWindowInfo returns windows in front-to-back order so first
+/// returned window is visually the topmost one.
+@MainActor
+private func resolveTopmostWindowUnderCursor(_ point: CGPoint) -> Window? {
+    let options = CGWindowListOption(arrayLiteral: .excludeDesktopElements, .optionOnScreenOnly)
+    guard let cfArray = CGWindowListCopyWindowInfo(options, CGWindowID(0)) as? [CFDictionary] else { return nil }
+    for elem in cfArray {
+        let dict = elem as NSDictionary
+        guard let _windowId = dict[kCGWindowNumber] else { continue }
+        let windowId = ((_windowId as! CFNumber) as NSNumber).uint32Value
+        guard let window = Window.get(byId: windowId) else { continue }
+        guard let boundsDict = dict[kCGWindowBounds] else { continue }
+        guard let bounds = CGRect(dictionaryRepresentation: boundsDict as! CFDictionary) else { continue }
+        if bounds.contains(point) {
+            return window
+        }
+    }
+    return nil
+}
+
+@MainActor
+private func handleMouseMoveForFocusFollows() {
+    guard let token: RunSessionGuard = .isServerEnabled else { return }
+    guard !isLeftMouseButtonDown else { return }
+
+    let mouseLocation = mouseLocation
+    let targetWindow = resolveTopmostWindowUnderCursor(mouseLocation)
+
+    guard let targetWindow else { return }
+    guard targetWindow.windowId != focus.windowOrNil?.windowId else { return }
+    guard targetWindow.visualWorkspace != nil else { return }
+
+    focusFollowsMouseTask?.cancel()
+    focusFollowsMouseTask = Task {
+        try checkCancellation()
+        try await runLightSession(.focusFollowsMouse, token) {
+            _ = targetWindow.focusWindow()
+            targetWindow.nativeFocus()
+        }
+    }
+}

--- a/Sources/Common/util/commonUtil.swift
+++ b/Sources/Common/util/commonUtil.swift
@@ -80,6 +80,7 @@ public enum RefreshSessionEvent: Sendable, CustomStringConvertible {
     case onFocusedMonitorChanged
     case onFocusChanged
     case onModeChanged
+    case focusFollowsMouse
 
     public var isStartup: Bool {
         if case .startup = self { return true } else { return false }
@@ -99,6 +100,7 @@ public enum RefreshSessionEvent: Sendable, CustomStringConvertible {
             case .onFocusedMonitorChanged: "onFocusedMonitorChanged"
             case .onFocusChanged: "onFocusChanged"
             case .onModeChanged: "onModeChanged"
+            case .focusFollowsMouse: "focusFollowsMouse"
         }
     }
 }

--- a/docs/config-examples/default-config.toml
+++ b/docs/config-examples/default-config.toml
@@ -40,6 +40,11 @@ default-root-container-orientation = 'auto'
 # Fallback value (if you omit the key): on-focused-monitor-changed = []
 on-focused-monitor-changed = ['move-mouse monitor-lazy-center']
 
+# Focus follows mouse: automatically focus the window under the mouse cursor
+# Possible values: (true|false)
+# Fallback value (if you omit the key): focus-follows-mouse = false
+# focus-follows-mouse = true
+
 # You can effectively turn off macOS "Hide application" (cmd-h) feature by toggling this flag
 # Useful if you don't use this macOS feature, but accidentally hit cmd-h or cmd-alt-h key
 # Also see: https://nikitabobko.github.io/AeroSpace/goodies#disable-hide-app


### PR DESCRIPTION
My third attempt at closing: https://github.com/nikitabobko/AeroSpace/issues/12

The following cases are handled with CGWindowListCopyWindowInfo
        - tiled over floating
        - floating over tiled 
        - multiple overlapping floating

CGWindowListCopyWindowInfo is a public CoreGraphics API already used in windowLevelCache.swift so hopefully it is ok to use in this context. 

The following edge cases are also considered:
        - Focus changes are suppressed while the left mouse button is held (drag operations).
        - The handler is a no-op when AeroSpace is disabled (RunSessionGuard check). 
        - No feedback loop occurs with mouse-follows-focus because move-mouse monitor-lazy-center is a no-op when the cursor is already inside the target,

