### PR TITLE
Exclude UniversalControl from AX queries entirely

### DIFF
--- a/Sources/AppBundle/GlobalObserver.swift
+++ b/Sources/AppBundle/GlobalObserver.swift
@@ -5,9 +5,9 @@ enum GlobalObserver {
     private static func onNotif(_ notification: Notification) {
         // Third line of defence against lock screen window. See: closedWindowsCache
         // Second and third lines of defence are technically needed only to avoid potential flickering
-        if (notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication)?.bundleIdentifier == lockScreenAppBundleId {
-            return
-        }
+        let notifBundleId = (notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication)?.bundleIdentifier
+        if notifBundleId == lockScreenAppBundleId { return }
+        if let notifBundleId, axExcludedBundleIds.contains(notifBundleId) { return }
         let notifName = notification.name.rawValue
         Task { @MainActor in
             if !TrayMenuModel.shared.isEnabled { return }

--- a/Sources/AppBundle/tree/MacApp.swift
+++ b/Sources/AppBundle/tree/MacApp.swift
@@ -26,7 +26,6 @@ final class MacApp: AbstractApp {
     //      and make deinitialization automatic in deinit
     @MainActor static var allAppsMap: [pid_t: MacApp] = [:]
     @MainActor private static var wipPids: [pid_t: AwaitableOneTimeBroadcastLatch] = [:]
-
     private init(_ nsApp: NSRunningApplication, _ axApp: AXUIElement, _ axSubscriptions: [AxSubscription], _ thread: Thread) {
         self.nsApp = nsApp
         self.axApp = .init(axApp)
@@ -44,6 +43,8 @@ final class MacApp: AbstractApp {
         // Don't perceive any of the lock screen windows as real windows
         // Otherwise, false positive ax notifications might trigger that lead to gcWindows
         if nsApp.bundleIdentifier == lockScreenAppBundleId { return nil }
+        // Skip system processes that don't support the accessibility server
+        if let bundleId = nsApp.bundleIdentifier, axExcludedBundleIds.contains(bundleId) { return nil }
         let pid = nsApp.processIdentifier
         // AX requests crash if you send them to yourself
         if pid == myPid { return nil }

--- a/Sources/AppBundle/util/appBundleUtil.swift
+++ b/Sources/AppBundle/util/appBundleUtil.swift
@@ -8,6 +8,14 @@ let signposter = OSSignposter(subsystem: aeroSpaceAppId, category: .pointsOfInte
 let myPid = NSRunningApplication.current.processIdentifier
 let lockScreenAppBundleId = "com.apple.loginwindow"
 
+/// Bundle IDs of system processes that should never be queried via the Accessibility API.
+/// These processes don't expose an axserver endpoint, and repeated AX queries against them
+/// generate aggressive Mach IPC traffic that can destabilize the process.
+/// For example, querying UniversalControl disrupts its connection to paired devices.
+let axExcludedBundleIds: Set<String> = [
+    "com.apple.universalcontrol",
+]
+
 func interceptTermination(_ _signal: Int32) {
     signal(_signal, { signal in
         check(Thread.current.isMainThread)


### PR DESCRIPTION
## Summary                                                                         
  Exclude UniversalControl from Accessibility API queries to prevent device          
  disconnects.                                                                       
   
  See commit message for details.                                                    
                                                                  
  ## PR checklist

  - [x] Explain your changes in the relevant commit messages rather than in the PR   
  description.
  - [x] Each commit must explain what/why/how and motivation in its description.     
  - [x] Each commit must be an atomic change.                                        
  - [x] `./run-tests.sh` exits with zero exit code.                                  
  - [x] Avoid merge commits, always rebase and force push.     

Failure to follow the checklist with no apparent reasons will result in silent PR rejection.
