### PR TITLE
Add scrolling workspace layout

### DIFF
--- a/Sources/AppBundle/command/cmdManifest.swift
+++ b/Sources/AppBundle/command/cmdManifest.swift
@@ -68,6 +68,8 @@ extension CmdArgs {
                 command = ReloadConfigCommand(args: self as! ReloadConfigCmdArgs)
             case .resize:
                 command = ResizeCommand(args: self as! ResizeCmdArgs)
+            case .scroll:
+                command = ScrollCommand(args: self as! ScrollCmdArgs)
             case .split:
                 command = SplitCommand(args: self as! SplitCmdArgs)
             case .subscribe:

--- a/Sources/AppBundle/command/format.swift
+++ b/Sources/AppBundle/command/format.swift
@@ -227,20 +227,30 @@ private func toLayoutString(tc: TilingContainer) -> String {
         case (.tiles, .v): return LayoutCmdArgs.LayoutDescription.v_tiles.rawValue
         case (.accordion, .h): return LayoutCmdArgs.LayoutDescription.h_accordion.rawValue
         case (.accordion, .v): return LayoutCmdArgs.LayoutDescription.v_accordion.rawValue
+        case (.scrolling, _): return LayoutCmdArgs.LayoutDescription.scrolling.rawValue
     }
 }
 
 private func toLayoutResult(w: Window) -> Result<Primitive, String> {
     guard let parent = w.parent else { return .failure("NULL-PARENT") }
-    return switch getChildParentRelation(child: w, parent: parent) {
-        case .tiling(let tc): .success(.string(toLayoutString(tc: tc)))
-        case .floatingWindow: .success(.string(LayoutCmdArgs.LayoutDescription.floating.rawValue))
-        case .macosNativeFullscreenWindow: .success(.string("macos_native_fullscreen"))
-        case .macosNativeHiddenAppWindow: .success(.string("macos_native_window_of_hidden_app"))
-        case .macosNativeMinimizedWindow: .success(.string("macos_native_minimized"))
-        case .macosPopupWindow: .success(.string("NULL-WINDOW-LAYOUT"))
-
-        case .rootTilingContainer: .failure("Not possible")
-        case .shimContainerRelation: .failure("Window cannot have a shim container relation")
+    switch getChildParentRelation(child: w, parent: parent) {
+        case .tiling(let tc):
+            let rootContainer = w.parentsWithSelf.compactMap { $0 as? TilingContainer }.last
+            let layoutContainer = rootContainer?.layout == .scrolling ? rootContainer ?? tc : tc
+            return .success(.string(toLayoutString(tc: layoutContainer)))
+        case .floatingWindow:
+            return .success(.string(LayoutCmdArgs.LayoutDescription.floating.rawValue))
+        case .macosNativeFullscreenWindow:
+            return .success(.string("macos_native_fullscreen"))
+        case .macosNativeHiddenAppWindow:
+            return .success(.string("macos_native_window_of_hidden_app"))
+        case .macosNativeMinimizedWindow:
+            return .success(.string("macos_native_minimized"))
+        case .macosPopupWindow:
+            return .success(.string("NULL-WINDOW-LAYOUT"))
+        case .rootTilingContainer:
+            return .failure("Not possible")
+        case .shimContainerRelation:
+            return .failure("Window cannot have a shim container relation")
     }
 }

--- a/Sources/AppBundle/command/impl/BalanceSizesCommand.swift
+++ b/Sources/AppBundle/command/impl/BalanceSizesCommand.swift
@@ -8,6 +8,9 @@ struct BalanceSizesCommand: Command {
 
     func run(_ env: CmdEnv, _ io: CmdIo) -> BinaryExitCode {
         guard let target = args.resolveTargetOrReportError(env, io) else { return .fail }
+        if target.workspace.rootTilingContainer.layout == .scrolling {
+            return .fail(io.err("balance-sizes command doesn't support the scrolling layout"))
+        }
         balance(target.workspace.rootTilingContainer)
         return .succ
     }
@@ -19,6 +22,7 @@ private func balance(_ parent: TilingContainer) {
         switch parent.layout {
             case .tiles: child.setWeight(parent.orientation, 1)
             case .accordion: break // Do nothing
+            case .scrolling: break
         }
         if let child = child as? TilingContainer {
             balance(child)

--- a/Sources/AppBundle/command/impl/LayoutCommand.swift
+++ b/Sources/AppBundle/command/impl/LayoutCommand.swift
@@ -26,6 +26,8 @@ struct LayoutCommand: Command {
                 return changeTilingLayout(io, targetLayout: .accordion, targetOrientation: nil, window: window)
             case .tiles:
                 return changeTilingLayout(io, targetLayout: .tiles, targetOrientation: nil, window: window)
+            case .scrolling:
+                return changeTilingLayout(io, targetLayout: .scrolling, targetOrientation: .h, window: window)
             case .horizontal:
                 return changeTilingLayout(io, targetLayout: nil, targetOrientation: .h, window: window)
             case .vertical:
@@ -57,10 +59,21 @@ struct LayoutCommand: Command {
     guard let parent = window.parent else { return .fail }
     switch parent.cases {
         case .tilingContainer(let parent):
+            if targetLayout == .scrolling && !parent.isRootContainer {
+                return .fail(io.err("The 'scrolling' layout is only supported for workspace root containers"))
+            }
+            if parent.layout == .scrolling && targetLayout == nil && targetOrientation == .v {
+                return .fail(io.err("The scrolling layout is always horizontal"))
+            }
             let targetOrientation = targetOrientation ?? parent.orientation
             let targetLayout = targetLayout ?? parent.layout
             parent.layout = targetLayout
             parent.changeOrientation(targetOrientation)
+            if targetLayout == .scrolling {
+                parent.reveal(window, preferRightPane: true)
+            } else {
+                parent.clampScrollingIndex()
+            }
             return .succ
         case .workspace, .macosMinimizedWindowsContainer, .macosFullscreenWindowsContainer,
              .macosPopupWindowsContainer, .macosHiddenAppsWindowsContainer:
@@ -73,6 +86,8 @@ extension Window {
         return switch layout {
             case .accordion:   (parent as? TilingContainer)?.layout == .accordion
             case .tiles:       (parent as? TilingContainer)?.layout == .tiles
+            case .scrolling:
+                parentsWithSelf.compactMap { $0 as? TilingContainer }.last?.layout == .scrolling
             case .horizontal:  (parent as? TilingContainer)?.orientation == .h
             case .vertical:    (parent as? TilingContainer)?.orientation == .v
             case .h_accordion: (parent as? TilingContainer).map { $0.layout == .accordion && $0.orientation == .h } == true

--- a/Sources/AppBundle/command/impl/MoveCommand.swift
+++ b/Sources/AppBundle/command/impl/MoveCommand.swift
@@ -12,6 +12,7 @@ struct MoveCommand: Command {
             return .fail(io.err(noWindowIsFocused))
         }
         guard let parent = currentWindow.parent else { return .fail }
+        let result: BinaryExitCode
         switch parent.cases {
             case .tilingContainer(let parent):
                 let indexOfCurrent = currentWindow.ownIndex.orDie()
@@ -19,22 +20,26 @@ struct MoveCommand: Command {
                 if parent.orientation == direction.orientation && parent.children.indices.contains(indexOfSiblingTarget) {
                     switch parent.children[indexOfSiblingTarget].tilingTreeNodeCasesOrDie() {
                         case .tilingContainer(let topLevelSiblingTargetContainer):
-                            return deepMoveIn(window: currentWindow, into: topLevelSiblingTargetContainer, moveDirection: direction)
+                            result = deepMoveIn(window: currentWindow, into: topLevelSiblingTargetContainer, moveDirection: direction)
                         case .window: // "swap windows"
                             let prevBinding = currentWindow.unbindFromParent()
                             currentWindow.bind(to: parent, adaptiveWeight: prevBinding.adaptiveWeight, index: indexOfSiblingTarget)
-                            return .succ
+                            result = .succ
                     }
                 } else {
-                    return moveOut(window: currentWindow, direction: direction, io, args, env)
+                    result = moveOut(window: currentWindow, direction: direction, io, args, env)
                 }
             case .workspace: // floating window
-                return .fail(io.err("moving floating windows isn't yet supported")) // todo
+                result = .fail(io.err("moving floating windows isn't yet supported")) // todo
             case .macosMinimizedWindowsContainer, .macosFullscreenWindowsContainer, .macosHiddenAppsWindowsContainer:
-                return .fail(io.err(moveOutMacosUnconventionalWindow))
+                result = .fail(io.err(moveOutMacosUnconventionalWindow))
             case .macosPopupWindowsContainer:
-                return .fail // Impossible
+                result = .fail // Impossible
         }
+        if result == .succ {
+            currentWindow.nodeWorkspace?.rootTilingContainer.reveal(currentWindow, preferRightPane: false)
+        }
+        return result
     }
 }
 
@@ -52,8 +57,7 @@ struct MoveCommand: Command {
                 case .stop: return .succ
                 case .fail: return .fail
                 case .createImplicitContainer:
-                    createImplicitContainerAndMoveWindow(window, workspace, direction)
-                    return .succ
+                    return .from(bool: createImplicitContainerAndMoveWindow(window, workspace, direction, io))
             }
         case .allMonitorsOuterFrame:
             guard let (monitors, index) = window.nodeMonitor?.findRelativeMonitor(inDirection: direction) else {
@@ -67,7 +71,7 @@ struct MoveCommand: Command {
 
                 return MoveNodeToMonitorCommand(args: moveNodeToMonitorArgs).run(env, io)
             } else {
-                return hitAllMonitorsOuterFrameBoundaries(window, workspace, args, direction)
+                return hitAllMonitorsOuterFrameBoundaries(window, workspace, args, direction, io)
             }
     }
 }
@@ -77,13 +81,13 @@ struct MoveCommand: Command {
     _ workspace: Workspace,
     _ args: MoveCmdArgs,
     _ direction: CardinalDirection,
+    _ io: CmdIo,
 ) -> BinaryExitCode {
     switch args.boundariesAction {
         case .stop: return .succ
         case .fail: return .fail
         case .createImplicitContainer:
-            createImplicitContainerAndMoveWindow(window, workspace, direction)
-            return .succ
+            return .from(bool: createImplicitContainerAndMoveWindow(window, workspace, direction, io))
     }
 }
 
@@ -125,14 +129,20 @@ private let moveOutMacosUnconventionalWindow = "moving macOS fullscreen, minimiz
     _ window: Window,
     _ workspace: Workspace,
     _ direction: CardinalDirection,
-) {
+    _ io: CmdIo,
+) -> Bool {
     let prevRoot = workspace.rootTilingContainer
+    if prevRoot.layout == .scrolling {
+        io.err("move --boundaries-action create-implicit-container doesn't support the scrolling layout")
+        return false
+    }
     prevRoot.unbindFromParent()
     // Force tiles layout
     _ = TilingContainer(parent: workspace, adaptiveWeight: WEIGHT_AUTO, direction.orientation, .tiles, index: 0)
     check(prevRoot != workspace.rootTilingContainer)
     prevRoot.bind(to: workspace.rootTilingContainer, adaptiveWeight: WEIGHT_AUTO, index: 0)
     window.bind(to: workspace.rootTilingContainer, adaptiveWeight: WEIGHT_AUTO, index: direction.insertionOffset)
+    return true
 }
 
 @MainActor private func deepMoveIn(window: Window, into container: TilingContainer, moveDirection: CardinalDirection) -> BinaryExitCode {

--- a/Sources/AppBundle/command/impl/ResizeCommand.swift
+++ b/Sources/AppBundle/command/impl/ResizeCommand.swift
@@ -7,6 +7,9 @@ struct ResizeCommand: Command { // todo cover with tests
 
     func run(_ env: CmdEnv, _ io: CmdIo) -> BinaryExitCode {
         guard let target = args.resolveTargetOrReportError(env, io) else { return .fail }
+        if target.workspace.rootTilingContainer.layout == .scrolling {
+            return .fail(io.err("resize command doesn't support the scrolling layout"))
+        }
 
         let candidates = target.windowOrNil?.parentsWithSelf
             .filter { ($0.parent as? TilingContainer)?.layout == .tiles }

--- a/Sources/AppBundle/command/impl/ScrollCommand.swift
+++ b/Sources/AppBundle/command/impl/ScrollCommand.swift
@@ -1,0 +1,22 @@
+import AppKit
+import Common
+
+struct ScrollCommand: Command {
+    let args: ScrollCmdArgs
+    /*conforms*/ let shouldResetClosedWindowsCache = false
+
+    @MainActor
+    func run(_ env: CmdEnv, _ io: CmdIo) async throws -> BinaryExitCode {
+        let root = focus.workspace.rootTilingContainer
+        guard root.layout == .scrolling else {
+            return .fail(io.err("scroll command only works when the workspace root container uses the scrolling layout"))
+        }
+        let direction: CardinalDirection = switch args.direction.val {
+            case .left: .left
+            case .right: .right
+        }
+        root.clampScrollingIndex()
+        guard let target = root.scroll(in: direction) else { return .succ }
+        return .from(bool: target.focusWindow())
+    }
+}

--- a/Sources/AppBundle/command/impl/SplitCommand.swift
+++ b/Sources/AppBundle/command/impl/SplitCommand.swift
@@ -24,6 +24,9 @@ struct SplitCommand: Command {
                     case .horizontal: .h
                     case .opposite: parent.orientation.opposite
                 }
+                if parent.layout == .scrolling && orientation != .h {
+                    return .fail(io.err("The scrolling layout is always horizontal"))
+                }
                 if parent.children.count == 1 {
                     parent.changeOrientation(orientation)
                 } else {

--- a/Sources/AppBundle/focus.swift
+++ b/Sources/AppBundle/focus.swift
@@ -72,6 +72,7 @@ private struct FrozenFocus: AeroAny, Equatable, Sendable {
     let status = newFocus.workspace.workspaceMonitor.setActiveWorkspace(newFocus.workspace)
 
     newFocus.windowOrNil?.markAsMostRecentChild()
+    newFocus.workspace.rootTilingContainer.reveal(newFocus.windowOrNil, preferRightPane: false)
     return status
 }
 extension Window {

--- a/Sources/AppBundle/initAppBundle.swift
+++ b/Sources/AppBundle/initAppBundle.swift
@@ -48,9 +48,16 @@ import Foundation
 private func smartLayoutAtStartup() {
     let workspace = focus.workspace
     let root = workspace.rootTilingContainer
-    switch root.children.count <= 3 {
-        case true: root.layout = .tiles
-        case false: root.layout = .accordion
+    if config.defaultRootContainerLayout == .scrolling {
+        root.layout = .scrolling
+        root.changeOrientation(.h)
+        root.reveal(focus.windowOrNil, preferRightPane: true)
+        return
+    }
+    if root.children.count <= 3 {
+        root.layout = .tiles
+    } else {
+        root.layout = .accordion
     }
 }
 

--- a/Sources/AppBundle/layout/layoutRecursive.swift
+++ b/Sources/AppBundle/layout/layoutRecursive.swift
@@ -46,6 +46,8 @@ extension TreeNode {
                         try await container.layoutTiles(point, width: width, height: height, virtual: virtual, context)
                     case .accordion:
                         try await container.layoutAccordion(point, width: width, height: height, virtual: virtual, context)
+                    case .scrolling:
+                        try await container.layoutScrolling(point, width: width, height: height, virtual: virtual, context)
                 }
             case .macosMinimizedWindowsContainer, .macosFullscreenWindowsContainer,
                  .macosPopupWindowsContainer, .macosHiddenAppsWindowsContainer:
@@ -169,6 +171,35 @@ extension TilingContainer {
                         context,
                     )
             }
+        }
+    }
+
+    @MainActor
+    fileprivate func layoutScrolling(_ point: CGPoint, width: CGFloat, height: CGFloat, virtual: Rect, _ context: LayoutContext) async throws {
+        clampScrollingIndex()
+        switch children.count {
+            case 0:
+                return
+            case 1:
+                try await children[0].layoutRecursive(point, width: width, height: height, virtual: virtual, context)
+            default:
+                let pageWidth = width / 2
+                let rawGap = context.resolvedGaps.inner.horizontal.toDouble()
+                for (index, child) in children.enumerated() {
+                    let virtualX = virtual.topLeftX + CGFloat(index) * pageWidth
+                    let physicalX = point.x + CGFloat(index - scrollingIndex) * pageWidth
+                    let isLeftVisiblePage = index == scrollingIndex
+                    let isRightVisiblePage = index == scrollingIndex + 1
+                    let lPadding = isRightVisiblePage ? rawGap / 2 : 0
+                    let rPadding = isLeftVisiblePage ? rawGap / 2 : 0
+                    try await child.layoutRecursive(
+                        CGPoint(x: physicalX + lPadding, y: point.y),
+                        width: pageWidth - lPadding - rPadding,
+                        height: height,
+                        virtual: Rect(topLeftX: virtualX, topLeftY: virtual.topLeftY, width: pageWidth, height: height),
+                        context,
+                    )
+                }
         }
     }
 }

--- a/Sources/AppBundle/mouse/moveWithMouse.swift
+++ b/Sources/AppBundle/mouse/moveWithMouse.swift
@@ -104,6 +104,10 @@ extension CGPoint {
                 })
             case .accordion:
                 tree.mostRecentChild
+            case .scrolling:
+                tree.children.first(where: {
+                    (virtual ? $0.lastAppliedLayoutVirtualRect : $0.lastAppliedLayoutPhysicalRect)?.contains(point) == true
+                })
         }
         guard let target else { return nil }
         return switch target.tilingTreeNodeCasesOrDie() {

--- a/Sources/AppBundle/tree/TilingContainer.swift
+++ b/Sources/AppBundle/tree/TilingContainer.swift
@@ -5,6 +5,11 @@ final class TilingContainer: TreeNode, NonLeafTreeNodeObject { // todo consider 
     fileprivate var _orientation: Orientation
     var orientation: Orientation { _orientation }
     var layout: Layout
+    private var _scrollingIndex: Int = 0
+    var scrollingIndex: Int {
+        get { _scrollingIndex }
+        set { _scrollingIndex = max(0, newValue) }
+    }
 
     @MainActor
     init(parent: NonLeafTreeNodeObject, adaptiveWeight: CGFloat, _ orientation: Orientation, _ layout: Layout, index: Int) {
@@ -26,6 +31,55 @@ final class TilingContainer: TreeNode, NonLeafTreeNodeObject { // todo consider 
 
 extension TilingContainer {
     var isRootContainer: Bool { parent is Workspace }
+    var isScrollingRoot: Bool { isRootContainer && layout == .scrolling }
+
+    var maxScrollingIndex: Int { max(0, children.count - 2) }
+
+    func clampScrollingIndex() {
+        scrollingIndex = isScrollingRoot ? min(scrollingIndex, maxScrollingIndex) : 0
+    }
+
+    @MainActor
+    func reveal(_ window: Window?, preferRightPane: Bool) {
+        guard isScrollingRoot else { return }
+        guard let index = window.flatMap(scrollingPageIndex(for:)) else {
+            clampScrollingIndex()
+            return
+        }
+        scrollingIndex = preferRightPane
+            ? min(max(0, index - 1), maxScrollingIndex)
+            : min(
+                max(
+                    0,
+                    index < scrollingIndex
+                        ? index
+                        : (index > scrollingIndex + 1 ? index - 1 : scrollingIndex),
+                ),
+                maxScrollingIndex,
+            )
+    }
+
+    @MainActor
+    func scroll(in direction: CardinalDirection) -> Window? {
+        guard isScrollingRoot else { return nil }
+        switch direction {
+            case .left:
+                let nextIndex = max(0, scrollingIndex - 1)
+                scrollingIndex = nextIndex
+                return children.getOrNil(atIndex: nextIndex)?.findLeafWindowRecursive(snappedTo: .left)
+            case .right:
+                let nextIndex = min(maxScrollingIndex, scrollingIndex + 1)
+                scrollingIndex = nextIndex
+                return children.getOrNil(atIndex: nextIndex + 1)?.findLeafWindowRecursive(snappedTo: .right)
+            case .up, .down:
+                return nil
+        }
+    }
+
+    @MainActor
+    private func scrollingPageIndex(for window: Window) -> Int? {
+        window.parentsWithSelf.first(where: { $0.parent === self })?.ownIndex
+    }
 
     @MainActor
     func changeOrientation(_ targetOrientation: Orientation) {
@@ -58,6 +112,7 @@ extension TilingContainer {
 enum Layout: String {
     case tiles
     case accordion
+    case scrolling
 }
 
 extension String {

--- a/Sources/AppBundle/tree/TreeNode.swift
+++ b/Sources/AppBundle/tree/TreeNode.swift
@@ -87,6 +87,7 @@ open class TreeNode: Equatable, AeroAny {
         newParent._children.insert(self, at: index != INDEX_BIND_LAST ? index : newParent._children.count)
         _parent = newParent
         unboundStacktrace = nil
+        (newParent as? TilingContainer)?.clampScrollingIndex()
         // todo consider disabling automatic mru propogation
         // 1. "floating windows" in FocusCommand break the MRU because of that :(
         // 2. Misbehaved apps that abuse real window as popups https://github.com/nikitabobko/AeroSpace/issues/106 (the
@@ -102,6 +103,7 @@ open class TreeNode: Equatable, AeroAny {
         check(_parent._mruChildren.remove(self))
         self._parent = nil
         unboundStacktrace = getStringStacktrace()
+        (_parent as? TilingContainer)?.clampScrollingIndex()
 
         return BindingData(parent: _parent, adaptiveWeight: adaptiveWeight, index: index)
     }

--- a/Sources/AppBundle/tree/WorkspaceEx.swift
+++ b/Sources/AppBundle/tree/WorkspaceEx.swift
@@ -10,7 +10,8 @@ extension Workspace {
                     case .vertical: .v
                     case .auto: workspaceMonitor.then { $0.width >= $0.height } ? .h : .v
                 }
-                return TilingContainer(parent: self, adaptiveWeight: 1, orientation, config.defaultRootContainerLayout, index: INDEX_BIND_LAST)
+                let rootOrientation = config.defaultRootContainerLayout == .scrolling ? .h : orientation
+                return TilingContainer(parent: self, adaptiveWeight: 1, rootOrientation, config.defaultRootContainerLayout, index: INDEX_BIND_LAST)
             case 1:
                 return containers.singleOrNil().orDie()
             default:

--- a/Sources/AppBundleTests/command/MoveCommandTest.swift
+++ b/Sources/AppBundleTests/command/MoveCommandTest.swift
@@ -125,6 +125,26 @@ final class MoveCommandTest: XCTestCase {
         assertEquals(result.exitCode.rawValue, 0)
     }
 
+    func testCreateImplicitContainerFailsInScrollingLayout() async throws {
+        let workspace = Workspace.get(byName: name)
+        workspace.rootTilingContainer.apply {
+            assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)
+            TestWindow.new(id: 2, parent: $0)
+        }
+        workspace.rootTilingContainer.layout = .scrolling
+
+        let result = try await parseCommand("move --boundaries-action create-implicit-container up").cmdOrDie
+            .run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode.rawValue, 2)
+        assertEquals(result.stderr, ["move --boundaries-action create-implicit-container doesn't support the scrolling layout"])
+        assertEquals(
+            workspace.layoutDescription,
+            .workspace([
+                .scrolling([.window(1), .window(2)]),
+            ]),
+        )
+    }
+
     func testStop_onRootNode() async throws {
         let workspace = Workspace.get(byName: name)
         workspace.rootTilingContainer.apply {
@@ -299,6 +319,8 @@ extension TreeNode {
                         container.orientation == .h
                             ? .h_accordion(container.children.map(\.layoutDescription))
                             : .v_accordion(container.children.map(\.layoutDescription))
+                    case .scrolling:
+                        .scrolling(container.children.map(\.layoutDescription))
                 }
         }
     }
@@ -310,6 +332,7 @@ enum LayoutDescription: Equatable {
     case v_tiles([LayoutDescription])
     case h_accordion([LayoutDescription])
     case v_accordion([LayoutDescription])
+    case scrolling([LayoutDescription])
     case window(UInt32)
     case macosPopupWindowsContainer
     case macosMinimized

--- a/Sources/AppBundleTests/command/ScrollCommandTest.swift
+++ b/Sources/AppBundleTests/command/ScrollCommandTest.swift
@@ -1,0 +1,176 @@
+@testable import AppBundle
+import Common
+import XCTest
+
+@MainActor
+final class ScrollCommandTest: XCTestCase {
+    override func setUp() async throws { setUpWorkspacesForTests() }
+
+    func testParse() {
+        testParseCommandSucc("scroll left", ScrollCmdArgs(rawArgs: [], direction: .left))
+        testParseCommandSucc("scroll right", ScrollCmdArgs(rawArgs: [], direction: .right))
+        testParseCommandSucc("layout scrolling", LayoutCmdArgs(rawArgs: [], toggleBetween: [.scrolling]))
+    }
+
+    func testSwitchRootToScrolling() async throws {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            assertEquals(TestWindow.new(id: 2, parent: $0).focusWindow(), true)
+        }
+
+        let result = try await parseCommand("layout scrolling").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode.rawValue, 0)
+        assertEquals(root.layout, .scrolling)
+        assertEquals(root.orientation, .h)
+        assertEquals(root.scrollingIndex, 0)
+    }
+
+    func testRejectNestedScrolling() async throws {
+        let workspace = Workspace.get(byName: name)
+        workspace.rootTilingContainer.apply {
+            TilingContainer.newVTiles(parent: $0, adaptiveWeight: 1).apply {
+                assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)
+            }
+        }
+
+        let result = try await parseCommand("layout scrolling").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode.rawValue, 2)
+        assertEquals(result.stderr, ["The 'scrolling' layout is only supported for workspace root containers"])
+    }
+
+    func testScrollingLayoutGeometry() async throws {
+        let workspace = Workspace.get(byName: name)
+        let root = workspace.rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            TestWindow.new(id: 2, parent: $0)
+            TestWindow.new(id: 3, parent: $0)
+        }
+        root.layout = .scrolling
+        root.scrollingIndex = 1
+
+        try await workspace.layoutWorkspace()
+
+        let workspaceRect = workspace.workspaceMonitor.visibleRectPaddedByOuterGaps
+        let pageWidth = workspaceRect.width / 2
+        let expectedHeight = workspaceRect.height - 1
+        let windows = root.children.compactMap { $0 as? TestWindow }
+
+        let rect1 = windows[0].lastAppliedLayoutPhysicalRect.orDie("window 1 should be laid out")
+        let rect2 = windows[1].lastAppliedLayoutPhysicalRect.orDie("window 2 should be laid out")
+        let rect3 = windows[2].lastAppliedLayoutPhysicalRect.orDie("window 3 should be laid out")
+
+        assertEquals(rect1.topLeftX, workspaceRect.topLeftX - pageWidth)
+        assertEquals(rect1.width, pageWidth)
+        assertEquals(rect2.topLeftX, workspaceRect.topLeftX)
+        assertEquals(rect2.width, pageWidth)
+        assertEquals(rect3.topLeftX, workspaceRect.topLeftX + pageWidth)
+        assertEquals(rect3.width, pageWidth)
+        assertEquals(rect3.height, expectedHeight)
+    }
+
+    func testScrollCommandsMoveViewportAndFocus() async throws {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            TestWindow.new(id: 2, parent: $0)
+            TestWindow.new(id: 3, parent: $0)
+            TestWindow.new(id: 4, parent: $0)
+        }
+        root.layout = .scrolling
+        assertEquals((root.children[1] as! Window).focusWindow(), true)
+        assertEquals(root.scrollingIndex, 0)
+
+        let scrollRight = try await parseCommand("scroll right").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(scrollRight.exitCode.rawValue, 0)
+        assertEquals(root.scrollingIndex, 1)
+        assertEquals(focus.windowOrNil?.windowId, 3)
+
+        try await parseCommand("scroll right").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(root.scrollingIndex, 2)
+        assertEquals(focus.windowOrNil?.windowId, 4)
+
+        try await parseCommand("scroll right").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(root.scrollingIndex, 2)
+        assertEquals(focus.windowOrNil?.windowId, 4)
+
+        try await parseCommand("scroll left").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(root.scrollingIndex, 1)
+        assertEquals(focus.windowOrNil?.windowId, 2)
+    }
+
+    func testMoveCommandKeepsFocusedWindowVisible() async throws {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            TestWindow.new(id: 2, parent: $0)
+            TestWindow.new(id: 3, parent: $0)
+            TestWindow.new(id: 4, parent: $0)
+        }
+        root.layout = .scrolling
+        assertEquals((root.children[2] as! Window).focusWindow(), true)
+        assertEquals(root.scrollingIndex, 1)
+
+        let result = try await parseCommand("move right").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode.rawValue, 0)
+        assertEquals(root.layoutDescription, .scrolling([.window(1), .window(2), .window(4), .window(3)]))
+        assertEquals(root.scrollingIndex, 2)
+        assertEquals(focus.windowOrNil?.windowId, 3)
+    }
+
+    func testFocusedWindowAutoRevealsNewestPage() {
+        let root = Workspace.get(byName: name).rootTilingContainer
+        root.layout = .scrolling
+
+        assertEquals(TestWindow.new(id: 1, parent: root).focusWindow(), true)
+        assertEquals(root.scrollingIndex, 0)
+
+        assertEquals(TestWindow.new(id: 2, parent: root).focusWindow(), true)
+        assertEquals(root.scrollingIndex, 0)
+
+        assertEquals(TestWindow.new(id: 3, parent: root).focusWindow(), true)
+        assertEquals(root.scrollingIndex, 1)
+
+        assertEquals(TestWindow.new(id: 4, parent: root).focusWindow(), true)
+        assertEquals(root.scrollingIndex, 2)
+    }
+
+    func testClosingClampsScrollingIndex() {
+        let root = Workspace.get(byName: name).rootTilingContainer
+        root.layout = .scrolling
+        let w1 = TestWindow.new(id: 1, parent: root)
+        let w2 = TestWindow.new(id: 2, parent: root)
+        let w3 = TestWindow.new(id: 3, parent: root)
+        let w4 = TestWindow.new(id: 4, parent: root)
+        _ = [w1, w2, w3]
+        root.scrollingIndex = 2
+
+        w4.closeAxWindow()
+        assertEquals(root.scrollingIndex, 1)
+    }
+
+    func testResizeAndBalanceSizesFailInScrollingLayout() async throws {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)
+            TestWindow.new(id: 2, parent: $0)
+        }
+        root.layout = .scrolling
+
+        let resizeResult = try await parseCommand("resize smart +10").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(resizeResult.exitCode.rawValue, 2)
+        assertEquals(resizeResult.stderr, ["resize command doesn't support the scrolling layout"])
+
+        let balanceResult = try await parseCommand("balance-sizes").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(balanceResult.exitCode.rawValue, 2)
+        assertEquals(balanceResult.stderr, ["balance-sizes command doesn't support the scrolling layout"])
+    }
+
+    func testWindowLayoutFormattingReportsScrolling() {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            let nested = TilingContainer.newVTiles(parent: $0, adaptiveWeight: 1)
+            TestWindow.new(id: 1, parent: nested)
+            TestWindow.new(id: 2, parent: $0)
+        }
+        root.layout = .scrolling
+
+        let windows = root.allLeafWindowsRecursive.map { AeroObj.window(.forTest(window: $0, title: "w\($0.windowId)")) }
+        assertSucc(windows.format([.interVar("window-layout")]), ["scrolling", "scrolling"])
+    }
+}

--- a/Sources/AppBundleTests/command/SplitCommandTest.swift
+++ b/Sources/AppBundleTests/command/SplitCommandTest.swift
@@ -69,4 +69,17 @@ final class SplitCommandTest: XCTestCase {
             .window(2),
         ]))
     }
+
+    func testSplitVerticalFailsInScrollingLayout() async throws {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)
+        }
+        root.layout = .scrolling
+
+        let result = try await SplitCommand(args: SplitCmdArgs(rawArgs: [], .vertical)).run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode.rawValue, 2)
+        assertEquals(result.stderr, ["The scrolling layout is always horizontal"])
+        assertEquals(root.layoutDescription, .scrolling([.window(1)]))
+        assertEquals(root.orientation, .h)
+    }
 }

--- a/Sources/AppBundleTests/tree/TestWindow.swift
+++ b/Sources/AppBundleTests/tree/TestWindow.swift
@@ -39,4 +39,9 @@ final class TestWindow: Window, CustomStringConvertible {
     @MainActor override func getAxRect() async throws -> Rect? { // todo change to not Optional
         _rect
     }
+
+    override func setAxFrame(_ topLeft: CGPoint?, _ size: CGSize?) {
+        guard let topLeft, let size else { return }
+        _rect = Rect(topLeftX: topLeft.x, topLeftY: topLeft.y, width: size.width, height: size.height)
+    }
 }

--- a/Sources/Cli/subcommandDescriptionsGenerated.swift
+++ b/Sources/Cli/subcommandDescriptionsGenerated.swift
@@ -32,6 +32,7 @@ let subcommandDescriptions = [
     ["  move", "Move the focused window in the given direction"],
     ["  reload-config", "Reload currently active config"],
     ["  resize", "Resize the focused window"],
+    ["  scroll", "Scroll the viewport of a workspace whose root container uses the scrolling layout"],
     ["  split", "Split focused window"],
     ["  subscribe", "Subscribe to AeroSpace events and receive notifications via socket"],
     ["  summon-workspace", "Move the requested workspace to the focused monitor."],

--- a/Sources/Common/cmdArgs/cmdArgsManifest.swift
+++ b/Sources/Common/cmdArgs/cmdArgsManifest.swift
@@ -33,6 +33,7 @@ public enum CmdKind: String, CaseIterable, Equatable, Sendable {
     case moveWorkspaceToMonitor = "move-workspace-to-monitor"
     case reloadConfig = "reload-config"
     case resize
+    case scroll
     case split
     case subscribe
     case summonWorkspace = "summon-workspace"
@@ -116,6 +117,8 @@ func initSubcommands() -> [String: any SubCommandParserProtocol] {
                 result[kind.rawValue] = SubCommandParser(ReloadConfigCmdArgs.init)
             case .resize:
                 result[kind.rawValue] = SubCommandParser(parseResizeCmdArgs)
+            case .scroll:
+                result[kind.rawValue] = SubCommandParser(parseScrollCmdArgs)
             case .split:
                 result[kind.rawValue] = SubCommandParser(parseSplitCmdArgs)
             case .subscribe:

--- a/Sources/Common/cmdArgs/impl/LayoutCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/LayoutCmdArgs.swift
@@ -19,7 +19,7 @@ public struct LayoutCmdArgs: CmdArgs {
     }
 
     public enum LayoutDescription: String, CaseIterable, Equatable, Sendable {
-        case accordion, tiles
+        case accordion, tiles, scrolling
         case horizontal, vertical
         case h_accordion, v_accordion, h_tiles, v_tiles
         case tiling, floating

--- a/Sources/Common/cmdArgs/impl/ScrollCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/ScrollCmdArgs.swift
@@ -1,0 +1,30 @@
+public struct ScrollCmdArgs: CmdArgs {
+    /*conforms*/ public var commonState: CmdArgsCommonState
+    fileprivate init(rawArgs: StrArrSlice) { self.commonState = .init(rawArgs) }
+    public static let parser: CmdParser<Self> = .init(
+        kind: .scroll,
+        allowInConfig: true,
+        help: scroll_help_generated,
+        flags: [:],
+        posArgs: [newMandatoryPosArgParser(\.direction, parseScrollDirection, placeholder: ScrollDirection.unionLiteral)],
+    )
+
+    public var direction: Lateinit<ScrollDirection> = .uninitialized
+
+    public init(rawArgs: [String], direction: ScrollDirection) {
+        self.commonState = .init(rawArgs.slice)
+        self.direction = .initialized(direction)
+    }
+}
+
+public enum ScrollDirection: String, CaseIterable, Equatable, Sendable {
+    case left, right
+}
+
+private func parseScrollDirection(input: PosArgParserInput) -> ParsedCliArgs<ScrollDirection> {
+    .init(parseEnum(input.arg, ScrollDirection.self), advanceBy: 1)
+}
+
+func parseScrollCmdArgs(_ args: StrArrSlice) -> ParsedCmd<ScrollCmdArgs> {
+    parseSpecificCmdArgs(ScrollCmdArgs(rawArgs: args), args)
+}

--- a/Sources/Common/cmdHelpGenerated.swift
+++ b/Sources/Common/cmdHelpGenerated.swift
@@ -61,7 +61,7 @@ let join_with_help_generated = """
     """
 let layout_help_generated = """
     USAGE: layout [-h|--help] [--window-id <window-id>]
-                  (h_tiles|v_tiles|h_accordion|v_accordion|tiles|accordion|horizontal|vertical|tiling|floating)...
+                  (h_tiles|v_tiles|h_accordion|v_accordion|tiles|accordion|scrolling|horizontal|vertical|tiling|floating)...
     """
 let list_apps_help_generated = """
     USAGE: list-apps [-h|--help] [--macos-native-hidden [no]] [--format <output-format>] [--count] [--json]
@@ -128,6 +128,9 @@ let reload_config_help_generated = """
     """
 let resize_help_generated = """
     USAGE: resize [-h|--help] [--window-id <window-id>] (smart|smart-opposite|width|height) [+|-]<number>
+    """
+let scroll_help_generated = """
+    USAGE: scroll [-h|--help] (left|right)
     """
 let split_help_generated = """
     USAGE: split [-h|--help] [--window-id <window-id>] (horizontal|vertical|opposite)

--- a/docs/aerospace-layout.adoc
+++ b/docs/aerospace-layout.adoc
@@ -10,7 +10,7 @@ include::util/man-attributes.adoc[]
 [verse]
 // tag::synopsis[]
 aerospace layout [-h|--help] [--window-id <window-id>]
-                 (h_tiles|v_tiles|h_accordion|v_accordion|tiles|accordion|horizontal|vertical|tiling|floating)...
+                 (h_tiles|v_tiles|h_accordion|v_accordion|tiles|accordion|scrolling|horizontal|vertical|tiling|floating)...
 
 // end::synopsis[]
 
@@ -24,8 +24,11 @@ If several arguments are supplied then finds the first argument that doesn't des
 
 * Change both tiling layout and orientation in one go: `h_tiles|v_tiles|h_accordion|v_accordion`
 * Change tiling layout but preserve orientation: `tiles|accordion`
+* Switch the workspace root container to scrolling layout: `scrolling`
 * Change orientation but preserve layout: `horizontal|vertical`
 * Toggle floating/tiling mode: `tiling|floating`
+
+The `scrolling` layout is only supported on the workspace root container, and it is always horizontal.
 
 // =========================================================== Options
 include::./util/conditional-options-header.adoc[]
@@ -46,6 +49,12 @@ include::util/conditional-examples-header.adoc[]
 
 * Toggle between `tiles` and `accordion` layouts (order of args doesn't matter): +
 `aerospace layout tiles accordion`
+
+* Switch the workspace root container to the scrolling layout: +
+`aerospace layout scrolling`
+
+* Return from scrolling layout to ordinary tiling: +
+`aerospace layout tiles`
 
 * Switch to `tiles` layout. Toggle the layout orientation if already in `tiles` layout: +
 `aerospace layout tiles horizontal vertical`

--- a/docs/aerospace-scroll.adoc
+++ b/docs/aerospace-scroll.adoc
@@ -1,0 +1,43 @@
+= aerospace-scroll(1)
+include::util/man-attributes.adoc[]
+:manname: aerospace-scroll
+// tag::purpose[]
+:manpurpose: Scroll the viewport of a workspace whose root container uses the scrolling layout
+// end::purpose[]
+
+== Synopsis
+[verse]
+// tag::synopsis[]
+aerospace scroll [-h|--help] (left|right)
+// end::synopsis[]
+
+== Description
+
+// tag::body[]
+{manpurpose}
+
+The command moves the viewport by one page and focuses the newly revealed window.
+
+This command only works when the focused workspace root container uses the `scrolling` layout.
+
+In the scrolling layout, `focus left|right` keeps its normal directional meaning, while `scroll left|right`
+is the explicit way to move the viewport itself.
+
+include::./util/conditional-options-header.adoc[]
+
+-h, --help:: Print help
+
+include::util/conditional-examples-header.adoc[]
+
+* Scroll one page to the left: +
+`aerospace scroll left`
+
+* Scroll one page to the right: +
+`aerospace scroll right`
+
+* Example bindings for the scrolling layout: +
+`alt-left = 'scroll left'` +
+`alt-right = 'scroll right'`
+// end::body[]
+
+include::util/man-footer.adoc[]

--- a/docs/commands.adoc
+++ b/docs/commands.adoc
@@ -161,6 +161,13 @@ include::aerospace-resize.adoc[tags=synopsis]
 include::aerospace-resize.adoc[tags=purpose]
 include::aerospace-resize.adoc[tags=body]
 
+== scroll
+----
+include::aerospace-scroll.adoc[tags=synopsis]
+----
+include::aerospace-scroll.adoc[tags=purpose]
+include::aerospace-scroll.adoc[tags=body]
+
 == split
 ----
 include::aerospace-split.adoc[tags=synopsis]

--- a/docs/config-examples/default-config.toml
+++ b/docs/config-examples/default-config.toml
@@ -25,7 +25,7 @@ enable-normalization-opposite-orientation-for-nested-containers = true
 # You can set 0 to disable the padding feature
 accordion-padding = 30
 
-# Possible values: tiles|accordion
+# Possible values: tiles|accordion|scrolling
 default-root-container-layout = 'tiles'
 
 # Possible values: horizontal|vertical|auto
@@ -115,6 +115,9 @@ on-mode-changed = []
     # See: https://nikitabobko.github.io/AeroSpace/commands#layout
     alt-slash = 'layout tiles horizontal vertical'
     alt-comma = 'layout accordion horizontal vertical'
+    # Useful when you switch a workspace to the scrolling layout with `layout scrolling`
+    alt-left = 'scroll left'
+    alt-right = 'scroll right'
 
     # See: https://nikitabobko.github.io/AeroSpace/commands#focus
     alt-h = 'focus left'

--- a/grammar/commands-bnf-grammar.txt
+++ b/grammar/commands-bnf-grammar.txt
@@ -39,7 +39,7 @@ aerospace -h;
 
     | join-with [--window-id <window_id>] (left|down|up|right)
 
-    | layout [--window-id <window_id>] (h_tiles|v_tiles|h_accordion|v_accordion|tiles|accordion|horizontal|vertical|tiling|floating)...
+    | layout [--window-id <window_id>] (h_tiles|v_tiles|h_accordion|v_accordion|tiles|accordion|scrolling|horizontal|vertical|tiling|floating)...
 
     | macos-native-fullscreen [--fail-if-noop|--window-id <window_id>]... [on|off] [--fail-if-noop|--window-id <window_id>]...
 
@@ -63,6 +63,8 @@ aerospace -h;
     | reload-config [--no-gui | --dry-run]...
 
     | resize [--window-id <window_id>] (smart|smart-opposite|width|height) [+|-]<number> [--window-id <window_id>]
+
+    | scroll (left|right)
 
     | split [--window-id <window_id>] (horizontal|vertical|opposite) [--window-id <window_id>]
 


### PR DESCRIPTION
The scrolling layout lets a workspace behave more like a horizontal strip of windows than a fixed split grid.

It is especially useful on laptop screens, where width is limited and ordinary tiling quickly makes every window too narrow. Instead of compressing more and more windows into the same visible area, the scrolling layout keeps the workspace readable by showing only a two-pane slice at a time and letting you move through the rest horizontally.

In my setup, this works especially well for the numbered workspaces 1 to 9, where I usually step through active task windows in sequence. The first window takes the whole workspace. As soon as a second window appears, the workspace becomes a two-pane view, and every additional window is added as another half-width page to the right. I can then move through that strip with alt-left and alt-right, keeping windows large enough to actually use on a laptop display.

## Change summary
- add a root-only scrolling workspace layout
- add `scroll left` and `scroll right` commands
- add tests and docs for scrolling behavior

## Verification
- `swift test`
