### PR TITLE
Drop stale windows missing from AXWindows

### DIFF
--- a/Sources/AppBundle/tree/MacApp.swift
+++ b/Sources/AppBundle/tree/MacApp.swift
@@ -102,10 +102,16 @@ final class MacApp: AbstractApp {
 
     // todo merge together with detectNewWindows
     func getFocusedWindow() async throws -> Window? {
-        let windowId = try await thread?.runInLoop { [nsApp, axApp, windows] job in
-            try axApp.threadGuarded.get(Ax.focusedWindowAttr)
-                .flatMap { try windows.threadGuarded.getOrRegisterAxWindow(windowId: $0.windowId, $0.ax.cast, nsApp, job) }?
-                .windowId
+        let windowId: UInt32? = try await thread?.runInLoop { [nsApp, axApp, windows] job -> UInt32? in
+            guard let focused = axApp.threadGuarded.get(Ax.focusedWindowAttr) else {
+                return nil
+            }
+            let listedWindows = axApp.threadGuarded.get(Ax.windowsAttr) ?? []
+            let isListedInWindows = listedWindows.contains(where: { $0.windowId == focused.windowId })
+            if !isListedInWindows && windows.threadGuarded[focused.windowId] == nil {
+                return nil
+            }
+            return try windows.threadGuarded.getOrRegisterAxWindow(windowId: focused.windowId, focused.ax.cast, nsApp, job)?.windowId
         }
         guard let windowId else { return nil }
         return try await MacWindow.getOrRegister(windowId: windowId, macApp: self)
@@ -273,18 +279,39 @@ final class MacApp: AbstractApp {
         }
         guard let thread else { return [] }
         let (alive, dead) = try await thread.runInLoop { [nsApp, windows, axApp] (job) -> ([UInt32], [UInt32]) in
-            var alive: [UInt32: AxWindow] = windows.threadGuarded
+            var alive: [UInt32: AxWindow] = [:]
             var dead = [UInt32: AxWindow]()
+            let currentWindows = axApp.threadGuarded.get(Ax.windowsAttr) ?? []
+            let currentWindowIds = Set(currentWindows.map(\.windowId))
+
+            func shouldKeepOmittedWindowAlive(_ window: AxWindow) -> Bool {
+                if nsApp.isHidden { return true }
+                if window.ax.get(Ax.minimizedAttr) == true { return true }
+                if window.ax.get(Ax.isFullscreenAttr) == true { return true }
+                return false
+            }
+
             // Second line of defence against lock screen. See the first line of defence: closedWindowsCache
             // Second and third lines of defence are technically needed only to avoid potential flickering
             if frontmostAppBundleId != lockScreenAppBundleId {
-                (alive, dead) = try alive.partition {
+                (_, dead) = try windows.threadGuarded.partition {
                     try job.checkCancellation()
-                    return $0.value.ax.containingWindowId() != nil
+                    guard $0.value.ax.containingWindowId() != nil else {
+                        return false
+                    }
+                    if currentWindowIds.contains($0.key) {
+                        return true
+                    }
+                    return shouldKeepOmittedWindowAlive($0.value)
                 }
+                for (id, window) in windows.threadGuarded where currentWindowIds.contains(id) || shouldKeepOmittedWindowAlive(window) {
+                    alive[id] = window
+                }
+            } else {
+                alive = windows.threadGuarded
             }
 
-            for (id, window) in axApp.threadGuarded.get(Ax.windowsAttr) ?? [] {
+            for (id, window) in currentWindows {
                 try job.checkCancellation()
                 try alive.getOrRegisterAxWindow(windowId: id, window, nsApp, job)
             }

--- a/Sources/AppBundle/tree/MacApp.swift
+++ b/Sources/AppBundle/tree/MacApp.swift
@@ -277,8 +277,16 @@ final class MacApp: AbstractApp {
             await destroy()
             return []
         }
+        let pid = self.pid
+        let visibleWorkspaceWindowIds = await MainActor.run { () -> Set<UInt32> in
+            Set(
+                MacWindow.allWindows.lazy
+                    .filter { $0.macApp.pid == pid && $0.nodeWorkspace?.isVisible == true }
+                    .map(\.windowId),
+            )
+        }
         guard let thread else { return [] }
-        let (alive, dead) = try await thread.runInLoop { [nsApp, windows, axApp] (job) -> ([UInt32], [UInt32]) in
+        let (alive, dead) = try await thread.runInLoop { [nsApp, windows, axApp, visibleWorkspaceWindowIds] (job) -> ([UInt32], [UInt32]) in
             var alive: [UInt32: AxWindow] = [:]
             var dead = [UInt32: AxWindow]()
             let currentWindows = axApp.threadGuarded.get(Ax.windowsAttr) ?? []
@@ -294,18 +302,19 @@ final class MacApp: AbstractApp {
             // Second line of defence against lock screen. See the first line of defence: closedWindowsCache
             // Second and third lines of defence are technically needed only to avoid potential flickering
             if frontmostAppBundleId != lockScreenAppBundleId {
-                (_, dead) = try windows.threadGuarded.partition {
+                for (id, window) in windows.threadGuarded {
                     try job.checkCancellation()
-                    guard $0.value.ax.containingWindowId() != nil else {
-                        return false
+                    guard window.ax.containingWindowId() != nil else {
+                        dead[id] = window
+                        continue
                     }
-                    if currentWindowIds.contains($0.key) {
-                        return true
+                    // AXWindows omits windows on inactive macOS Spaces, so only visible-workspace
+                    // windows should be pruned against the current AXWindows membership.
+                    if currentWindowIds.contains(id) || !visibleWorkspaceWindowIds.contains(id) || shouldKeepOmittedWindowAlive(window) {
+                        alive[id] = window
+                    } else {
+                        dead[id] = window
                     }
-                    return shouldKeepOmittedWindowAlive($0.value)
-                }
-                for (id, window) in windows.threadGuarded where currentWindowIds.contains(id) || shouldKeepOmittedWindowAlive(window) {
-                    alive[id] = window
                 }
             } else {
                 alive = windows.threadGuarded


### PR DESCRIPTION
## Summary

Fix a native-tab stale-window case where AeroSpace keeps old cached windows after the app stops exposing them in `AXWindows`.

## Repro

1. Start with one tiled window
2. Press `Cmd-T` to create a native tab

Reproduced in Ghostty and Finder.

## Change

- Treat current `AXWindows` as authoritative membership for normal top-level windows
- Keep explicit exceptions for hidden, minimized, and fullscreen windows
- Do not register a newly focused window unless it is already in `AXWindows` or already cached

## Validation

Manual testing on macOS 26.3.1:
- Ghostty 1.3.1
- Finder

Ghostty result:
- before: managed window count increased after `Cmd-T`
- after: `before=1 after=1`

## Notes

- No private APIs
- Narrow fix for a stale-window native-tab case, not a full native-tabs solution