### PR TITLE
Fix on-window-detected floating rule causing brief tiling flash

### DIFF
--- a/Sources/AppBundle/layout/layoutRecursive.swift
+++ b/Sources/AppBundle/layout/layoutRecursive.swift
@@ -22,11 +22,13 @@ extension TreeNode {
                 lastAppliedLayoutVirtualRect = virtual
                 try await workspace.rootTilingContainer.layoutRecursive(point, width: width, height: height, virtual: virtual, context)
                 for window in workspace.children.filterIsInstance(of: Window.self) {
+                    if window.isAwaitingOnWindowDetected { continue }
                     window.lastAppliedLayoutPhysicalRect = nil
                     window.lastAppliedLayoutVirtualRect = nil
                     try await window.layoutFloatingWindow(context)
                 }
             case .window(let window):
+                if window.isAwaitingOnWindowDetected { break }
                 if window.windowId != currentlyManipulatedWithMouseWindowId {
                     lastAppliedLayoutVirtualRect = virtual
                     if window.isFullscreen && window == context.workspace.rootTilingContainer.mostRecentWindowRecursive {
@@ -108,11 +110,15 @@ extension TilingContainer {
         var point = point
         var virtualPoint = virtual.topLeftCorner
 
-        guard let delta = ((orientation == .h ? width : height) - CGFloat(children.sumOfDouble { $0.getWeight(orientation) }))
-            .div(children.count) else { return }
+        // Exclude windows awaiting on-window-detected from space allocation --
+        // their slot would otherwise shrink siblings while they sit invisible.
+        let effectiveChildren = children.filter { ($0 as? Window)?.isAwaitingOnWindowDetected != true }
 
-        let lastIndex = children.indices.last
-        for (i, child) in children.enumerated() {
+        guard let delta = ((orientation == .h ? width : height) - CGFloat(effectiveChildren.sumOfDouble { $0.getWeight(orientation) }))
+            .div(effectiveChildren.count) else { return }
+
+        let lastIndex = effectiveChildren.indices.last
+        for (i, child) in effectiveChildren.enumerated() {
             child.setWeight(orientation, child.getWeight(orientation) + delta)
             let rawGap = context.resolvedGaps.inner.get(orientation).toDouble()
             // Gaps. Consider 4 cases:

--- a/Sources/AppBundle/tree/MacWindow.swift
+++ b/Sources/AppBundle/tree/MacWindow.swift
@@ -31,9 +31,11 @@ final class MacWindow: Window {
         // atomic synchronous section
         if let existing = allWindowsMap[windowId] { return existing }
         let window = MacWindow(windowId, macApp, lastFloatingSize: rect?.size, parent: data.parent, adaptiveWeight: data.adaptiveWeight, index: data.index)
+        window.isAwaitingOnWindowDetected = true
         allWindowsMap[windowId] = window
 
         try await debugWindowsIfRecording(window)
+        defer { window.isAwaitingOnWindowDetected = false }
         if try await !restoreClosedWindowsCacheIfNeeded(newlyDetectedWindow: window) {
             try await tryOnWindowDetected(window)
         }

--- a/Sources/AppBundle/tree/Window.swift
+++ b/Sources/AppBundle/tree/Window.swift
@@ -5,6 +5,7 @@ open class Window: TreeNode, Hashable {
     let windowId: UInt32
     let app: any AbstractApp
     var lastFloatingSize: CGSize?
+    var isAwaitingOnWindowDetected: Bool = false
     var isFullscreen: Bool = false
     var noOuterGapsInFullscreen: Bool = false
     var layoutReason: LayoutReason = .standard


### PR DESCRIPTION
Fixes two related visual glitches when an `on-window-detected` rule applies `layout floating`:

1. The new window briefly flashes at its tiled position before floating.
2. Sibling tiling windows briefly shift to make room for the incoming window's tile slot.

See the commit message for root cause and fix details.

Related discussion: https://github.com/nikitabobko/AeroSpace/discussions/2016

Summary:
- if you set an app as layout floating in [on-window-detected], sometimes it tries to tile it first

---

- [x] I've read [CONTRIBUTING.md](https://github.com/nikitabobko/AeroSpace/blob/main/CONTRIBUTING.md)
- [x] My PR contains atomic commits (each commit is a self-contained change with a descriptive message explaining what and why)
- [x] My PR doesn't contain merge commits (I've rebased on top of the target branch instead)
- [x] If my PR is ready for review, I've marked it as such (not a draft)
- [x] I've added a link to the relevant GitHub Discussion (if applicable)
- [x] I've tested my changes manually