### PR TITLE
Fix crash: ThreadGuardedValue accessed after destroy in RunLoop race

### DIFF
--- a/Sources/AppBundle/tree/MacApp.swift
+++ b/Sources/AppBundle/tree/MacApp.swift
@@ -89,6 +89,7 @@ final class MacApp: AbstractApp {
         _ = withWindowAsync(windowId) { [windows] window, job in
             guard let closeButton = window.get(Ax.closeButtonAttr) else { return }
             if AXUIElementPerformAction(closeButton.cast, kAXPressAction as CFString) == .success {
+                guard windows.threadGuardedOrNil != nil else { return }
                 windows.threadGuarded.removeValue(forKey: windowId)
             }
         }
@@ -102,8 +103,10 @@ final class MacApp: AbstractApp {
 
     // todo merge together with detectNewWindows
     func getFocusedWindow() async throws -> Window? {
-        let windowId = try await thread?.runInLoop { [nsApp, axApp, windows] job in
-            try axApp.threadGuarded.get(Ax.focusedWindowAttr)
+        let windowId = try await thread?.runInLoop { [nsApp, axApp, windows] (job) -> UInt32? in
+            guard let axApp = axApp.threadGuardedOrNil else { return nil }
+            guard windows.threadGuardedOrNil != nil else { return nil }
+            return try axApp.get(Ax.focusedWindowAttr)
                 .flatMap { try windows.threadGuarded.getOrRegisterAxWindow(windowId: $0.windowId, $0.ax.cast, nsApp, job) }?
                 .windowId
         }
@@ -134,7 +137,8 @@ final class MacApp: AbstractApp {
     func setAxFrame(_ windowId: UInt32, _ topLeft: CGPoint?, _ size: CGSize?) {
         setFrameJobs.removeValue(forKey: windowId)?.cancel()
         setFrameJobs[windowId] = withWindowAsync(windowId) { [axApp] window, job in
-            try disableAnimations(app: axApp.threadGuarded, job) {
+            guard let axApp = axApp.threadGuardedOrNil else { return }
+            try disableAnimations(app: axApp, job) {
                 try setFrame(window, topLeft, size, job)
             }
         }
@@ -143,7 +147,8 @@ final class MacApp: AbstractApp {
     func setAxFrameBlocking(_ windowId: UInt32, _ topLeft: CGPoint?, _ size: CGSize?) async throws {
         setFrameJobs.removeValue(forKey: windowId)?.cancel()
         try await withWindow(windowId) { [axApp] window, job in
-            try disableAnimations(app: axApp.threadGuarded, job) {
+            guard let axApp = axApp.threadGuardedOrNil else { return }
+            try disableAnimations(app: axApp, job) {
                 try setFrame(window, topLeft, size, job)
             }
         }
@@ -151,7 +156,7 @@ final class MacApp: AbstractApp {
 
     func getAxWindowsCount() async throws -> Int? {
         try await thread?.runInLoop { [axApp] job in
-            axApp.threadGuarded.get(Ax.windowsAttr)?.count
+            axApp.threadGuardedOrNil?.get(Ax.windowsAttr)?.count
         }
     }
 
@@ -165,13 +170,15 @@ final class MacApp: AbstractApp {
 
     func isWindowHeuristic(_ windowId: UInt32, _ windowLevel: MacOsWindowLevel?) async throws -> Bool {
         return try await withWindow(windowId) { [nsApp, axApp, appId] window, job in
-            window.isWindowHeuristic(axApp: axApp.threadGuarded, appId, nsApp.activationPolicy, windowLevel)
+            guard let axApp = axApp.threadGuardedOrNil else { return nil }
+            return window.isWindowHeuristic(axApp: axApp, appId, nsApp.activationPolicy, windowLevel)
         } == true
     }
 
     func getAxUiElementWindowType(_ windowId: UInt32, _ windowLevel: MacOsWindowLevel?) async throws -> AxUiElementWindowType {
         return try await withWindow(windowId) { [nsApp, axApp, appId] window, job in
-            window.getWindowType(axApp: axApp.threadGuarded, appId, nsApp.activationPolicy, windowLevel)
+            guard let axApp = axApp.threadGuardedOrNil else { return nil }
+            return window.getWindowType(axApp: axApp, appId, nsApp.activationPolicy, windowLevel)
         } ?? .window
     }
 
@@ -203,7 +210,8 @@ final class MacApp: AbstractApp {
 
     func dumpAppAxInfo() async throws -> [String: Json] {
         try await thread?.runInLoop { [axApp] job in
-            dumpAxRecursive(axApp.threadGuarded, .app)
+            guard let axApp = axApp.threadGuardedOrNil else { return nil }
+            return dumpAxRecursive(axApp, .app)
         } ?? [:]
     }
 
@@ -273,7 +281,8 @@ final class MacApp: AbstractApp {
         }
         guard let thread else { return [] }
         let (alive, dead) = try await thread.runInLoop { [nsApp, windows, axApp] (job) -> ([UInt32], [UInt32]) in
-            var alive: [UInt32: AxWindow] = windows.threadGuarded
+            guard var alive: [UInt32: AxWindow] = windows.threadGuardedOrNil else { return ([], []) }
+            guard let axApp = axApp.threadGuardedOrNil else { return ([], []) }
             var dead = [UInt32: AxWindow]()
             // Second line of defence against lock screen. See the first line of defence: closedWindowsCache
             // Second and third lines of defence are technically needed only to avoid potential flickering
@@ -284,7 +293,7 @@ final class MacApp: AbstractApp {
                 }
             }
 
-            for (id, window) in axApp.threadGuarded.get(Ax.windowsAttr) ?? [] {
+            for (id, window) in axApp.get(Ax.windowsAttr) ?? [] {
                 try job.checkCancellation()
                 try alive.getOrRegisterAxWindow(windowId: id, window, nsApp, job)
             }
@@ -316,14 +325,14 @@ final class MacApp: AbstractApp {
 
     private func withWindow<T>(_ windowId: UInt32, _ body: @Sendable @escaping (AXUIElement, RunLoopJob) throws -> T?) async throws -> T? {
         try await thread?.runInLoop { [windows] job in
-            guard let window = windows.threadGuarded[windowId] else { return nil }
+            guard let window = windows.threadGuardedOrNil?[windowId] else { return nil }
             return try body(window.ax, job)
         }
     }
 
     private func withWindowAsync(_ windowId: UInt32, _ body: @Sendable @escaping (AXUIElement, RunLoopJob) throws -> ()) -> RunLoopJob {
         thread?.runInLoopAsync { [windows] job in
-            guard let window = windows.threadGuarded[windowId] else { return }
+            guard let window = windows.threadGuardedOrNil?[windowId] else { return }
             try? body(window.ax, job)
         } ?? .cancelled
     }

--- a/Sources/AppBundle/util/ThreadGuardedValue.swift
+++ b/Sources/AppBundle/util/ThreadGuardedValue.swift
@@ -14,6 +14,10 @@ final class ThreadGuardedValue<Value>: Sendable {
             _threadGuarded = newValue
         }
     }
+    var threadGuardedOrNil: Value? {
+        threadToken.checkEquals(axTaskLocalAppThreadToken)
+        return _threadGuarded
+    }
     func destroy() {
         threadToken.checkEquals(axTaskLocalAppThreadToken)
         _threadGuarded = nil


### PR DESCRIPTION
When an app is destroyed, `CFRunLoopStop` is asynchronous — pending AX notification callbacks can still fire and access `windows`/`axApp` after `destroy()` has already set `_threadGuarded` to nil, causing a crash with "Value is already destroyed".

Add `threadGuardedOrNil` safe accessor to `ThreadGuardedValue` that returns nil instead of crashing, and use it in all RunLoop closures in `MacApp` so they gracefully bail out post-destroy.

Try to fix https://github.com/nikitabobko/AeroSpace/issues/1921

## PR checklist

- [x] Explain your changes in the relevant commit messages rather than in the PR description. The PR description must not contain more information than the commit messages (except for images and other media).
- [x] Each commit must explain what/why/how and motivation in its description. https://cbea.ms/git-commit/
- [x] Don't forget to link the appropriate issues/discussions in commit messages (if applicable).
- [x] Each commit must be an atomic change (a PR may contain several commits). Don't introduce new functional changes together with refactorings in the same commit.
- [x] `./run-tests.sh` exits with non-zero exit code.
- [x] Avoid merge commits, always rebase and force push.

Failure to follow the checklist with no apparent reasons will result in silent PR rejection.
