### PR TITLE
[codex] Add container-local focus cycling

### DIFF
--- a/Sources/AppBundle/command/impl/FocusCommand.swift
+++ b/Sources/AppBundle/command/impl/FocusCommand.swift
@@ -15,7 +15,7 @@ struct FocusCommand: Command {
             }
         }
 
-        switch args.target {
+        switch args.resolvedTarget {
             case .direction(let direction):
                 let window = target.windowOrNil
                 if let (parent, ownIndex) = window?.closestParent(hasChildrenInDirection: direction, withLayout: nil) {
@@ -55,8 +55,27 @@ struct FocusCommand: Command {
                     }
                 }
                 return windows[targetIndex].focusWindow()
+            case .containerRelative(let nextPrev):
+                guard let window = target.windowOrNil else {
+                    return io.err(noWindowIsFocused)
+                }
+                return focusInParentContainer(window, nextPrev: nextPrev)
         }
     }
+}
+
+@MainActor private func focusInParentContainer(_ window: Window, nextPrev: ContainerFocusNextPrev) -> Bool {
+    guard let parent = window.parent as? TilingContainer else { return true }
+    let siblingWindows = parent.children.compactMap { $0 as? Window }
+    guard siblingWindows.count > 1 else { return true }
+    guard let currentIndex = siblingWindows.firstIndex(of: window) else { return true }
+
+    let targetIndex = switch nextPrev {
+        case .containerNext: currentIndex + 1
+        case .containerPrev: currentIndex - 1
+    }
+    let wrappedIndex = (targetIndex + siblingWindows.count) % siblingWindows.count
+    return siblingWindows[wrappedIndex].focusWindow()
 }
 
 @MainActor private func hitWorkspaceBoundaries(

--- a/Sources/AppBundleTests/command/FocusCommandTest.swift
+++ b/Sources/AppBundleTests/command/FocusCommandTest.swift
@@ -25,9 +25,14 @@ final class FocusCommandTest: XCTestCase {
 
     func testParse() {
         XCTAssertTrue(parseCommand("focus --boundaries left").errorOrNil?.contains("Possible values") == true)
-        var expected = FocusCmdArgs(rawArgs: [], cardinalOrDfsDirection: .direction(.left))
+        var expected = FocusCmdArgs(rawArgs: [], target: .direction(.left))
         expected.rawBoundaries = .workspace
         testParseCommandSucc("focus --boundaries workspace left", expected)
+        testParseCommandSucc("focus container-next", FocusCmdArgs(rawArgs: [], target: .containerRelative(.containerNext)))
+        testParseCommandSucc(
+            "focus --ignore-floating container-prev",
+            FocusCmdArgs(rawArgs: [], target: .containerRelative(.containerPrev)).copy(\.floatingAsTiling, false),
+        )
 
         assertEquals(
             parseCommand("focus --boundaries workspace --boundaries workspace left").errorOrNil,
@@ -40,6 +45,10 @@ final class FocusCommandTest: XCTestCase {
         assertEquals(
             parseCommand("focus --boundaries all-monitors-outer-frame dfs-next").errorOrNil,
             "(dfs-next|dfs-prev) only supports --boundaries workspace",
+        )
+        assertEquals(
+            parseCommand("focus container-next --wrap-around").errorOrNil,
+            "(container-next|container-prev) only supports --ignore-floating",
         )
 
         assertEquals(
@@ -118,7 +127,7 @@ final class FocusCommandTest: XCTestCase {
         }
 
         assertEquals(focus.windowOrNil?.windowId, 1)
-        var args = FocusCmdArgs(rawArgs: [], cardinalOrDfsDirection: .direction(.left))
+        var args = FocusCmdArgs(rawArgs: [], target: .direction(.left))
         args.rawBoundaries = .workspace
         args.rawBoundariesAction = .wrapAroundTheWorkspace
         try await FocusCommand(args: args).run(.defaultEnv, .emptyStdin)
@@ -183,6 +192,40 @@ final class FocusCommandTest: XCTestCase {
         assertEquals(focus.windowOrNil?.windowId, 1)
     }
 
+    func testFocusContainerRelative() async throws {
+        Workspace.get(byName: name).rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            TilingContainer.newVTiles(parent: $0, adaptiveWeight: 1).apply {
+                $0.layout = .accordion
+                assertEquals(TestWindow.new(id: 2, parent: $0).focusWindow(), true)
+                TestWindow.new(id: 3, parent: $0)
+            }
+        }
+
+        assertEquals(focus.windowOrNil?.windowId, 2)
+        try await FocusCommand.new(containerRelative: .containerNext).run(.defaultEnv, .emptyStdin)
+        assertEquals(focus.windowOrNil?.windowId, 3)
+        try await FocusCommand.new(containerRelative: .containerNext).run(.defaultEnv, .emptyStdin)
+        assertEquals(focus.windowOrNil?.windowId, 2)
+        try await FocusCommand.new(containerRelative: .containerPrev).run(.defaultEnv, .emptyStdin)
+        assertEquals(focus.windowOrNil?.windowId, 3)
+        assertNotEquals(focus.windowOrNil?.windowId, 1)
+    }
+
+    func testFocusContainerRelativeNoopWithSingleFocusableChild() async throws {
+        Workspace.get(byName: name).rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            TilingContainer.newVTiles(parent: $0, adaptiveWeight: 1).apply {
+                $0.layout = .accordion
+                assertEquals(TestWindow.new(id: 2, parent: $0).focusWindow(), true)
+            }
+        }
+
+        assertEquals(focus.windowOrNil?.windowId, 2)
+        try await FocusCommand.new(containerRelative: .containerNext).run(.defaultEnv, .emptyStdin)
+        assertEquals(focus.windowOrNil?.windowId, 2)
+    }
+
     func testFocusDfsRelative() async throws {
         Workspace.get(byName: name).rootTilingContainer.apply {
             TilingContainer.newVTiles(parent: $0, adaptiveWeight: 1).apply {
@@ -220,7 +263,7 @@ final class FocusCommandTest: XCTestCase {
 
         assertEquals(focus.windowOrNil?.windowId, 1)
 
-        var args = FocusCmdArgs(rawArgs: [], cardinalOrDfsDirection: .dfsRelative(.dfsPrev))
+        var args = FocusCmdArgs(rawArgs: [], target: .dfsRelative(.dfsPrev))
 
         args.rawBoundariesAction = .stop
         assertEquals(try await FocusCommand(args: args).run(.defaultEnv, .emptyStdin).exitCode, 0)
@@ -234,7 +277,7 @@ final class FocusCommandTest: XCTestCase {
         assertEquals(try await FocusCommand(args: args).run(.defaultEnv, .emptyStdin).exitCode, 0)
         assertEquals(focus.windowOrNil?.windowId, 2)
 
-        args.cardinalOrDfsDirection = .dfsRelative(.dfsNext)
+        args.target = .dfsRelative(.dfsNext)
 
         args.rawBoundariesAction = .stop
         assertEquals(try await FocusCommand(args: args).run(.defaultEnv, .emptyStdin).exitCode, 0)
@@ -252,9 +295,12 @@ final class FocusCommandTest: XCTestCase {
 
 extension FocusCommand {
     static func new(direction: CardinalDirection) -> FocusCommand {
-        FocusCommand(args: FocusCmdArgs(rawArgs: [], cardinalOrDfsDirection: .direction(direction)))
+        FocusCommand(args: FocusCmdArgs(rawArgs: [], target: .direction(direction)))
     }
     static func new(dfsRelative: DfsNextPrev) -> FocusCommand {
-        FocusCommand(args: FocusCmdArgs(rawArgs: [], cardinalOrDfsDirection: .dfsRelative(dfsRelative)))
+        FocusCommand(args: FocusCmdArgs(rawArgs: [], target: .dfsRelative(dfsRelative)))
+    }
+    static func new(containerRelative: ContainerFocusNextPrev) -> FocusCommand {
+        FocusCommand(args: FocusCmdArgs(rawArgs: [], target: .containerRelative(containerRelative)))
     }
 }

--- a/Sources/Common/cmdArgs/impl/FocusCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/FocusCmdArgs.swift
@@ -14,7 +14,7 @@ public struct FocusCmdArgs: CmdArgs {
             "--boundaries-action": ArgParser(\.rawBoundariesAction, upcastArgParserFun(parseBoundariesAction)),
             "--wrap-around": trueBoolFlag(\.wrapAroundAlias),
         ],
-        posArgs: [ArgParser(\.cardinalOrDfsDirection, upcastArgParserFun(parseCardinalOrDfsDirection))],
+        posArgs: [ArgParser(\.target, upcastArgParserFun(parseFocusTarget))],
         conflictingOptions: [
             ["--wrap-around", "--boundaries-action"],
             ["--wrap-around", "--boundaries"],
@@ -25,12 +25,12 @@ public struct FocusCmdArgs: CmdArgs {
     public var rawBoundariesAction: WhenBoundariesCrossed? = nil
     fileprivate var wrapAroundAlias: Bool = false
     public var dfsIndex: UInt32? = nil
-    public var cardinalOrDfsDirection: CardinalOrDfsDirection? = nil
+    public var target: FocusCmdTarget? = nil
     public var floatingAsTiling: Bool = true
 
-    public init(rawArgs: StrArrSlice, cardinalOrDfsDirection: CardinalOrDfsDirection) {
+    public init(rawArgs: StrArrSlice, target: FocusCmdTarget) {
         self.commonState = .init(rawArgs)
-        self.cardinalOrDfsDirection = cardinalOrDfsDirection
+        self.target = target
     }
 
     public init(rawArgs: StrArrSlice, windowId: UInt32) {
@@ -55,11 +55,12 @@ public struct FocusCmdArgs: CmdArgs {
     }
 }
 
-public enum FocusCmdTarget {
+public enum FocusCmdTarget: Equatable, Sendable {
     case direction(CardinalDirection)
     case windowId(UInt32)
     case dfsIndex(UInt32)
     case dfsRelative(DfsNextPrev)
+    case containerRelative(ContainerFocusNextPrev)
 
     var isDfsRelative: Bool {
         if case .dfsRelative = self {
@@ -68,16 +69,30 @@ public enum FocusCmdTarget {
             return false
         }
     }
+
+    var isContainerRelative: Bool {
+        if case .containerRelative = self {
+            return true
+        } else {
+            return false
+        }
+    }
+
+    static var cliArgsCases: [String] {
+        CardinalDirection.cliArgsCases + DfsNextPrev.cliArgsCases + ContainerFocusNextPrev.cliArgsCases
+    }
+
+    static var unionLiteral: String { cliArgsCases.joinedCliArgs }
+}
+
+public enum ContainerFocusNextPrev: String, CaseIterable, Equatable, Sendable {
+    case containerNext = "container-next"
+    case containerPrev = "container-prev"
 }
 
 extension FocusCmdArgs {
-    public var target: FocusCmdTarget {
-        if let cardinalOrDfsDirection {
-            return switch cardinalOrDfsDirection {
-                case .direction(let dir): .direction(dir)
-                case .dfsRelative(let nextPrev): .dfsRelative(nextPrev)
-            }
-        }
+    public var resolvedTarget: FocusCmdTarget {
+        if let target { return target }
         if let windowId {
             return .windowId(windowId)
         }
@@ -100,8 +115,8 @@ func parseFocusCmdArgs(_ args: StrArrSlice) -> ParsedCmd<FocusCmdArgs> {
                 ? .failure("\(raw.boundaries.rawValue) and \(raw.boundariesAction.rawValue) is an invalid combination of values")
                 : .cmd(raw)
         }
-        .filter("Mandatory argument is missing. \(CardinalOrDfsDirection.unionLiteral), --window-id or --dfs-index is required") {
-            $0.cardinalOrDfsDirection != nil || $0.windowId != nil || $0.dfsIndex != nil
+        .filter("Mandatory argument is missing. \(FocusCmdTarget.unionLiteral), --window-id or --dfs-index is required") {
+            $0.target != nil || $0.windowId != nil || $0.dfsIndex != nil
         }
         .filter("--window-id is incompatible with other options") {
             $0.windowId == nil || $0 == FocusCmdArgs(rawArgs: args, windowId: $0.windowId.orDie())
@@ -109,9 +124,29 @@ func parseFocusCmdArgs(_ args: StrArrSlice) -> ParsedCmd<FocusCmdArgs> {
         .filter("--dfs-index is incompatible with other options") {
             $0.dfsIndex == nil || $0 == FocusCmdArgs(rawArgs: args, dfsIndex: $0.dfsIndex.orDie())
         }
-        .filter("(dfs-next|dfs-prev) only supports --boundaries workspace") {
-            $0.target.isDfsRelative.implies($0.boundaries == .workspace)
+        .filter("(container-next|container-prev) only supports --ignore-floating") {
+            !($0.target?.isContainerRelative == true) || ($0.rawBoundaries == nil && $0.rawBoundariesAction == nil && !$0.wrapAroundAlias)
         }
+        .filter("(dfs-next|dfs-prev) only supports --boundaries workspace") {
+            ($0.target?.isDfsRelative == true).implies($0.boundaries == .workspace)
+        }
+}
+
+private func parseFocusTarget(i: PosArgParserInput) -> ParsedCliArgs<FocusCmdTarget> {
+    switch i.arg {
+        case ContainerFocusNextPrev.containerNext.rawValue:
+            return .succ(.containerRelative(.containerNext), advanceBy: 1)
+        case ContainerFocusNextPrev.containerPrev.rawValue:
+            return .succ(.containerRelative(.containerPrev), advanceBy: 1)
+        default:
+            if let direction = CardinalDirection(rawValue: i.arg) {
+                return .succ(.direction(direction), advanceBy: 1)
+            } else if let nextPrev = DfsNextPrev(rawValue: i.arg) {
+                return .succ(.dfsRelative(nextPrev), advanceBy: 1)
+            } else {
+                return .fail("Can't parse '\(i.arg)'.\nPossible values: \(FocusCmdTarget.unionLiteral)", advanceBy: 1)
+            }
+    }
 }
 
 private func parseBoundariesAction(i: SubArgParserInput) -> ParsedCliArgs<FocusCmdArgs.WhenBoundariesCrossed> {

--- a/Sources/Common/cmdHelpGenerated.swift
+++ b/Sources/Common/cmdHelpGenerated.swift
@@ -45,6 +45,8 @@ let focus_help_generated = """
        OR: focus [-h|--help] [--ignore-floating] [--wrap-around]
                  [--boundaries <boundary>] [--boundaries-action <action>]
                  (dfs-next|dfs-prev)
+       OR: focus [-h|--help] [--ignore-floating]
+                 (container-next|container-prev)
        OR: focus [-h|--help] --window-id <window-id>
        OR: focus [-h|--help] --dfs-index <dfs-index>
     """

--- a/docs/aerospace-focus.adoc
+++ b/docs/aerospace-focus.adoc
@@ -15,6 +15,8 @@ aerospace focus [-h|--help] [--ignore-floating] [--wrap-around]
 aerospace focus [-h|--help] [--ignore-floating] [--wrap-around]
                 [--boundaries <boundary>] [--boundaries-action <action>]
                 (dfs-next|dfs-prev)
+aerospace focus [-h|--help] [--ignore-floating]
+                (container-next|container-prev)
 aerospace focus [-h|--help] --window-id <window-id>
 aerospace focus [-h|--help] --dfs-index <dfs-index>
 
@@ -32,8 +34,9 @@ The floating window parent container is determined as the smallest tiling contai
 The technique eliminates the need for an additional binding for floating windows.
 This behavior can be disabled with `--ignore-floating` flag.
 
-`focus child|parent` isn't supported because the necessity of this operation is under the question.
-https://github.com/nikitabobko/AeroSpace/issues/5
+`focus container-next|container-prev` cycles only among the direct child windows of the currently focused window's parent container.
+It wraps within that container and is useful for accordion groups.
+Boundary flags like `--boundaries`, `--boundaries-action`, and `--wrap-around` are not supported for container-local cycling.
 
 // =========================================================== Options
 include::util/conditional-options-header.adoc[]
@@ -74,6 +77,10 @@ Set focus to the nearest window in the given direction.
 (dfs-next|dfs-prev)::
 Set focus to the window before or after the current window in the depth-first order (top-to-bottom and left-to-right) of windows in the current workspace tree.
 In this mode, `--boundaries` must be `workspace` (the default) and `--boundaries-action` can be set to one of `(stop|fail|wrap-around-the-workspace)`.
+
+(container-next|container-prev)::
+Set focus to the next or previous sibling window inside the focused window's direct parent container.
+The command wraps within that container and accepts `--ignore-floating`.
 
 // end::body[]
 

--- a/docs/config-examples/i3-like-config-example.toml
+++ b/docs/config-examples/i3-like-config-example.toml
@@ -52,9 +52,9 @@ on-focused-monitor-changed = ['move-mouse monitor-lazy-center']
     # See: https://nikitabobko.github.io/AeroSpace/guide#floating-windows
     #alt-space = 'focus toggle_tiling_floating'
 
-    # `focus parent`/`focus child` are not yet supported, and it's not clear whether they
-    # should be supported at all https://github.com/nikitabobko/AeroSpace/issues/5
-    # alt-a = 'focus parent'
+    # Cycle only inside the current container, which is useful for accordion groups.
+    ctrl-tab = 'focus container-next'
+    ctrl-shift-tab = 'focus container-prev'
 
     alt-1 = 'workspace 1'
     alt-2 = 'workspace 2'

--- a/grammar/commands-bnf-grammar.txt
+++ b/grammar/commands-bnf-grammar.txt
@@ -24,6 +24,7 @@ aerospace -h;
     | focus --window-id <window_id>
     | focus --dfs-index <number>
     | focus [<focus_dfs_relative_flag>]... (dfs-next|dfs-prev) [<focus_dfs_relative_flag>]...
+    | focus [<focus_container_relative_flag>]... (container-next|container-prev) [<focus_container_relative_flag>]...
 
     | focus-back-and-forth
 
@@ -121,6 +122,7 @@ aerospace -h;
 
 <focus_direction_flag> ::= --boundaries <boundary>|--boundaries-action <boundaries_action>|--ignore-floating|--wrap-around;
 <focus_dfs_relative_flag> ::= --boundaries-action <boundaries_action>|--ignore-floating|--wrap-around;
+<focus_container_relative_flag> ::= --ignore-floating;
 <boundaries_action> ::= stop|fail|wrap-around-the-workspace|wrap-around-all-monitors;
 <boundary> ::= workspace|all-monitors-outer-frame;
 


### PR DESCRIPTION
## Summary
Add `focus container-next` and `focus container-prev` for container-local sibling cycling.

## Behavior
- Cycles only among direct sibling windows in the focused window's parent container.
- Wraps within that container.
- No-ops when there is only one focusable child.
- Keeps existing workspace-wide focus behavior unchanged.

## Validation
- `swift test --filter FocusCommandTest`
- Live test on my system:
  - moved two windows into a workspace container
  - verified `focus container-next` toggled focus between them
  - verified `focus container-prev` toggled back
