### PR TITLE
Fix black window rendering in GTK3 apps after tiling

### DIFF
--- a/Sources/AppBundle/tree/MacApp.swift
+++ b/Sources/AppBundle/tree/MacApp.swift
@@ -137,6 +137,17 @@ final class MacApp: AbstractApp {
             try disableAnimations(app: axApp.threadGuarded, job) {
                 try setFrame(window, topLeft, size, job)
             }
+            // Nudge the window size by 1px and back after AXEnhancedUserInterface is
+            // restored.  Some toolkits (e.g. GTK3's Quartz backend) don't redraw after
+            // AX-driven frame changes made while AXEnhancedUserInterface is disabled,
+            // leaving windows visually stale.  A no-op re-set of the same size is
+            // optimized away by macOS, so a real geometry change is needed to trigger
+            // the resize notification that prompts the app to redraw.
+            try job.checkCancellation()
+            if let size {
+                window.set(Ax.sizeAttr, CGSize(width: size.width + 1, height: size.height))
+                window.set(Ax.sizeAttr, size)
+            }
         }
     }
 
@@ -145,6 +156,11 @@ final class MacApp: AbstractApp {
         try await withWindow(windowId) { [axApp] window, job in
             try disableAnimations(app: axApp.threadGuarded, job) {
                 try setFrame(window, topLeft, size, job)
+            }
+            try job.checkCancellation()
+            if let size {
+                window.set(Ax.sizeAttr, CGSize(width: size.width + 1, height: size.height))
+                window.set(Ax.sizeAttr, size)
             }
         }
     }


### PR DESCRIPTION
## Summary

- Fixes black window rendering in GTK3 apps (e.g. GnuCash) after AeroSpace tiles them
- After `disableAnimations` restores `AXEnhancedUserInterface`, nudges the window size by 1px and back to force a real resize notification
- This prompts the app to redraw, fixing the stale Quartz surface

Discussion: https://github.com/nikitabobko/AeroSpace/discussions/2051

## Root cause

Frame changes via `AXUIElementSetAttributeValue` made while `AXEnhancedUserInterface` is disabled don't reliably deliver resize/move notifications to the app. GTK3's Quartz backend depends on these notifications to trigger redraws, so the window surface goes stale and appears black.

## Test plan

- [x] Open GnuCash (GTK3, Homebrew) with AeroSpace running
- [x] Open Tools → Price Database dialog
- [x] Confirm dialog renders correctly (previously rendered black)
- [x] Confirm no visible flicker from the 1px size jitter
- [x] Build compiles cleanly (`swift build`)