### PR TITLE
Add on-monitor-changed config callback

### DIFF
--- a/Sources/AppBundle/GlobalObserver.swift
+++ b/Sources/AppBundle/GlobalObserver.swift
@@ -53,6 +53,16 @@ enum GlobalObserver {
         nc.addObserver(forName: NSWorkspace.activeSpaceDidChangeNotification, object: nil, queue: .main, using: onNotif)
         nc.addObserver(forName: NSWorkspace.didTerminateApplicationNotification, object: nil, queue: .main, using: onNotif)
 
+        // Detect monitor connect/disconnect via CoreGraphics callback.
+        CGDisplayRegisterReconfigurationCallback({ _, flags, _ in
+            // Only act on completion of a reconfiguration, not the begin phase
+            guard flags.contains(.beginConfigurationFlag) == false else { return }
+            Task { @MainActor in
+                if !TrayMenuModel.shared.isEnabled { return }
+                scheduleRefreshSession(.globalObserver("displayReconfiguration"))
+            }
+        }, nil)
+
         NSEvent.addGlobalMonitorForEvents(matching: .leftMouseUp) { _ in
             // todo reduce number of refreshSession in the callback
             //  resetManipulatedWithMouseIfPossible might call its own refreshSession

--- a/Sources/AppBundle/config/Config.swift
+++ b/Sources/AppBundle/config/Config.swift
@@ -54,6 +54,7 @@ struct Config: ConvenienceCopyable {
     var onFocusChanged: [any Command] = []
     // var onFocusedWorkspaceChanged: [any Command] = []
     var onFocusedMonitorChanged: [any Command] = []
+    var onMonitorChanged: [any Command] = []
 
     var gaps: Gaps = .zero
     var workspaceToMonitorForceAssignment: [String: [MonitorDescription]] = [:]

--- a/Sources/AppBundle/config/parseConfig.swift
+++ b/Sources/AppBundle/config/parseConfig.swift
@@ -102,6 +102,7 @@ private let configParser: [String: any ParserProtocol<Config>] = [
     "on-focus-changed": Parser(\.onFocusChanged) { parseCommandOrCommands($0).toParsedConfig($1) },
     "on-mode-changed": Parser(\.onModeChanged) { parseCommandOrCommands($0).toParsedConfig($1) },
     "on-focused-monitor-changed": Parser(\.onFocusedMonitorChanged) { parseCommandOrCommands($0).toParsedConfig($1) },
+    "on-monitor-changed": Parser(\.onMonitorChanged) { parseCommandOrCommands($0).toParsedConfig($1) },
     // "on-focused-workspace-changed": Parser(\.onFocusedWorkspaceChanged, { parseCommandOrCommands($0).toParsedConfig($1) }),
 
     "enable-normalization-flatten-containers": Parser(\.enableNormalizationFlattenContainers, parseBool),

--- a/Sources/AppBundle/layout/refresh.swift
+++ b/Sources/AppBundle/layout/refresh.swift
@@ -41,6 +41,7 @@ func runRefreshSessionBlocking(
             SecureInputPanel.shared.refresh()
             try await normalizeLayoutReason()
             if shouldLayoutWorkspaces { try await layoutWorkspaces() }
+            checkOnMonitorChangedCallback()
         }
     }
 }

--- a/Sources/AppBundle/model/ServerEvent.swift
+++ b/Sources/AppBundle/model/ServerEvent.swift
@@ -45,4 +45,8 @@ public struct ServerEvent: Codable, Sendable {
     public static func bindingTriggered(mode: String, binding: String) -> ServerEvent {
         ServerEvent(_event: .bindingTriggered, mode: mode, binding: binding)
     }
+
+    public static func monitorChanged(monitorCount: Int) -> ServerEvent {
+        ServerEvent(_event: .monitorChanged, monitorId: monitorCount)
+    }
 }

--- a/Sources/AppBundle/subscriptions.swift
+++ b/Sources/AppBundle/subscriptions.swift
@@ -30,7 +30,7 @@ func handleSubscribeAndWaitTillError(_ connection: NWConnection, _ args: Subscri
                         workspace: f.workspace.name,
                         monitorId_oneBased: f.workspace.workspaceMonitor.monitorId_oneBased ?? 0,
                     )
-                case .windowDetected, .bindingTriggered: continue
+                case .windowDetected, .bindingTriggered, .monitorChanged: continue
             }
             if await connection.writeAtomic(event, jsonEncoder).error != nil {
                 return

--- a/Sources/AppBundle/tree/Workspace.swift
+++ b/Sources/AppBundle/tree/Workspace.swift
@@ -133,9 +133,30 @@ extension Monitor {
 }
 
 @MainActor
+var _previousMonitorCount: Int = NSScreen.screens.count
+
+@MainActor
 func gcMonitors() {
     if screenPointToVisibleWorkspace.count != monitors.count {
         rearrangeWorkspacesOnMonitors()
+    }
+}
+
+/// Check if the monitor count changed since last check and fire the callback.
+/// Must be called AFTER layoutWorkspaces() so that external tools see the final state.
+@MainActor
+func checkOnMonitorChangedCallback() {
+    let current = monitors.count
+    if current != _previousMonitorCount {
+        _previousMonitorCount = current
+        broadcastEvent(.monitorChanged(monitorCount: current))
+        if config.onMonitorChanged.isEmpty { return }
+        guard let token: RunSessionGuard = .isServerEnabled else { return }
+        Task {
+            try await runLightSession(.onMonitorChanged, token) {
+                _ = try await config.onMonitorChanged.runCmdSeq(.defaultEnv, .emptyStdin)
+            }
+        }
     }
 }
 

--- a/Sources/AppBundleTests/command/SubscribeCmdArgsTest.swift
+++ b/Sources/AppBundleTests/command/SubscribeCmdArgsTest.swift
@@ -31,7 +31,7 @@ final class SubscribeCmdArgsTest: XCTestCase {
             case .failure(let err):
                 assertEquals(err, """
                     ERROR: Can't parse 'unknown-event'.
-                           Possible values: (focus-changed|focused-monitor-changed|focused-workspace-changed|mode-changed|window-detected|binding-triggered)
+                           Possible values: (focus-changed|focused-monitor-changed|focused-workspace-changed|mode-changed|window-detected|binding-triggered|monitor-changed)
                     """)
         }
     }

--- a/Sources/Common/cmdArgs/impl/SubscribeCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/SubscribeCmdArgs.swift
@@ -61,4 +61,5 @@ public enum ServerEventType: String, Codable, CaseIterable, Sendable {
     case modeChanged = "mode-changed"
     case windowDetected = "window-detected"
     case bindingTriggered = "binding-triggered"
+    case monitorChanged = "monitor-changed"
 }

--- a/Sources/Common/util/commonUtil.swift
+++ b/Sources/Common/util/commonUtil.swift
@@ -80,6 +80,8 @@ public enum RefreshSessionEvent: Sendable, CustomStringConvertible {
     case onFocusedMonitorChanged
     case onFocusChanged
     case onModeChanged
+    case focusFollowsMouse
+    case onMonitorChanged
 
     public var isStartup: Bool {
         if case .startup = self { return true } else { return false }
@@ -99,6 +101,8 @@ public enum RefreshSessionEvent: Sendable, CustomStringConvertible {
             case .onFocusedMonitorChanged: "onFocusedMonitorChanged"
             case .onFocusChanged: "onFocusChanged"
             case .onModeChanged: "onModeChanged"
+            case .focusFollowsMouse: "focusFollowsMouse"
+            case .onMonitorChanged: "onMonitorChanged"
         }
     }
 }


### PR DESCRIPTION
See the commit message for details.

Config syntax:
```toml
on-monitor-changed = 'exec-and-forget sketchybar --reload'
```

Use case: I use this to reload sketchybar when connecting/disconnecting an external monitor, so workspace items are recreated for the current display configuration.

---

- [x] I've read [CONTRIBUTING.md](https://github.com/nikitabobko/AeroSpace/blob/main/CONTRIBUTING.md)
- [x] My PR contains atomic commits (each commit is a self-contained change with a descriptive message explaining what and why)
- [x] My PR doesn't contain merge commits (I've rebased on top of the target branch instead)
- [x] If my PR is ready for review, I've marked it as such (not a draft)
- [x] I've added a link to the relevant GitHub Discussion (if applicable)
- [x] I've tested my changes manually