### PR TITLE
Add scrolling and tabs workspace layouts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,90 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+AeroSpace is an i3-like tiling window manager for macOS, written in Swift 6.3 (SPM-driven). It does not require disabling SIP and uses only one private accessibility API (`_AXUIElementGetWindow`). Avoid introducing further "dark magic" (private APIs, code injection). Avoid GUI surfaces beyond the menu bar icon — config is plain text TOML.
+
+## Build / test / run
+
+All entry-point scripts live at the repo root. They `cd` to the repo root and `source ./script/setup.sh`, so always invoke via `./script/...` from the project root rather than copying the underlying `swift` invocation.
+
+- `./build-debug.sh` — debug build via SPM into `.debug/`. Calls `./generate.sh --ignore-xcodeproj --ignore-cmd-help --ignore-shell-parser` first; pass any extra `swift build` flags through.
+- `./run-debug.sh` — build + run `.debug/AeroSpaceApp`.
+- `./run-cli.sh <args>` — build + run `.debug/aerospace` with forwarded args (CLI client).
+- `./swift-test.sh` — `swift test` with noisy lines stripped. Single test: `swift test --filter <SuiteName>[/<testName>]` (e.g. `swift test --filter LayoutTests/testTabbing`).
+- `./test.sh` — full CI gate: clean-tree check → debug build with `-warnings-as-errors` → swift tests → CLI smoke (`-h`, `-v`) → `lint.sh --check-uncommitted-files` → `generate.sh` → second clean-tree check. Run before declaring work done.
+- `./format.sh` — runs swiftformat then swiftlint `--fix` (auto-installs both into `.deps/`).
+- `./lint.sh` — periphery dead-code scan with `--strict` (skipped on macOS 14 due to a periphery dylib bug).
+- `./generate.sh` — regenerates `Sources/Common/versionGenerated.swift`, `Sources/Common/gitHashGenerated.swift`, `Sources/Cli/subcommandDescriptionsGenerated.swift`, the shell parser (under `ShellParserGenerated/`), and `AeroSpace.xcodeproj` (via xcodegen + `project.yml`). Use `--ignore-xcodeproj`/`--ignore-cmd-help`/`--ignore-shell-parser` to skip parts. **Files ending in `Generated.swift` are output of this script — never hand-edit them; change the source (`docs/aerospace-*.adoc`, `grammar/*`) and rerun.**
+- `./build-release.sh` — Xcode-driven universal release build into `.release/` (Xcode 26+, requires the `aerospace-codesign-certificate` self-signed identity). Not needed for normal dev.
+- `./build-docs.sh` / `./build-shell-completion.sh` — site/manpages and shell completion artifacts.
+- `make <script>.sh` works (the `makefile` just shells out) so `:make` in vim is wired up.
+
+## Codesigning for local debug
+
+Debug builds run unsigned from terminal. To run as `.app` with stable accessibility permission, create a self-signed cert in Keychain Access named `aerospace-codesign-certificate` (see `dev-docs/development.md`). In Xcode: File → Open `Package.swift` (not the xcodeproj), then Edit Scheme → Options → Console → Terminal so accessibility permission is granted to Terminal once instead of on every rebuild.
+
+## Architecture
+
+Two binaries, three SPM targets, one shared library:
+
+- `Sources/Cli/` (`aerospace` executable) — thin client. Parses args, sends them over a UNIX socket to the running app, prints stdout/stderr, exits with the server's exit code. Depends on `Common` only.
+- `Sources/AeroSpaceApp/` — App Bundle entry point (the actual `AeroSpace.app`). Depends on `AppBundle`. Tiny — almost everything is in the library.
+- `Sources/AppBundle/` — server library (the real window manager). Depends on `Common`, `PrivateApi`, and external packages (HotKey, ISSoundAdditions, swift-collections, TOMLDecoder, ShellParserGenerated).
+- `Sources/Common/` — shared between client and server: command-line arg models (`cmdArgs/`), util, generated version/hash.
+- `Sources/PrivateApi/` — C shim exposing `_AXUIElementGetWindow`.
+
+The reason for this split: SPM cannot build macOS `.app` bundles, only CLIs/libraries. So `AppBundle` is a library that Xcode wraps into the app via the generated `AeroSpace.xcodeproj` (skeleton in `project.yml`). Most logic lives in `AppBundle` so SourceKit-LSP works without Xcode.
+
+### Client/server protocol
+
+Each CLI invocation:
+1. Client parses args (errors / `--help` short-circuit here).
+2. Args are sent to the server over a predefined UNIX socket (see `Sources/AppBundle/server.swift`).
+3. Server re-parses and executes against the live tree.
+4. Server returns stdout/stderr/exit code; client prints and exits.
+
+This means **command logic lives in the server**, but **arg models are shared in `Common/cmdArgs/`** so both sides agree on the wire format.
+
+### Server subsystems (`Sources/AppBundle/`)
+
+- `tree/` — the core data model. `TreeNode` is the abstract base; concrete cases are workspaces, tiling containers (split H/V, accordion, **tabs** — see `tabHeaders.swift`), windows, and `MacosUnconventionalWindowsContainer` for floating/fullscreen escape hatches. **Note:** the tree is currently mutable + double-linked. There is an in-flight rewrite to an immutable single-linked persistent tree (issue #1215) — be conservative when refactoring tree internals.
+- `layout/` — applies the tree to actual macOS window frames. `refresh.swift` is the main reconcile loop; `layoutRecursive.swift` walks the tree and computes frames; `tabHeaders.swift` draws tab strip overlays via `TabHeadersView`.
+- `command/` — every user-facing command (`focus`, `move`, `workspace`, `mode`, `layout`, …) lives in `command/impl/`. `cmdManifest.swift` is the registry. `frozen/` contains commands that operate on a snapshot (split brain between mutable tree and command execution).
+- `config/` — TOML config parser (TOMLDecoder) and validation. Config errors must be surfaced with line numbers.
+- `model/` — runtime singletons: focus state, monitor model, mode state.
+- `mouse/` — drag/resize/hover handling driven by mouse events.
+- `shell/` — shell-combinator parser glue (the upcoming `&&`/`||`/`;`/`eval` work, issue #278). The actual lexer/parser is generated from `grammar/Shell{Lexer,Parser}.g4` into the separate `ShellParserGenerated` package.
+- `ui/` — the small AppKit surface: status menu icon, `TabHeadersView`. No config GUI by design.
+- `GlobalObserver.swift` / `runLoop.swift` / `subscriptions.swift` — AX-event observation and the main run-loop tick.
+- `focus.swift` / `focusCache.swift` / `getNativeFocusedWindow.swift` / `windowLevelCache.swift` — focus tracking; aggressively cached because AX calls are blocking and slow.
+
+### Adding a new command
+
+When adding a command, the contributor checklist (per `dev-docs/architecture.md`) is:
+- Command impl in `Sources/AppBundle/command/impl/`, registered in `cmdManifest.swift`.
+- Arg model in `Sources/Common/cmdArgs/` (shared with CLI).
+- Docs in `docs/aerospace-<cmd>.adoc` and `docs/commands.adoc` (asciidoc, fed into manpages and the site).
+- Decide if `--window-id` and/or `--workspace` flags apply.
+- Update shell completion grammar in `grammar/commands-bnf-grammar.txt`.
+- Run `./generate.sh` to regenerate `subcommandDescriptionsGenerated.swift` and `cmdHelpGenerated.swift`.
+
+## Conventions
+
+- Swift 6.3, strict memory safety, `NonisolatedNonsendingByDefault` upcoming feature on. Treat warnings as errors when in doubt — `./test.sh` does.
+- Formatting: swiftformat config in `.swiftformat` (tabs of 4 spaces, no semicolons, trailing closures, etc., explicit allowlist of rules). swiftlint config in `.swiftlint.yml`. Always `./format.sh` before committing.
+- **Generated files** (`*Generated.swift`, `ShellParserGenerated/`, `AeroSpace.xcodeproj/`) must be regenerated, not hand-edited. CI's `script/check-uncommitted-files.sh` will fail otherwise.
+- **Commit hygiene** (from `CONTRIBUTING.md`): each commit is one atomic change; do not mix refactors with feature changes; commit messages describe what / why / how.
+- **Don't refactor along the way.** When fixing a bug or adding a feature, stick to the existing code structure even if you'd prefer something else — the maintainer prefers PRs that don't bundle drive-by cleanup.
+- **No GUI for config**, no animations / borders / transparency / "ricing" features — those proposals will be rejected on principle (see `README.md` "Project values"). Performance and correctness only.
+- This project does **not** accept GitHub Issues directly — bugs and feature ideas are filed as Discussions first. Don't open Issues from automated workflows.
+
+## Useful tools while debugging
+
+- `Accessibility Inspector.app` (built into macOS) to inspect AX properties of windows.
+- `aerospace debug-windows` for window-handling bug reports.
+- `script/clean-project.sh` when build state goes sideways.
+- `script/reset-accessibility-permission-for-debug.sh` if AX permission gets stuck.
+- DeskPad / BetterDisplay 2 to emulate multi-monitor setups locally.

--- a/Sources/AppBundle/GlobalObserver.swift
+++ b/Sources/AppBundle/GlobalObserver.swift
@@ -71,7 +71,9 @@ enum GlobalObserver {
                     // Detect close button clicks for unfocused windows. Yes, kAXUIElementDestroyedNotification is that unreliable
                     //  And trigger new window detection that could be delayed due to mouseDown event
                     default:
-                        scheduleCancellableCompleteRefreshSession(.globalObserverLeftMouseUp)
+                        if !TabHeaderInteractionState.shared.consumePendingGlobalMouseRefreshSuppression() {
+                            scheduleCancellableCompleteRefreshSession(.globalObserverLeftMouseUp)
+                        }
                 }
             }
         }

--- a/Sources/AppBundle/command/cmdManifest.swift
+++ b/Sources/AppBundle/command/cmdManifest.swift
@@ -68,6 +68,8 @@ extension CmdArgs {
                 command = ReloadConfigCommand(args: self as! ReloadConfigCmdArgs)
             case .resize:
                 command = ResizeCommand(args: self as! ResizeCmdArgs)
+            case .scroll:
+                command = ScrollCommand(args: self as! ScrollCmdArgs)
             case .split:
                 command = SplitCommand(args: self as! SplitCmdArgs)
             case .subscribe:

--- a/Sources/AppBundle/command/cmdManifest.swift
+++ b/Sources/AppBundle/command/cmdManifest.swift
@@ -74,6 +74,8 @@ extension CmdArgs {
                 command = ResizeCommand(args: self as! ResizeCmdArgs)
             case .runCallback:
                 command = RunCallbackCommand(args: self as! RunCallbackCmdArgs)
+            case .scroll:
+                command = ScrollCommand(args: self as! ScrollCmdArgs)
             case .split:
                 command = SplitCommand(args: self as! SplitCmdArgs)
             case .subscribe:

--- a/Sources/AppBundle/command/format.swift
+++ b/Sources/AppBundle/command/format.swift
@@ -227,20 +227,30 @@ private func toLayoutString(tc: TilingContainer) -> String {
         case (.tiles, .v): return LayoutCmdArgs.LayoutDescription.v_tiles.rawValue
         case (.accordion, .h): return LayoutCmdArgs.LayoutDescription.h_accordion.rawValue
         case (.accordion, .v): return LayoutCmdArgs.LayoutDescription.v_accordion.rawValue
+        case (.scrolling, _): return LayoutCmdArgs.LayoutDescription.scrolling.rawValue
     }
 }
 
 private func toLayoutResult(w: Window) -> Result<Primitive, String> {
     guard let parent = w.parent else { return .failure("NULL-PARENT") }
-    return switch getChildParentRelation(child: w, parent: parent) {
-        case .tiling(let tc): .success(.string(toLayoutString(tc: tc)))
-        case .floatingWindow: .success(.string(LayoutCmdArgs.LayoutDescription.floating.rawValue))
-        case .macosNativeFullscreenWindow: .success(.string("macos_native_fullscreen"))
-        case .macosNativeHiddenAppWindow: .success(.string("macos_native_window_of_hidden_app"))
-        case .macosNativeMinimizedWindow: .success(.string("macos_native_minimized"))
-        case .macosPopupWindow: .success(.string("NULL-WINDOW-LAYOUT"))
-
-        case .rootTilingContainer: .failure("Not possible")
-        case .shimContainerRelation: .failure("Window cannot have a shim container relation")
+    switch getChildParentRelation(child: w, parent: parent) {
+        case .tiling(let tc):
+            let rootContainer = w.parentsWithSelf.compactMap { $0 as? TilingContainer }.last
+            let layoutContainer = rootContainer?.layout == .scrolling ? rootContainer ?? tc : tc
+            return .success(.string(toLayoutString(tc: layoutContainer)))
+        case .floatingWindow:
+            return .success(.string(LayoutCmdArgs.LayoutDescription.floating.rawValue))
+        case .macosNativeFullscreenWindow:
+            return .success(.string("macos_native_fullscreen"))
+        case .macosNativeHiddenAppWindow:
+            return .success(.string("macos_native_window_of_hidden_app"))
+        case .macosNativeMinimizedWindow:
+            return .success(.string("macos_native_minimized"))
+        case .macosPopupWindow:
+            return .success(.string("NULL-WINDOW-LAYOUT"))
+        case .rootTilingContainer:
+            return .failure("Not possible")
+        case .shimContainerRelation:
+            return .failure("Window cannot have a shim container relation")
     }
 }

--- a/Sources/AppBundle/command/format.swift
+++ b/Sources/AppBundle/command/format.swift
@@ -228,6 +228,7 @@ private func toLayoutString(tc: TilingContainer) -> String {
         case (.accordion, .h): return LayoutCmdArgs.LayoutDescription.h_accordion.rawValue
         case (.accordion, .v): return LayoutCmdArgs.LayoutDescription.v_accordion.rawValue
         case (.scrolling, _): return LayoutCmdArgs.LayoutDescription.scrolling.rawValue
+        case (.tabs, _): return LayoutCmdArgs.LayoutDescription.tabs.rawValue
     }
 }
 

--- a/Sources/AppBundle/command/format.swift
+++ b/Sources/AppBundle/command/format.swift
@@ -240,13 +240,20 @@ private func toLayoutString(tc: TilingContainer) -> String {
         case (.tiles, .v): return LayoutCmdArgs.LayoutDescription.v_tiles.rawValue
         case (.accordion, .h): return LayoutCmdArgs.LayoutDescription.h_accordion.rawValue
         case (.accordion, .v): return LayoutCmdArgs.LayoutDescription.v_accordion.rawValue
+        case (.scrolling, _): return LayoutCmdArgs.LayoutDescription.scrolling.rawValue
+        case (.tabs, _): return LayoutCmdArgs.LayoutDescription.tabs.rawValue
     }
 }
 
 private func toLayoutResult(w: Window) -> Result<Primitive, InterVarExpansionError> {
     guard let parent = w.parent else { return .failure(.nullParent("NULL-PARENT")) }
     return switch getChildParentRelation(child: w, parent: parent) {
-        case .tiling(let tc): .success(.string(toLayoutString(tc: tc)))
+        case .tiling(let tc):
+            {
+                let rootContainer = w.parentsWithSelf.compactMap { $0 as? TilingContainer }.last
+                let layoutContainer = rootContainer?.layout == .scrolling ? rootContainer ?? tc : tc
+                return .success(.string(toLayoutString(tc: layoutContainer)))
+            }()
         case .floatingWindow: .success(.string(LayoutCmdArgs.LayoutDescription.floating.rawValue))
         case .macosNativeFullscreenWindow: .success(.string("macos_native_fullscreen"))
         case .macosNativeHiddenAppWindow: .success(.string("macos_native_window_of_hidden_app"))

--- a/Sources/AppBundle/command/impl/BalanceSizesCommand.swift
+++ b/Sources/AppBundle/command/impl/BalanceSizesCommand.swift
@@ -8,6 +8,9 @@ struct BalanceSizesCommand: Command {
 
     func run(_ env: CmdEnv, _ io: CmdIo) -> BinaryExitCode {
         guard let target = args.resolveTargetOrReportError(env, io) else { return .fail }
+        if target.workspace.rootTilingContainer.layout == .scrolling {
+            return .fail(io.err("balance-sizes command doesn't support the scrolling layout"))
+        }
         balance(target.workspace.rootTilingContainer)
         return .succ
     }
@@ -19,6 +22,8 @@ private func balance(_ parent: TilingContainer) {
         switch parent.layout {
             case .tiles: child.setWeight(parent.orientation, 1)
             case .accordion: break // Do nothing
+            case .scrolling: break
+            case .tabs: break
         }
         if let child = child as? TilingContainer {
             balance(child)

--- a/Sources/AppBundle/command/impl/BalanceSizesCommand.swift
+++ b/Sources/AppBundle/command/impl/BalanceSizesCommand.swift
@@ -23,6 +23,7 @@ private func balance(_ parent: TilingContainer) {
             case .tiles: child.setWeight(parent.orientation, 1)
             case .accordion: break // Do nothing
             case .scrolling: break
+            case .tabs: break
         }
         if let child = child as? TilingContainer {
             balance(child)

--- a/Sources/AppBundle/command/impl/BalanceSizesCommand.swift
+++ b/Sources/AppBundle/command/impl/BalanceSizesCommand.swift
@@ -8,6 +8,9 @@ struct BalanceSizesCommand: Command {
 
     func run(_ env: CmdEnv, _ io: CmdIo) -> BinaryExitCode {
         guard let target = args.resolveTargetOrReportError(env, io) else { return .fail }
+        if target.workspace.rootTilingContainer.layout == .scrolling {
+            return .fail(io.err("balance-sizes command doesn't support the scrolling layout"))
+        }
         balance(target.workspace.rootTilingContainer)
         return .succ
     }
@@ -19,6 +22,7 @@ private func balance(_ parent: TilingContainer) {
         switch parent.layout {
             case .tiles: child.setWeight(parent.orientation, 1)
             case .accordion: break // Do nothing
+            case .scrolling: break
         }
         if let child = child as? TilingContainer {
             balance(child)

--- a/Sources/AppBundle/command/impl/FocusCommand.swift
+++ b/Sources/AppBundle/command/impl/FocusCommand.swift
@@ -187,6 +187,9 @@ extension TreeNode {
             case .window(let window):
                 return window
             case .tilingContainer(let container):
+                if container.layout == .tabs {
+                    return container.mostRecentChild?.findLeafWindowRecursive(snappedTo: direction)
+                }
                 if direction.orientation == container.orientation {
                     return (direction.isPositive ? container.children.last : container.children.first)?
                         .findLeafWindowRecursive(snappedTo: direction)

--- a/Sources/AppBundle/command/impl/FocusCommand.swift
+++ b/Sources/AppBundle/command/impl/FocusCommand.swift
@@ -141,11 +141,11 @@ struct FocusCommand: Command {
             guard let _tilingParent = target.parent as? TilingContainer else { continue }
             tilingParent = _tilingParent
             index = switch tilingParent.layout {
-                case .tiles:
+                case .tiles, .scrolling:
                     center.getProjection(tilingParent.orientation) >= targetCenter.getProjection(tilingParent.orientation)
                         ? target.ownIndex.orDie() + 1
                         : target.ownIndex.orDie()
-                case .accordion:
+                case .accordion, .tabs:
                     center.getProjection(tilingParent.orientation) >= targetCenter.getProjection(tilingParent.orientation)
                         ? tilingParent.children.count
                         : 0
@@ -201,6 +201,9 @@ extension TreeNode {
             case .window(let window):
                 return window
             case .tilingContainer(let container):
+                if container.layout == .tabs {
+                    return container.mostRecentChild?.findLeafWindowRecursive(snappedTo: direction)
+                }
                 if direction.orientation == container.orientation {
                     return (direction.isPositive ? container.children.last : container.children.first)?
                         .findLeafWindowRecursive(snappedTo: direction)

--- a/Sources/AppBundle/command/impl/LayoutCommand.swift
+++ b/Sources/AppBundle/command/impl/LayoutCommand.swift
@@ -26,6 +26,8 @@ struct LayoutCommand: Command {
                 return changeTilingLayout(io, targetLayout: .accordion, targetOrientation: nil, window: window)
             case .tiles:
                 return changeTilingLayout(io, targetLayout: .tiles, targetOrientation: nil, window: window)
+            case .scrolling:
+                return changeTilingLayout(io, targetLayout: .scrolling, targetOrientation: .h, window: window)
             case .horizontal:
                 return changeTilingLayout(io, targetLayout: nil, targetOrientation: .h, window: window)
             case .vertical:
@@ -57,10 +59,21 @@ struct LayoutCommand: Command {
     guard let parent = window.parent else { return .fail }
     switch parent.cases {
         case .tilingContainer(let parent):
+            if targetLayout == .scrolling && !parent.isRootContainer {
+                return .fail(io.err("The 'scrolling' layout is only supported for workspace root containers"))
+            }
+            if parent.layout == .scrolling && targetLayout == nil && targetOrientation == .v {
+                return .fail(io.err("The scrolling layout is always horizontal"))
+            }
             let targetOrientation = targetOrientation ?? parent.orientation
             let targetLayout = targetLayout ?? parent.layout
             parent.layout = targetLayout
             parent.changeOrientation(targetOrientation)
+            if targetLayout == .scrolling {
+                parent.reveal(window, preferRightPane: true)
+            } else {
+                parent.clampScrollingIndex()
+            }
             return .succ
         case .workspace, .macosMinimizedWindowsContainer, .macosFullscreenWindowsContainer,
              .macosPopupWindowsContainer, .macosHiddenAppsWindowsContainer:
@@ -73,6 +86,8 @@ extension Window {
         return switch layout {
             case .accordion:   (parent as? TilingContainer)?.layout == .accordion
             case .tiles:       (parent as? TilingContainer)?.layout == .tiles
+            case .scrolling:
+                parentsWithSelf.compactMap { $0 as? TilingContainer }.last?.layout == .scrolling
             case .horizontal:  (parent as? TilingContainer)?.orientation == .h
             case .vertical:    (parent as? TilingContainer)?.orientation == .v
             case .h_accordion: (parent as? TilingContainer).map { $0.layout == .accordion && $0.orientation == .h } == true

--- a/Sources/AppBundle/command/impl/LayoutCommand.swift
+++ b/Sources/AppBundle/command/impl/LayoutCommand.swift
@@ -28,6 +28,8 @@ struct LayoutCommand: Command {
                 return changeTilingLayout(io, targetLayout: .tiles, targetOrientation: nil, window: window)
             case .scrolling:
                 return changeTilingLayout(io, targetLayout: .scrolling, targetOrientation: .h, window: window)
+            case .tabs:
+                return changeTilingLayout(io, targetLayout: .tabs, targetOrientation: nil, window: window)
             case .horizontal:
                 return changeTilingLayout(io, targetLayout: nil, targetOrientation: .h, window: window)
             case .vertical:
@@ -86,6 +88,7 @@ extension Window {
         return switch layout {
             case .accordion:   (parent as? TilingContainer)?.layout == .accordion
             case .tiles:       (parent as? TilingContainer)?.layout == .tiles
+            case .tabs:        (parent as? TilingContainer)?.layout == .tabs
             case .scrolling:
                 parentsWithSelf.compactMap { $0 as? TilingContainer }.last?.layout == .scrolling
             case .horizontal:  (parent as? TilingContainer)?.orientation == .h

--- a/Sources/AppBundle/command/impl/LayoutCommand.swift
+++ b/Sources/AppBundle/command/impl/LayoutCommand.swift
@@ -42,21 +42,25 @@ struct LayoutCommand: Command {
         }
         switch targetDescription {
             case .h_accordion:
-                return changeTilingLayout(io, targetLayout: .accordion, targetOrientation: .h, node: node)
+                return changeTilingLayout(io, targetLayout: .accordion, targetOrientation: .h, node: node, window: target.windowOrNil)
             case .v_accordion:
-                return changeTilingLayout(io, targetLayout: .accordion, targetOrientation: .v, node: node)
+                return changeTilingLayout(io, targetLayout: .accordion, targetOrientation: .v, node: node, window: target.windowOrNil)
             case .h_tiles:
-                return changeTilingLayout(io, targetLayout: .tiles, targetOrientation: .h, node: node)
+                return changeTilingLayout(io, targetLayout: .tiles, targetOrientation: .h, node: node, window: target.windowOrNil)
             case .v_tiles:
-                return changeTilingLayout(io, targetLayout: .tiles, targetOrientation: .v, node: node)
+                return changeTilingLayout(io, targetLayout: .tiles, targetOrientation: .v, node: node, window: target.windowOrNil)
             case .accordion:
-                return changeTilingLayout(io, targetLayout: .accordion, targetOrientation: nil, node: node)
+                return changeTilingLayout(io, targetLayout: .accordion, targetOrientation: nil, node: node, window: target.windowOrNil)
             case .tiles:
-                return changeTilingLayout(io, targetLayout: .tiles, targetOrientation: nil, node: node)
+                return changeTilingLayout(io, targetLayout: .tiles, targetOrientation: nil, node: node, window: target.windowOrNil)
+            case .scrolling:
+                return changeTilingLayout(io, targetLayout: .scrolling, targetOrientation: .h, node: node, window: target.windowOrNil)
+            case .tabs:
+                return changeTilingLayout(io, targetLayout: .tabs, targetOrientation: nil, node: node, window: target.windowOrNil)
             case .horizontal:
-                return changeTilingLayout(io, targetLayout: nil, targetOrientation: .h, node: node)
+                return changeTilingLayout(io, targetLayout: nil, targetOrientation: .h, node: node, window: target.windowOrNil)
             case .vertical:
-                return changeTilingLayout(io, targetLayout: nil, targetOrientation: .v, node: node)
+                return changeTilingLayout(io, targetLayout: nil, targetOrientation: .v, node: node, window: target.windowOrNil)
             case .tiling:
                 guard let window = target.windowOrNil else { return .fail(io.err(noWindowIsFocused)) }
                 switch node {
@@ -87,15 +91,27 @@ struct LayoutCommand: Command {
     targetLayout: Layout?,
     targetOrientation: Orientation?,
     node: ConventionalWindowParentCases,
+    window: Window?,
 ) -> BinaryExitCode {
     switch node {
         case .floatingWindowsContainer:
             return .fail(io.err("The window is non-tiling"))
         case .tilingContainer(let parent):
+            if targetLayout == .scrolling && !parent.isRootContainer {
+                return .fail(io.err("The 'scrolling' layout is only supported for workspace root containers"))
+            }
+            if parent.layout == .scrolling && targetLayout == nil && targetOrientation == .v {
+                return .fail(io.err("The scrolling layout is always horizontal"))
+            }
             let targetOrientation = targetOrientation ?? parent.orientation
             let targetLayout = targetLayout ?? parent.layout
             parent.layout = targetLayout
             parent.changeOrientation(targetOrientation)
+            if targetLayout == .scrolling {
+                parent.reveal(window, preferRightPane: true)
+            } else {
+                parent.clampScrollingIndex()
+            }
             return .succ
     }
 }
@@ -105,6 +121,9 @@ extension ConventionalWindowParentCases {
         return switch layout {
             case .accordion:   tilingContainerOrNil?.layout == .accordion
             case .tiles:       tilingContainerOrNil?.layout == .tiles
+            case .tabs:        tilingContainerOrNil?.layout == .tabs
+            case .scrolling:
+                tilingContainerOrNil?.parentsWithSelf.compactMap { $0 as? TilingContainer }.last?.layout == .scrolling
             case .horizontal:  tilingContainerOrNil?.orientation == .h
             case .vertical:    tilingContainerOrNil?.orientation == .v
             case .h_accordion: tilingContainerOrNil.map { $0.layout == .accordion && $0.orientation == .h } == true

--- a/Sources/AppBundle/command/impl/MoveCommand.swift
+++ b/Sources/AppBundle/command/impl/MoveCommand.swift
@@ -12,6 +12,7 @@ struct MoveCommand: Command {
             return .fail(io.err(noWindowIsFocused))
         }
         guard let parent = currentWindow.parent else { return .fail }
+        let result: BinaryExitCode
         switch parent.cases {
             case .tilingContainer(let parent):
                 let indexOfCurrent = currentWindow.ownIndex.orDie()
@@ -19,22 +20,26 @@ struct MoveCommand: Command {
                 if parent.orientation == direction.orientation && parent.children.indices.contains(indexOfSiblingTarget) {
                     switch parent.children[indexOfSiblingTarget].tilingTreeNodeCasesOrDie() {
                         case .tilingContainer(let topLevelSiblingTargetContainer):
-                            return deepMoveIn(window: currentWindow, into: topLevelSiblingTargetContainer, moveDirection: direction)
+                            result = deepMoveIn(window: currentWindow, into: topLevelSiblingTargetContainer, moveDirection: direction)
                         case .window: // "swap windows"
                             let prevBinding = currentWindow.unbindFromParent()
                             currentWindow.bind(to: parent, adaptiveWeight: prevBinding.adaptiveWeight, index: indexOfSiblingTarget)
-                            return .succ
+                            result = .succ
                     }
                 } else {
-                    return moveOut(window: currentWindow, direction: direction, io, args, env)
+                    result = moveOut(window: currentWindow, direction: direction, io, args, env)
                 }
             case .workspace: // floating window
-                return .fail(io.err("moving floating windows isn't yet supported")) // todo
+                result = .fail(io.err("moving floating windows isn't yet supported")) // todo
             case .macosMinimizedWindowsContainer, .macosFullscreenWindowsContainer, .macosHiddenAppsWindowsContainer:
-                return .fail(io.err(moveOutMacosUnconventionalWindow))
+                result = .fail(io.err(moveOutMacosUnconventionalWindow))
             case .macosPopupWindowsContainer:
-                return .fail // Impossible
+                result = .fail // Impossible
         }
+        if result == .succ {
+            currentWindow.nodeWorkspace?.rootTilingContainer.reveal(currentWindow, preferRightPane: false)
+        }
+        return result
     }
 }
 
@@ -52,8 +57,7 @@ struct MoveCommand: Command {
                 case .stop: return .succ
                 case .fail: return .fail
                 case .createImplicitContainer:
-                    createImplicitContainerAndMoveWindow(window, workspace, direction)
-                    return .succ
+                    return .from(bool: createImplicitContainerAndMoveWindow(window, workspace, direction, io))
             }
         case .allMonitorsOuterFrame:
             guard let (monitors, index) = window.nodeMonitor?.findRelativeMonitor(inDirection: direction) else {
@@ -67,7 +71,7 @@ struct MoveCommand: Command {
 
                 return MoveNodeToMonitorCommand(args: moveNodeToMonitorArgs).run(env, io)
             } else {
-                return hitAllMonitorsOuterFrameBoundaries(window, workspace, args, direction)
+                return hitAllMonitorsOuterFrameBoundaries(window, workspace, args, direction, io)
             }
     }
 }
@@ -77,13 +81,13 @@ struct MoveCommand: Command {
     _ workspace: Workspace,
     _ args: MoveCmdArgs,
     _ direction: CardinalDirection,
+    _ io: CmdIo,
 ) -> BinaryExitCode {
     switch args.boundariesAction {
         case .stop: return .succ
         case .fail: return .fail
         case .createImplicitContainer:
-            createImplicitContainerAndMoveWindow(window, workspace, direction)
-            return .succ
+            return .from(bool: createImplicitContainerAndMoveWindow(window, workspace, direction, io))
     }
 }
 
@@ -125,14 +129,20 @@ private let moveOutMacosUnconventionalWindow = "moving macOS fullscreen, minimiz
     _ window: Window,
     _ workspace: Workspace,
     _ direction: CardinalDirection,
-) {
+    _ io: CmdIo,
+) -> Bool {
     let prevRoot = workspace.rootTilingContainer
+    if prevRoot.layout == .scrolling {
+        io.err("move --boundaries-action create-implicit-container doesn't support the scrolling layout")
+        return false
+    }
     prevRoot.unbindFromParent()
     // Force tiles layout
     _ = TilingContainer(parent: workspace, adaptiveWeight: WEIGHT_AUTO, direction.orientation, .tiles, index: 0)
     check(prevRoot != workspace.rootTilingContainer)
     prevRoot.bind(to: workspace.rootTilingContainer, adaptiveWeight: WEIGHT_AUTO, index: 0)
     window.bind(to: workspace.rootTilingContainer, adaptiveWeight: WEIGHT_AUTO, index: direction.insertionOffset)
+    return true
 }
 
 @MainActor private func deepMoveIn(window: Window, into container: TilingContainer, moveDirection: CardinalDirection) -> BinaryExitCode {

--- a/Sources/AppBundle/command/impl/MoveCommand.swift
+++ b/Sources/AppBundle/command/impl/MoveCommand.swift
@@ -165,13 +165,15 @@ extension TilingTreeNodeCases {
     @MainActor fileprivate func findDeepMoveInTargetRecursive(_ orientation: Orientation) -> TilingTreeNodeCases {
         switch self {
             case .window:
-                self
+                return self
             case .tilingContainer(let container) where container.orientation == orientation:
-                .tilingContainer(container)
+                return .tilingContainer(container)
             case .tilingContainer(let container):
-                container.mostRecentChild.orDie("Empty containers must be detached during normalization")
-                    .tilingTreeNodeCasesOrDie()
-                    .findDeepMoveInTargetRecursive(orientation)
+                return container.layout == .tabs
+                    ? .tilingContainer(container)
+                    : container.mostRecentChild.orDie("Empty containers must be detached during normalization")
+                        .tilingTreeNodeCasesOrDie()
+                        .findDeepMoveInTargetRecursive(orientation)
         }
     }
 }

--- a/Sources/AppBundle/command/impl/MoveCommand.swift
+++ b/Sources/AppBundle/command/impl/MoveCommand.swift
@@ -18,30 +18,35 @@ struct MoveCommand: Command {
         ) {
             return .fail
         }
+        let result: BinaryExitCode
         switch currentWindow.windowParentCases {
-            case .unbound: return .fail
+            case .unbound: result = .fail
             case .tilingContainer(let parent):
                 guard let indexOfCurrent = currentWindow.ownIndex else { return .fail(io.err(bugPrompt())) }
                 let indexOfSiblingTarget = indexOfCurrent + direction.focusOffset
                 if parent.orientation == direction.orientation && parent.children.indices.contains(indexOfSiblingTarget) {
                     switch parent.children[indexOfSiblingTarget].tilingTreeNodeCasesOrDie() {
                         case .tilingContainer(let topLevelSiblingTargetContainer):
-                            return deepMoveIn(window: currentWindow, into: topLevelSiblingTargetContainer, moveDirection: direction, io)
+                            result = deepMoveIn(window: currentWindow, into: topLevelSiblingTargetContainer, moveDirection: direction, io)
                         case .window: // "swap windows"
                             let prevBinding = currentWindow.unbindFromParent()
                             currentWindow.bind(to: parent, adaptiveWeight: prevBinding.adaptiveWeight, index: indexOfSiblingTarget)
-                            return .succ
+                            result = .succ
                     }
                 } else {
-                    return moveOut(tilingWindow: currentWindow, direction: direction, io, args, env)
+                    result = moveOut(tilingWindow: currentWindow, direction: direction, io, args, env)
                 }
             case .floatingWindowsContainer: // floating window
-                return .fail(io.err("moving floating windows isn't yet supported")) // todo
+                result = .fail(io.err("moving floating windows isn't yet supported")) // todo
             case .macosMinimizedWindowsContainer, .macosFullscreenWindowsContainer, .macosHiddenAppsWindowsContainer:
-                return .fail(io.err(moveOutMacosUnconventionalWindow))
+                result = .fail(io.err(moveOutMacosUnconventionalWindow))
             case .macosPopupWindowsContainer:
-                return .fail(io.err(bugPrompt())) // Impossible
+                result = .fail(io.err(bugPrompt())) // Impossible
         }
+        if result == .succ {
+            currentWindow.nodeWorkspace?.rootTilingContainer.reveal(currentWindow, preferRightPane: false)
+        }
+        return result
     }
 }
 
@@ -59,8 +64,7 @@ struct MoveCommand: Command {
                 case .stop: return .succ
                 case .fail: return .fail
                 case .createImplicitContainer:
-                    createImplicitContainerAndMoveWindow(window, workspace, direction)
-                    return .succ
+                    return .from(bool: createImplicitContainerAndMoveWindow(window, workspace, direction, io))
             }
         case .allMonitorsOuterFrame:
             guard let (monitors, index) = window.nodeMonitor?.findRelativeMonitor(inDirection: direction) else {
@@ -74,7 +78,7 @@ struct MoveCommand: Command {
 
                 return MoveNodeToMonitorCommand(args: moveNodeToMonitorArgs).run(env, io)
             } else {
-                return hitAllMonitorsOuterFrameBoundaries(window, workspace, args, direction)
+                return hitAllMonitorsOuterFrameBoundaries(window, workspace, args, direction, io)
             }
     }
 }
@@ -84,13 +88,13 @@ struct MoveCommand: Command {
     _ workspace: Workspace,
     _ args: MoveCmdArgs,
     _ direction: CardinalDirection,
+    _ io: CmdIo,
 ) -> BinaryExitCode {
     switch args.boundariesAction {
         case .stop: return .succ
         case .fail: return .fail
         case .createImplicitContainer:
-            createImplicitContainerAndMoveWindow(window, workspace, direction)
-            return .succ
+            return .from(bool: createImplicitContainerAndMoveWindow(window, workspace, direction, io))
     }
 }
 
@@ -133,14 +137,20 @@ private let moveOutMacosUnconventionalWindow = "moving macOS fullscreen, minimiz
     _ window: Window,
     _ workspace: Workspace,
     _ direction: CardinalDirection,
-) {
+    _ io: CmdIo,
+) -> Bool {
     let prevRoot = workspace.rootTilingContainer
+    if prevRoot.layout == .scrolling {
+        io.err("move --boundaries-action create-implicit-container doesn't support the scrolling layout")
+        return false
+    }
     prevRoot.unbindFromParent()
     // Force tiles layout
     _ = TilingContainer(parent: workspace, adaptiveWeight: WEIGHT_AUTO, direction.orientation, .tiles, index: 0)
     check(prevRoot != workspace.rootTilingContainer)
     prevRoot.bind(to: workspace.rootTilingContainer, adaptiveWeight: WEIGHT_AUTO, index: 0)
     window.bind(to: workspace.rootTilingContainer, adaptiveWeight: WEIGHT_AUTO, index: direction.insertionOffset)
+    return true
 }
 
 @MainActor private func deepMoveIn(window: Window, into container: TilingContainer, moveDirection: CardinalDirection, _ io: CmdIo) -> BinaryExitCode {
@@ -160,13 +170,15 @@ extension TilingTreeNodeCases {
     @MainActor fileprivate func findDeepMoveInTargetRecursive(_ orientation: Orientation) -> TilingTreeNodeCases {
         switch self {
             case .window:
-                self
+                return self
             case .tilingContainer(let container) where container.orientation == orientation:
-                .tilingContainer(container)
+                return .tilingContainer(container)
             case .tilingContainer(let container):
-                container.mostRecentChild.orDie("Empty containers must be detached during normalization")
-                    .tilingTreeNodeCasesOrDie()
-                    .findDeepMoveInTargetRecursive(orientation)
+                return container.layout == .tabs
+                    ? .tilingContainer(container)
+                    : container.mostRecentChild.orDie("Empty containers must be detached during normalization")
+                        .tilingTreeNodeCasesOrDie()
+                        .findDeepMoveInTargetRecursive(orientation)
         }
     }
 }

--- a/Sources/AppBundle/command/impl/ResizeCommand.swift
+++ b/Sources/AppBundle/command/impl/ResizeCommand.swift
@@ -7,6 +7,9 @@ struct ResizeCommand: Command { // todo cover with tests
 
     func run(_ env: CmdEnv, _ io: CmdIo) -> BinaryExitCode {
         guard let target = args.resolveTargetOrReportError(env, io) else { return .fail }
+        if target.workspace.rootTilingContainer.layout == .scrolling {
+            return .fail(io.err("resize command doesn't support the scrolling layout"))
+        }
 
         let candidates = target.windowOrNil?.parentsWithSelf
             .filter { ($0.parent as? TilingContainer)?.layout == .tiles }

--- a/Sources/AppBundle/command/impl/ResizeCommand.swift
+++ b/Sources/AppBundle/command/impl/ResizeCommand.swift
@@ -7,6 +7,9 @@ struct ResizeCommand: Command {
 
     func run(_ env: CmdEnv, _ io: CmdIo) -> BinaryExitCode {
         guard let target = args.resolveTargetOrReportError(env, io) else { return .fail }
+        if target.workspace.rootTilingContainer.layout == .scrolling {
+            return .fail(io.err("resize command doesn't support the scrolling layout"))
+        }
 
         let candidates = target.windowOrNil?.parentsWithSelf
             .filter { ($0.parent as? TilingContainer)?.layout == .tiles }

--- a/Sources/AppBundle/command/impl/ScrollCommand.swift
+++ b/Sources/AppBundle/command/impl/ScrollCommand.swift
@@ -1,0 +1,21 @@
+import AppKit
+import Common
+
+struct ScrollCommand: Command {
+    let args: ScrollCmdArgs
+    /*conforms*/ let shouldResetClosedWindowsCache = false
+
+    func run(_ env: CmdEnv, _ io: CmdIo) async throws -> Bool {
+        let root = focus.workspace.rootTilingContainer
+        guard root.layout == .scrolling else {
+            return io.err("scroll command only works when the workspace root container uses the scrolling layout")
+        }
+        let direction: CardinalDirection = switch args.direction.val {
+            case .left: .left
+            case .right: .right
+        }
+        root.clampScrollingIndex()
+        guard let target = root.scroll(in: direction) else { return true }
+        return target.focusWindow()
+    }
+}

--- a/Sources/AppBundle/command/impl/ScrollCommand.swift
+++ b/Sources/AppBundle/command/impl/ScrollCommand.swift
@@ -5,17 +5,18 @@ struct ScrollCommand: Command {
     let args: ScrollCmdArgs
     /*conforms*/ let shouldResetClosedWindowsCache = false
 
-    func run(_ env: CmdEnv, _ io: CmdIo) async throws -> Bool {
+    @MainActor
+    func run(_ env: CmdEnv, _ io: CmdIo) async throws -> BinaryExitCode {
         let root = focus.workspace.rootTilingContainer
         guard root.layout == .scrolling else {
-            return io.err("scroll command only works when the workspace root container uses the scrolling layout")
+            return .fail(io.err("scroll command only works when the workspace root container uses the scrolling layout"))
         }
         let direction: CardinalDirection = switch args.direction.val {
             case .left: .left
             case .right: .right
         }
         root.clampScrollingIndex()
-        guard let target = root.scroll(in: direction) else { return true }
-        return target.focusWindow()
+        guard let target = root.scroll(in: direction) else { return .succ }
+        return .from(bool: target.focusWindow())
     }
 }

--- a/Sources/AppBundle/command/impl/ScrollCommand.swift
+++ b/Sources/AppBundle/command/impl/ScrollCommand.swift
@@ -1,0 +1,21 @@
+import AppKit
+import Common
+
+struct ScrollCommand: Command {
+    let args: ScrollCmdArgs
+    /*conforms*/ let shouldResetClosedWindowsCache = false
+
+    func run(_ env: CmdEnv, _ io: CmdIo) async -> BinaryExitCode {
+        let root = focus.workspace.rootTilingContainer
+        guard root.layout == .scrolling else {
+            return .fail(io.err("scroll command only works when the workspace root container uses the scrolling layout"))
+        }
+        let direction: CardinalDirection = switch args.direction.val {
+            case .left: .left
+            case .right: .right
+        }
+        root.clampScrollingIndex()
+        guard let target = root.scroll(in: direction) else { return .succ }
+        return .from(bool: target.focusWindow())
+    }
+}

--- a/Sources/AppBundle/command/impl/SplitCommand.swift
+++ b/Sources/AppBundle/command/impl/SplitCommand.swift
@@ -24,6 +24,9 @@ struct SplitCommand: Command {
                     case .horizontal: .h
                     case .opposite: parent.orientation.opposite
                 }
+                if parent.layout == .scrolling && orientation != .h {
+                    return .fail(io.err("The scrolling layout is always horizontal"))
+                }
                 if parent.children.count == 1 {
                     parent.changeOrientation(orientation)
                 } else {

--- a/Sources/AppBundle/command/impl/SplitCommand.swift
+++ b/Sources/AppBundle/command/impl/SplitCommand.swift
@@ -24,6 +24,9 @@ struct SplitCommand: Command {
                     case .horizontal: .h
                     case .opposite: parent.orientation.opposite
                 }
+                if parent.layout == .scrolling && orientation != .h {
+                    return io.err("The scrolling layout is always horizontal")
+                }
                 if parent.children.count == 1 {
                     parent.changeOrientation(orientation)
                 } else {

--- a/Sources/AppBundle/command/impl/SplitCommand.swift
+++ b/Sources/AppBundle/command/impl/SplitCommand.swift
@@ -25,7 +25,7 @@ struct SplitCommand: Command {
                     case .opposite: parent.orientation.opposite
                 }
                 if parent.layout == .scrolling && orientation != .h {
-                    return io.err("The scrolling layout is always horizontal")
+                    return .fail(io.err("The scrolling layout is always horizontal"))
                 }
                 if parent.children.count == 1 {
                     parent.changeOrientation(orientation)

--- a/Sources/AppBundle/focus.swift
+++ b/Sources/AppBundle/focus.swift
@@ -72,6 +72,7 @@ private struct FrozenFocus: AeroAny, Equatable, Sendable {
     let status = newFocus.workspace.workspaceMonitor.setActiveWorkspace(newFocus.workspace)
 
     newFocus.windowOrNil?.markAsMostRecentChild()
+    newFocus.workspace.rootTilingContainer.reveal(newFocus.windowOrNil, preferRightPane: false)
     return status
 }
 extension Window {

--- a/Sources/AppBundle/initAppBundle.swift
+++ b/Sources/AppBundle/initAppBundle.swift
@@ -48,9 +48,16 @@ import Foundation
 private func smartLayoutAtStartup() {
     let workspace = focus.workspace
     let root = workspace.rootTilingContainer
-    switch root.children.count <= 3 {
-        case true: root.layout = .tiles
-        case false: root.layout = .accordion
+    if config.defaultRootContainerLayout == .scrolling {
+        root.layout = .scrolling
+        root.changeOrientation(.h)
+        root.reveal(focus.windowOrNil, preferRightPane: true)
+        return
+    }
+    if root.children.count <= 3 {
+        root.layout = .tiles
+    } else {
+        root.layout = .accordion
     }
 }
 

--- a/Sources/AppBundle/initAppBundle.swift
+++ b/Sources/AppBundle/initAppBundle.swift
@@ -50,9 +50,16 @@ import Foundation
 private func smartLayoutAtStartup() {
     let workspace = focus.workspace
     let root = workspace.rootTilingContainer
-    switch root.children.count <= 3 {
-        case true: root.layout = .tiles
-        case false: root.layout = .accordion
+    if config.defaultRootContainerLayout == .scrolling {
+        root.layout = .scrolling
+        root.changeOrientation(.h)
+        root.reveal(focus.windowOrNil, preferRightPane: true)
+        return
+    }
+    if root.children.count <= 3 {
+        root.layout = .tiles
+    } else {
+        root.layout = .accordion
     }
 }
 

--- a/Sources/AppBundle/layout/layoutRecursive.swift
+++ b/Sources/AppBundle/layout/layoutRecursive.swift
@@ -2,13 +2,15 @@ import AppKit
 
 extension Workspace {
     @MainActor
-    func layoutWorkspace() async throws {
-        if isEffectivelyEmpty { return }
+    func layoutWorkspace() async throws -> [TabHeaderSnapshot] {
+        if isEffectivelyEmpty { return [] }
         let rect = workspaceMonitor.visibleRectPaddedByOuterGaps
+        let context = LayoutContext(self)
         // If monitors are aligned vertically and the monitor below has smaller width, then macOS may not allow the
         // window on the upper monitor to take full width. rect.height - 1 resolves this problem
         // But I also faced this problem in monitors horizontal configuration. ¯\_(ツ)_/¯
-        try await layoutRecursive(rect.topLeftCorner, width: rect.width, height: rect.height - 1, virtual: rect, LayoutContext(self))
+        try await layoutRecursive(rect.topLeftCorner, width: rect.width, height: rect.height - 1, virtual: rect, context)
+        return context.tabHeaderSnapshots
     }
 }
 
@@ -28,14 +30,20 @@ extension TreeNode {
                 }
             case .window(let window):
                 if window.windowId != currentlyManipulatedWithMouseWindowId {
+                    let previousPhysicalRect = lastAppliedLayoutPhysicalRect
                     lastAppliedLayoutVirtualRect = virtual
                     if window.isFullscreen && window == context.workspace.rootTilingContainer.mostRecentWindowRecursive {
                         lastAppliedLayoutPhysicalRect = nil
+                        window.isHiddenForTabs = false
                         window.layoutFullscreen(context)
                     } else {
                         lastAppliedLayoutPhysicalRect = physicalRect
                         window.isFullscreen = false
-                        window.setAxFrame(point, CGSize(width: width, height: height))
+                        let wasHiddenForTabs = window.isHiddenForTabs
+                        window.isHiddenForTabs = false
+                        if wasHiddenForTabs || !rectEquals(previousPhysicalRect, physicalRect) {
+                            window.setAxFrame(point, CGSize(width: width, height: height))
+                        }
                     }
                 }
             case .tilingContainer(let container):
@@ -48,6 +56,8 @@ extension TreeNode {
                         try await container.layoutAccordion(point, width: width, height: height, virtual: virtual, context)
                     case .scrolling:
                         try await container.layoutScrolling(point, width: width, height: height, virtual: virtual, context)
+                    case .tabs:
+                        try await container.layoutTabs(point, width: width, height: height, virtual: virtual, context)
                 }
             case .macosMinimizedWindowsContainer, .macosFullscreenWindowsContainer,
                  .macosPopupWindowsContainer, .macosHiddenAppsWindowsContainer:
@@ -56,18 +66,17 @@ extension TreeNode {
     }
 }
 
-private struct LayoutContext {
-    let workspace: Workspace
-    let resolvedGaps: ResolvedGaps
-
-    @MainActor
-    init(_ workspace: Workspace) {
-        self.workspace = workspace
-        self.resolvedGaps = ResolvedGaps(gaps: config.gaps, monitor: workspace.workspaceMonitor)
-    }
+private func rectEquals(_ lhs: Rect?, _ rhs: Rect) -> Bool {
+    guard let lhs else { return false }
+    return lhs.topLeftX == rhs.topLeftX &&
+        lhs.topLeftY == rhs.topLeftY &&
+        lhs.width == rhs.width &&
+        lhs.height == rhs.height
 }
 
 extension Window {
+    static let tabsHiddenPoint = CGPoint(x: -20000, y: -20000)
+
     @MainActor
     fileprivate func layoutFloatingWindow(_ context: LayoutContext) async throws {
         let workspace = context.workspace
@@ -101,6 +110,18 @@ extension Window {
             ? context.workspace.workspaceMonitor.visibleRect
             : context.workspace.workspaceMonitor.visibleRectPaddedByOuterGaps
         setAxFrame(monitorRect.topLeftCorner, CGSize(width: monitorRect.width, height: monitorRect.height))
+    }
+
+    @MainActor
+    fileprivate func hideForTabs() {
+        if isHiddenForTabs { return }
+        let size = lastAppliedLayoutPhysicalRect?.size
+            ?? lastAppliedLayoutVirtualRect?.size
+            ?? lastFloatingSize
+            ?? CGSize(width: 1, height: 1)
+        lastAppliedLayoutPhysicalRect = nil
+        isHiddenForTabs = true
+        setAxFrame(Self.tabsHiddenPoint, size)
     }
 }
 
@@ -200,6 +221,102 @@ extension TilingContainer {
                         context,
                     )
                 }
+        }
+    }
+
+    @MainActor
+    fileprivate func layoutTabs(_ point: CGPoint, width: CGFloat, height: CGFloat, virtual: Rect, _ context: LayoutContext) async throws {
+        guard let activeChild = mostRecentChild ?? children.first else { return }
+        let headerHeight = TabHeaderMetrics.height
+        let hasVisibleHeader = width >= TabHeaderMetrics.minTabWidth && height > headerHeight + 1
+        let headerFrame = Rect(topLeftX: point.x, topLeftY: point.y, width: width, height: hasVisibleHeader ? headerHeight : 0)
+        if hasVisibleHeader {
+            let availableWidth = max(0, width - 2 * TabHeaderMetrics.horizontalPadding)
+            let spacingCount = max(0, children.count - 1)
+            let itemWidth = max(
+                1,
+                (availableWidth - CGFloat(spacingCount) * TabHeaderMetrics.itemSpacing) / CGFloat(max(1, children.count)),
+            )
+            var cursorX = TabHeaderMetrics.horizontalPadding
+            var items: [TabHeaderItem] = []
+            for (index, child) in children.enumerated() {
+                guard let targetWindow = child.tabHeaderTargetWindow(),
+                      let title = try await child.tabHeaderTitle()
+                else { continue }
+                let remaining = max(0, width - cursorX - TabHeaderMetrics.horizontalPadding)
+                let currentWidth = min(itemWidth, remaining)
+                if currentWidth <= 0 { break }
+                let itemFrame = Rect(
+                    topLeftX: cursorX,
+                    topLeftY: TabHeaderMetrics.verticalPadding,
+                    width: currentWidth,
+                    height: headerHeight - 2 * TabHeaderMetrics.verticalPadding,
+                )
+                let closeButtonFrame = Rect(
+                    topLeftX: max(
+                        itemFrame.minX,
+                        itemFrame.maxX - TabHeaderMetrics.closeButtonTrailingInset - TabHeaderMetrics.closeButtonSize,
+                    ),
+                    topLeftY: itemFrame.topLeftY + (itemFrame.height - TabHeaderMetrics.closeButtonSize) / 2,
+                    width: min(TabHeaderMetrics.closeButtonSize, itemFrame.width),
+                    height: min(TabHeaderMetrics.closeButtonSize, itemFrame.height),
+                )
+                let titleMaxX = max(itemFrame.minX, closeButtonFrame.minX - TabHeaderMetrics.closeButtonLeadingSpacing)
+                let titleFrame = Rect(
+                    topLeftX: itemFrame.topLeftX,
+                    topLeftY: itemFrame.topLeftY,
+                    width: max(0, titleMaxX - itemFrame.topLeftX),
+                    height: itemFrame.height,
+                )
+                items.append(
+                    TabHeaderItem(
+                        id: "\(ObjectIdentifier(self).debugDescription)-\(index)-\(targetWindow.windowId)",
+                        targetWindow: targetWindow,
+                        title: title,
+                        frame: itemFrame,
+                        titleFrame: titleFrame,
+                        closeButtonFrame: closeButtonFrame,
+                        isActive: child == activeChild,
+                    ),
+                )
+                cursorX += currentWidth + TabHeaderMetrics.itemSpacing
+            }
+            if !items.isEmpty {
+                context.tabHeaderSnapshots.append(
+                    TabHeaderSnapshot(
+                        id: ObjectIdentifier(self),
+                        headerFrame: headerFrame,
+                        items: items,
+                    ),
+                )
+            }
+        }
+        for child in children where child != activeChild {
+            try await child.hideSubtreeForTabs()
+        }
+        let contentPoint = hasVisibleHeader ? point + CGPoint(x: 0, y: headerHeight) : point
+        let contentHeight = hasVisibleHeader ? height - headerHeight : height
+        let contentVirtual = hasVisibleHeader
+            ? Rect(topLeftX: virtual.topLeftX, topLeftY: virtual.topLeftY + headerHeight, width: virtual.width, height: virtual.height - headerHeight)
+            : virtual
+        try await activeChild.layoutRecursive(contentPoint, width: width, height: contentHeight, virtual: contentVirtual, context)
+    }
+}
+
+extension TreeNode {
+    @MainActor
+    fileprivate func hideSubtreeForTabs() async throws {
+        switch nodeCases {
+            case .window(let window):
+                window.hideForTabs()
+            case .tilingContainer(let container):
+                container.lastAppliedLayoutPhysicalRect = nil
+                for child in container.children {
+                    try await child.hideSubtreeForTabs()
+                }
+            case .workspace, .macosMinimizedWindowsContainer, .macosFullscreenWindowsContainer,
+                 .macosPopupWindowsContainer, .macosHiddenAppsWindowsContainer:
+                return
         }
     }
 }

--- a/Sources/AppBundle/layout/layoutRecursive.swift
+++ b/Sources/AppBundle/layout/layoutRecursive.swift
@@ -46,6 +46,8 @@ extension TreeNode {
                         try await container.layoutTiles(point, width: width, height: height, virtual: virtual, context)
                     case .accordion:
                         try await container.layoutAccordion(point, width: width, height: height, virtual: virtual, context)
+                    case .scrolling:
+                        try await container.layoutScrolling(point, width: width, height: height, virtual: virtual, context)
                 }
             case .macosMinimizedWindowsContainer, .macosFullscreenWindowsContainer,
                  .macosPopupWindowsContainer, .macosHiddenAppsWindowsContainer:
@@ -169,6 +171,35 @@ extension TilingContainer {
                         context,
                     )
             }
+        }
+    }
+
+    @MainActor
+    fileprivate func layoutScrolling(_ point: CGPoint, width: CGFloat, height: CGFloat, virtual: Rect, _ context: LayoutContext) async throws {
+        clampScrollingIndex()
+        switch children.count {
+            case 0:
+                return
+            case 1:
+                try await children[0].layoutRecursive(point, width: width, height: height, virtual: virtual, context)
+            default:
+                let pageWidth = width / 2
+                let rawGap = context.resolvedGaps.inner.horizontal.toDouble()
+                for (index, child) in children.enumerated() {
+                    let virtualX = virtual.topLeftX + CGFloat(index) * pageWidth
+                    let physicalX = point.x + CGFloat(index - scrollingIndex) * pageWidth
+                    let isLeftVisiblePage = index == scrollingIndex
+                    let isRightVisiblePage = index == scrollingIndex + 1
+                    let lPadding = isRightVisiblePage ? rawGap / 2 : 0
+                    let rPadding = isLeftVisiblePage ? rawGap / 2 : 0
+                    try await child.layoutRecursive(
+                        CGPoint(x: physicalX + lPadding, y: point.y),
+                        width: pageWidth - lPadding - rPadding,
+                        height: height,
+                        virtual: Rect(topLeftX: virtualX, topLeftY: virtual.topLeftY, width: pageWidth, height: height),
+                        context,
+                    )
+                }
         }
     }
 }

--- a/Sources/AppBundle/layout/layoutRecursive.swift
+++ b/Sources/AppBundle/layout/layoutRecursive.swift
@@ -2,13 +2,15 @@ import AppKit
 
 extension Workspace {
     @MainActor
-    func layoutWorkspace() async throws {
-        if isEffectivelyEmpty { return }
+    func layoutWorkspace() async throws -> [TabHeaderSnapshot] {
+        if isEffectivelyEmpty { return [] }
         let rect = workspaceMonitor.visibleRectPaddedByOuterGaps
+        let context = LayoutContext(self)
         // If monitors are aligned vertically and the monitor below has smaller width, then macOS may not allow the
         // window on the upper monitor to take full width. rect.height - 1 resolves this problem
         // But I also faced this problem in monitors horizontal configuration. ¯\_(ツ)_/¯
-        try await layoutRecursive(rect.topLeftCorner, width: rect.width, height: rect.height - 1, virtual: rect, LayoutContext(self))
+        try await layoutRecursive(rect.topLeftCorner, width: rect.width, height: rect.height - 1, virtual: rect, context)
+        return context.tabHeaderSnapshots
     }
 }
 
@@ -30,14 +32,20 @@ extension TreeNode {
                 }
             case .window(let window):
                 if window.windowId != currentlyManipulatedWithMouseWindowId {
+                    let previousPhysicalRect = lastAppliedLayoutPhysicalRect
                     lastAppliedLayoutVirtualRect = virtual
                     if window.isFullscreen && window == context.workspace.rootTilingContainer.mostRecentWindowRecursive {
                         lastAppliedLayoutPhysicalRect = nil
+                        window.isHiddenForTabs = false
                         window.layoutFullscreen(context)
                     } else {
                         lastAppliedLayoutPhysicalRect = physicalRect
                         window.isFullscreen = false
-                        window.setAxFrame(point, CGSize(width: width, height: height))
+                        let wasHiddenForTabs = window.isHiddenForTabs
+                        window.isHiddenForTabs = false
+                        if wasHiddenForTabs || !rectEquals(previousPhysicalRect, physicalRect) {
+                            window.setAxFrame(point, CGSize(width: width, height: height))
+                        }
                     }
                 }
             case .tilingContainer(let container):
@@ -48,6 +56,10 @@ extension TreeNode {
                         try await container.layoutTiles(point, width: width, height: height, virtual: virtual, context)
                     case .accordion:
                         try await container.layoutAccordion(point, width: width, height: height, virtual: virtual, context)
+                    case .scrolling:
+                        try await container.layoutScrolling(point, width: width, height: height, virtual: virtual, context)
+                    case .tabs:
+                        try await container.layoutTabs(point, width: width, height: height, virtual: virtual, context)
                 }
             case .macosMinimizedWindowsContainer, .macosFullscreenWindowsContainer,
                  .macosPopupWindowsContainer, .macosHiddenAppsWindowsContainer:
@@ -56,18 +68,17 @@ extension TreeNode {
     }
 }
 
-private struct LayoutContext {
-    let workspace: Workspace
-    let resolvedGaps: ResolvedGaps
-
-    @MainActor
-    init(_ workspace: Workspace) {
-        self.workspace = workspace
-        self.resolvedGaps = ResolvedGaps(gaps: config.gaps, monitor: workspace.workspaceMonitor)
-    }
+private func rectEquals(_ lhs: Rect?, _ rhs: Rect) -> Bool {
+    guard let lhs else { return false }
+    return lhs.topLeftX == rhs.topLeftX &&
+        lhs.topLeftY == rhs.topLeftY &&
+        lhs.width == rhs.width &&
+        lhs.height == rhs.height
 }
 
 extension Window {
+    static let tabsHiddenPoint = CGPoint(x: -20000, y: -20000)
+
     @MainActor
     fileprivate func layoutFloatingWindow(_ context: LayoutContext) async throws {
         let workspace = context.workspace
@@ -101,6 +112,18 @@ extension Window {
             ? context.workspace.workspaceMonitor.visibleRect
             : context.workspace.workspaceMonitor.visibleRectPaddedByOuterGaps
         setAxFrame(monitorRect.topLeftCorner, CGSize(width: monitorRect.width, height: monitorRect.height))
+    }
+
+    @MainActor
+    fileprivate func hideForTabs() {
+        if isHiddenForTabs { return }
+        let size = lastAppliedLayoutPhysicalRect?.size
+            ?? lastAppliedLayoutVirtualRect?.size
+            ?? lastFloatingSize
+            ?? CGSize(width: 1, height: 1)
+        lastAppliedLayoutPhysicalRect = nil
+        isHiddenForTabs = true
+        setAxFrame(Self.tabsHiddenPoint, size)
     }
 }
 
@@ -171,6 +194,137 @@ extension TilingContainer {
                         context,
                     )
             }
+        }
+    }
+
+    @MainActor
+    fileprivate func layoutScrolling(_ point: CGPoint, width: CGFloat, height: CGFloat, virtual: Rect, _ context: LayoutContext) async throws {
+        clampScrollingIndex()
+        switch children.count {
+            case 0:
+                return
+            case 1:
+                try await children[0].layoutRecursive(point, width: width, height: height, virtual: virtual, context)
+            default:
+                let pageWidth = width / 2
+                let rawGap = context.resolvedGaps.inner.horizontal.toDouble()
+                for (index, child) in children.enumerated() {
+                    let isLeftVisiblePage = index == scrollingIndex
+                    let isRightVisiblePage = index == scrollingIndex + 1
+                    // Off-screen pages must be parked off-screen, otherwise their
+                    // negative/overflowing physicalX bleeds onto adjacent monitors.
+                    guard isLeftVisiblePage || isRightVisiblePage else {
+                        try await child.hideSubtreeForTabs()
+                        continue
+                    }
+                    let virtualX = virtual.topLeftX + CGFloat(index) * pageWidth
+                    let physicalX = point.x + CGFloat(index - scrollingIndex) * pageWidth
+                    let lPadding = isRightVisiblePage ? rawGap / 2 : 0
+                    let rPadding = isLeftVisiblePage ? rawGap / 2 : 0
+                    try await child.layoutRecursive(
+                        CGPoint(x: physicalX + lPadding, y: point.y),
+                        width: pageWidth - lPadding - rPadding,
+                        height: height,
+                        virtual: Rect(topLeftX: virtualX, topLeftY: virtual.topLeftY, width: pageWidth, height: height),
+                        context,
+                    )
+                }
+        }
+    }
+
+    @MainActor
+    fileprivate func layoutTabs(_ point: CGPoint, width: CGFloat, height: CGFloat, virtual: Rect, _ context: LayoutContext) async throws {
+        guard let activeChild = mostRecentChild ?? children.first else { return }
+        let headerHeight = TabHeaderMetrics.height
+        let hasVisibleHeader = width >= TabHeaderMetrics.minTabWidth && height > headerHeight + 1
+        let headerFrame = Rect(topLeftX: point.x, topLeftY: point.y, width: width, height: hasVisibleHeader ? headerHeight : 0)
+        if hasVisibleHeader {
+            let availableWidth = max(0, width - 2 * TabHeaderMetrics.horizontalPadding)
+            let spacingCount = max(0, children.count - 1)
+            let itemWidth = max(
+                1,
+                (availableWidth - CGFloat(spacingCount) * TabHeaderMetrics.itemSpacing) / CGFloat(max(1, children.count)),
+            )
+            var cursorX = TabHeaderMetrics.horizontalPadding
+            var items: [TabHeaderItem] = []
+            for (index, child) in children.enumerated() {
+                guard let targetWindow = child.tabHeaderTargetWindow(),
+                      let title = try await child.tabHeaderTitle()
+                else { continue }
+                let remaining = max(0, width - cursorX - TabHeaderMetrics.horizontalPadding)
+                let currentWidth = min(itemWidth, remaining)
+                if currentWidth <= 0 { break }
+                let itemFrame = Rect(
+                    topLeftX: cursorX,
+                    topLeftY: TabHeaderMetrics.verticalPadding,
+                    width: currentWidth,
+                    height: headerHeight - 2 * TabHeaderMetrics.verticalPadding,
+                )
+                let closeButtonFrame = Rect(
+                    topLeftX: max(
+                        itemFrame.minX,
+                        itemFrame.maxX - TabHeaderMetrics.closeButtonTrailingInset - TabHeaderMetrics.closeButtonSize,
+                    ),
+                    topLeftY: itemFrame.topLeftY + (itemFrame.height - TabHeaderMetrics.closeButtonSize) / 2,
+                    width: min(TabHeaderMetrics.closeButtonSize, itemFrame.width),
+                    height: min(TabHeaderMetrics.closeButtonSize, itemFrame.height),
+                )
+                let titleMaxX = max(itemFrame.minX, closeButtonFrame.minX - TabHeaderMetrics.closeButtonLeadingSpacing)
+                let titleFrame = Rect(
+                    topLeftX: itemFrame.topLeftX,
+                    topLeftY: itemFrame.topLeftY,
+                    width: max(0, titleMaxX - itemFrame.topLeftX),
+                    height: itemFrame.height,
+                )
+                items.append(
+                    TabHeaderItem(
+                        id: "\(ObjectIdentifier(self).debugDescription)-\(index)-\(targetWindow.windowId)",
+                        targetWindow: targetWindow,
+                        title: title,
+                        frame: itemFrame,
+                        titleFrame: titleFrame,
+                        closeButtonFrame: closeButtonFrame,
+                        isActive: child == activeChild,
+                    ),
+                )
+                cursorX += currentWidth + TabHeaderMetrics.itemSpacing
+            }
+            if !items.isEmpty {
+                context.tabHeaderSnapshots.append(
+                    TabHeaderSnapshot(
+                        id: ObjectIdentifier(self),
+                        headerFrame: headerFrame,
+                        items: items,
+                    ),
+                )
+            }
+        }
+        for child in children where child != activeChild {
+            try await child.hideSubtreeForTabs()
+        }
+        let contentPoint = hasVisibleHeader ? point + CGPoint(x: 0, y: headerHeight) : point
+        let contentHeight = hasVisibleHeader ? height - headerHeight : height
+        let contentVirtual = hasVisibleHeader
+            ? Rect(topLeftX: virtual.topLeftX, topLeftY: virtual.topLeftY + headerHeight, width: virtual.width, height: virtual.height - headerHeight)
+            : virtual
+        try await activeChild.layoutRecursive(contentPoint, width: width, height: contentHeight, virtual: contentVirtual, context)
+    }
+}
+
+extension TreeNode {
+    @MainActor
+    fileprivate func hideSubtreeForTabs() async throws {
+        switch nodeCases {
+            case .window(let window):
+                window.hideForTabs()
+            case .tilingContainer(let container):
+                container.lastAppliedLayoutPhysicalRect = nil
+                for child in container.children {
+                    try await child.hideSubtreeForTabs()
+                }
+            case .workspace, .macosMinimizedWindowsContainer, .macosFullscreenWindowsContainer,
+                 .macosPopupWindowsContainer, .macosHiddenAppsWindowsContainer, .floatingWindowsContainer:
+                return
         }
     }
 }

--- a/Sources/AppBundle/layout/refresh.swift
+++ b/Sources/AppBundle/layout/refresh.swift
@@ -29,7 +29,10 @@ func runHeavyCompleteRefreshSession(
 ) async {
     let state = signposter.beginInterval(#function, "event: \(event) axTaskLocalAppThreadToken: \(axTaskLocalAppThreadToken?.idForDebug)")
     defer { signposter.endInterval(#function, state) }
-    if !TrayMenuModel.shared.isEnabled { return }
+    if !TrayMenuModel.shared.isEnabled {
+        TabHeadersPanelController.shared.closeAll()
+        return
+    }
     let res = await Result {
         try await $refreshSessionEvent.withValue(event) {
             try await $_isStartup.withValue(event.isStartup) {
@@ -155,9 +158,10 @@ enum OptimalHideCorner {
 @MainActor
 private func layoutWorkspaces() async throws {
     if !TrayMenuModel.shared.isEnabled {
+        TabHeadersPanelController.shared.closeAll()
         for workspace in Workspace.all {
             workspace.allLeafWindowsRecursive.forEach { ($0 as! MacWindow).unhideFromCorner() } // todo as!
-            try await workspace.layoutWorkspace() // Unhide tiling windows from corner
+            _ = try await workspace.layoutWorkspace() // Unhide tiling windows from corner
         }
         return
     }
@@ -187,11 +191,12 @@ private func layoutWorkspaces() async throws {
         monitorToOptimalHideCorner[monitor.rect.topLeftCorner] = corner
     }
 
+    var tabHeaderSnapshots: [TabHeaderSnapshot] = []
     // to reduce flicker, first unhide visible workspaces, then hide invisible ones
     for monitor in monitors {
         let workspace = monitor.activeWorkspace
         workspace.allLeafWindowsRecursive.forEach { ($0 as! MacWindow).unhideFromCorner() } // todo as!
-        try await workspace.layoutWorkspace()
+        tabHeaderSnapshots += try await workspace.layoutWorkspace()
     }
     for workspace in Workspace.all where !workspace.isVisible {
         let corner = monitorToOptimalHideCorner[workspace.workspaceMonitor.rect.topLeftCorner] ?? .bottomRightCorner
@@ -199,6 +204,7 @@ private func layoutWorkspaces() async throws {
             try await (window as! MacWindow).hideInCorner(corner) // todo as!
         }
     }
+    TabHeadersPanelController.shared.refresh(with: tabHeaderSnapshots)
 }
 
 @MainActor

--- a/Sources/AppBundle/layout/refresh.swift
+++ b/Sources/AppBundle/layout/refresh.swift
@@ -29,7 +29,10 @@ func runHeavyCompleteRefreshSession(
 ) async {
     let state = signposter.beginInterval(#function, "event: \(event) axTaskLocalAppThreadToken: \(axTaskLocalAppThreadToken?.idForDebug)")
     defer { signposter.endInterval(#function, state) }
-    if !TrayMenuModel.shared.isEnabled { return }
+    if !TrayMenuModel.shared.isEnabled {
+        TabHeadersPanelController.shared.closeAll()
+        return
+    }
     let res = await Result {
         try await $refreshSessionEvent.withValue(event) {
             let nativeFocused = try await getNativeFocusedWindow(.cancellable)
@@ -155,9 +158,10 @@ enum OptimalHideCorner {
 @MainActor
 private func layoutWorkspaces() async throws {
     if !TrayMenuModel.shared.isEnabled {
+        TabHeadersPanelController.shared.closeAll()
         for workspace in Workspace.all {
             workspace.allLeafWindowsRecursive.forEach { ($0 as! MacWindow).unhideFromCorner() } // todo as!
-            try await workspace.layoutWorkspace() // Unhide tiling windows from corner
+            _ = try await workspace.layoutWorkspace() // Unhide tiling windows from corner
         }
         return
     }
@@ -187,11 +191,12 @@ private func layoutWorkspaces() async throws {
         monitorToOptimalHideCorner[monitor.rect.topLeftCorner] = corner
     }
 
+    var tabHeaderSnapshots: [TabHeaderSnapshot] = []
     // to reduce flicker, first unhide visible workspaces, then hide invisible ones
     for monitor in monitors {
         let workspace = monitor.activeWorkspace
         workspace.allLeafWindowsRecursive.forEach { ($0 as! MacWindow).unhideFromCorner() } // todo as!
-        try await workspace.layoutWorkspace()
+        tabHeaderSnapshots += try await workspace.layoutWorkspace()
     }
     for workspace in Workspace.all where !workspace.isVisible {
         let corner = monitorToOptimalHideCorner[workspace.workspaceMonitor.rect.topLeftCorner] ?? .bottomRightCorner
@@ -199,6 +204,7 @@ private func layoutWorkspaces() async throws {
             try await (window as! MacWindow).hideInCorner(corner) // todo as!
         }
     }
+    TabHeadersPanelController.shared.refresh(with: tabHeaderSnapshots)
 }
 
 @MainActor

--- a/Sources/AppBundle/layout/tabHeaders.swift
+++ b/Sources/AppBundle/layout/tabHeaders.swift
@@ -1,0 +1,133 @@
+import AppKit
+import Foundation
+
+enum TabHeaderMetrics {
+    static let height = CGFloat(28)
+    static let horizontalPadding = CGFloat(6)
+    static let verticalPadding = CGFloat(4)
+    static let itemSpacing = CGFloat(6)
+    static let cornerRadius = CGFloat(7)
+    static let minTabWidth = CGFloat(72)
+    static let titleHorizontalInset = CGFloat(10)
+    static let closeButtonSize = CGFloat(12)
+    static let closeButtonTrailingInset = CGFloat(9)
+    static let closeButtonLeadingSpacing = CGFloat(6)
+}
+
+struct TabHeaderItem: Identifiable {
+    let id: String
+    let targetWindow: Window
+    let title: String
+    let frame: Rect
+    let titleFrame: Rect
+    let closeButtonFrame: Rect
+    let isActive: Bool
+}
+
+struct TabHeaderSnapshot: Identifiable {
+    let id: ObjectIdentifier
+    let headerFrame: Rect
+    let items: [TabHeaderItem]
+}
+
+@MainActor
+final class LayoutContext {
+    let workspace: Workspace
+    let resolvedGaps: ResolvedGaps
+    var tabHeaderSnapshots: [TabHeaderSnapshot] = []
+
+    init(_ workspace: Workspace) {
+        self.workspace = workspace
+        self.resolvedGaps = ResolvedGaps(gaps: config.gaps, monitor: workspace.workspaceMonitor)
+    }
+}
+
+@MainActor
+final class TabHeaderInteractionState {
+    static let shared = TabHeaderInteractionState()
+
+    private var latestInteractionAt: Date = .distantPast
+    private var hasPendingGlobalMouseUpSuppression = false
+    private let suppressionInterval: TimeInterval = 0.35
+
+    private init() {}
+
+    func markInteraction() {
+        latestInteractionAt = .now
+        hasPendingGlobalMouseUpSuppression = true
+    }
+
+    func consumePendingGlobalMouseRefreshSuppression(now: Date = .now) -> Bool {
+        guard hasPendingGlobalMouseUpSuppression else { return false }
+        hasPendingGlobalMouseUpSuppression = false
+        return latestInteractionAt.distance(to: now) <= suppressionInterval
+    }
+}
+
+@MainActor
+final class TabHeaderTitleCache {
+    static let shared = TabHeaderTitleCache()
+
+    private struct Entry {
+        let title: String
+        let updatedAt: Date
+    }
+
+    private var titles: [UInt32: Entry] = [:]
+    private let ttl: TimeInterval = 1
+
+    private init() {}
+
+    func title(for window: Window, now: Date = .now) async throws -> String {
+        let shouldRefresh = focus.windowOrNil == window
+        if let cached = titles[window.windowId],
+           !shouldRefresh,
+           cached.updatedAt.distance(to: now) <= ttl
+        {
+            return cached.title
+        }
+        let rawTitle = try await window.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolved = if !rawTitle.isEmpty {
+            rawTitle
+        } else if let appName = window.app.name?.trimmingCharacters(in: .whitespacesAndNewlines), !appName.isEmpty {
+            appName
+        } else {
+            "Window \(window.windowId)"
+        }
+        titles[window.windowId] = Entry(title: resolved, updatedAt: now)
+        return resolved
+    }
+
+    func cachedTitle(for windowId: UInt32) -> String? {
+        titles[windowId]?.title
+    }
+
+    func invalidate(windowId: UInt32) {
+        titles.removeValue(forKey: windowId)
+    }
+
+    func invalidateAll() {
+        titles = [:]
+    }
+}
+
+extension TreeNode {
+    @MainActor
+    func tabHeaderTargetWindow() -> Window? {
+        switch nodeCases {
+            case .window(let window):
+                return window
+            case .tilingContainer:
+                return mostRecentWindowRecursive ?? anyLeafWindowRecursive
+            case .workspace, .macosMinimizedWindowsContainer, .macosFullscreenWindowsContainer,
+                 .macosPopupWindowsContainer, .macosHiddenAppsWindowsContainer:
+                return nil
+        }
+    }
+
+    @MainActor
+    func tabHeaderTitle() async throws -> String? {
+        guard let targetWindow = tabHeaderTargetWindow() else { return nil }
+        return try await TabHeaderTitleCache.shared.title(for: targetWindow)
+    }
+}

--- a/Sources/AppBundle/layout/tabHeaders.swift
+++ b/Sources/AppBundle/layout/tabHeaders.swift
@@ -1,0 +1,133 @@
+import AppKit
+import Foundation
+
+enum TabHeaderMetrics {
+    static let height = CGFloat(28)
+    static let horizontalPadding = CGFloat(6)
+    static let verticalPadding = CGFloat(4)
+    static let itemSpacing = CGFloat(6)
+    static let cornerRadius = CGFloat(7)
+    static let minTabWidth = CGFloat(72)
+    static let titleHorizontalInset = CGFloat(10)
+    static let closeButtonSize = CGFloat(12)
+    static let closeButtonTrailingInset = CGFloat(9)
+    static let closeButtonLeadingSpacing = CGFloat(6)
+}
+
+struct TabHeaderItem: Identifiable {
+    let id: String
+    let targetWindow: Window
+    let title: String
+    let frame: Rect
+    let titleFrame: Rect
+    let closeButtonFrame: Rect
+    let isActive: Bool
+}
+
+struct TabHeaderSnapshot: Identifiable {
+    let id: ObjectIdentifier
+    let headerFrame: Rect
+    let items: [TabHeaderItem]
+}
+
+@MainActor
+final class LayoutContext {
+    let workspace: Workspace
+    let resolvedGaps: ResolvedGaps
+    var tabHeaderSnapshots: [TabHeaderSnapshot] = []
+
+    init(_ workspace: Workspace) {
+        self.workspace = workspace
+        self.resolvedGaps = ResolvedGaps(gaps: config.gaps, monitor: workspace.workspaceMonitor)
+    }
+}
+
+@MainActor
+final class TabHeaderInteractionState {
+    static let shared = TabHeaderInteractionState()
+
+    private var latestInteractionAt: Date = .distantPast
+    private var hasPendingGlobalMouseUpSuppression = false
+    private let suppressionInterval: TimeInterval = 0.35
+
+    private init() {}
+
+    func markInteraction() {
+        latestInteractionAt = .now
+        hasPendingGlobalMouseUpSuppression = true
+    }
+
+    func consumePendingGlobalMouseRefreshSuppression(now: Date = .now) -> Bool {
+        guard hasPendingGlobalMouseUpSuppression else { return false }
+        hasPendingGlobalMouseUpSuppression = false
+        return latestInteractionAt.distance(to: now) <= suppressionInterval
+    }
+}
+
+@MainActor
+final class TabHeaderTitleCache {
+    static let shared = TabHeaderTitleCache()
+
+    private struct Entry {
+        let title: String
+        let updatedAt: Date
+    }
+
+    private var titles: [UInt32: Entry] = [:]
+    private let ttl: TimeInterval = 1
+
+    private init() {}
+
+    func title(for window: Window, now: Date = .now) async throws -> String {
+        let shouldRefresh = focus.windowOrNil == window
+        if let cached = titles[window.windowId],
+           !shouldRefresh,
+           cached.updatedAt.distance(to: now) <= ttl
+        {
+            return cached.title
+        }
+        let rawTitle = try await window.getTitle(.nonCancellable).trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolved = if !rawTitle.isEmpty {
+            rawTitle
+        } else if let appName = window.app.name?.trimmingCharacters(in: .whitespacesAndNewlines), !appName.isEmpty {
+            appName
+        } else {
+            "Window \(window.windowId)"
+        }
+        titles[window.windowId] = Entry(title: resolved, updatedAt: now)
+        return resolved
+    }
+
+    func cachedTitle(for windowId: UInt32) -> String? {
+        titles[windowId]?.title
+    }
+
+    func invalidate(windowId: UInt32) {
+        titles.removeValue(forKey: windowId)
+    }
+
+    func invalidateAll() {
+        titles = [:]
+    }
+}
+
+extension TreeNode {
+    @MainActor
+    func tabHeaderTargetWindow() -> Window? {
+        switch nodeCases {
+            case .window(let window):
+                return window
+            case .tilingContainer:
+                return mostRecentWindowRecursive ?? anyLeafWindowRecursive
+            case .workspace, .macosMinimizedWindowsContainer, .macosFullscreenWindowsContainer,
+                 .macosPopupWindowsContainer, .macosHiddenAppsWindowsContainer, .floatingWindowsContainer:
+                return nil
+        }
+    }
+
+    @MainActor
+    func tabHeaderTitle() async throws -> String? {
+        guard let targetWindow = tabHeaderTargetWindow() else { return nil }
+        return try await TabHeaderTitleCache.shared.title(for: targetWindow)
+    }
+}

--- a/Sources/AppBundle/model/Rect.swift
+++ b/Sources/AppBundle/model/Rect.swift
@@ -62,4 +62,13 @@ extension Rect {
     var size: CGSize { CGSize(width: width, height: height) }
 
     func getDimension(_ orientation: Orientation) -> CGFloat { orientation == .h ? width : height }
+
+    var nsRect: NSRect {
+        NSRect(
+            x: topLeftX,
+            y: mainMonitor.height - topLeftY - height,
+            width: width,
+            height: height,
+        )
+    }
 }

--- a/Sources/AppBundle/mouse/moveWithMouse.swift
+++ b/Sources/AppBundle/mouse/moveWithMouse.swift
@@ -108,6 +108,8 @@ extension CGPoint {
                 tree.children.first(where: {
                     (virtual ? $0.lastAppliedLayoutVirtualRect : $0.lastAppliedLayoutPhysicalRect)?.contains(point) == true
                 })
+            case .tabs:
+                tree.mostRecentChild
         }
         guard let target else { return nil }
         return switch target.tilingTreeNodeCasesOrDie() {

--- a/Sources/AppBundle/mouse/moveWithMouse.swift
+++ b/Sources/AppBundle/mouse/moveWithMouse.swift
@@ -104,6 +104,10 @@ extension CGPoint {
                 })
             case .accordion:
                 tree.mostRecentChild
+            case .scrolling:
+                tree.children.first(where: {
+                    (virtual ? $0.lastAppliedLayoutVirtualRect : $0.lastAppliedLayoutPhysicalRect)?.contains(point) == true
+                })
         }
         guard let target else { return nil }
         return switch target.tilingTreeNodeCasesOrDie() {

--- a/Sources/AppBundle/mouse/moveWithMouse.swift
+++ b/Sources/AppBundle/mouse/moveWithMouse.swift
@@ -109,6 +109,12 @@ extension CGPoint {
                 })
             case .accordion:
                 tree.mostRecentChild
+            case .scrolling:
+                tree.children.first(where: {
+                    (virtual ? $0.lastAppliedLayoutVirtualRect : $0.lastAppliedLayoutPhysicalRect)?.contains(point) == true
+                })
+            case .tabs:
+                tree.mostRecentChild
         }
         guard let target else { return nil }
         return switch target.tilingTreeNodeCasesOrDie() {

--- a/Sources/AppBundle/tree/MacWindow.swift
+++ b/Sources/AppBundle/tree/MacWindow.swift
@@ -79,6 +79,7 @@ final class MacWindow: Window {
         if MacWindow.allWindowsMap.removeValue(forKey: windowId) == nil {
             return
         }
+        TabHeaderTitleCache.shared.invalidate(windowId: windowId)
         if !skipClosedWindowsCache { cacheClosedWindowIfNeeded() }
         let parent = unbindFromParent().parent
         let deadWindowWorkspace = parent.nodeWorkspace
@@ -112,6 +113,7 @@ final class MacWindow: Window {
     }
 
     override func closeAxWindow() {
+        TabHeaderTitleCache.shared.invalidate(windowId: windowId)
         garbageCollect(skipClosedWindowsCache: true)
         macApp.closeAndUnregisterAxWindow(windowId)
     }
@@ -171,7 +173,10 @@ final class MacWindow: Window {
 
                 setAxFrame(CGPoint(x: newX, y: newY), nil)
             case .macosNativeFullscreenWindow, .macosNativeHiddenAppWindow, .macosNativeMinimizedWindow,
-                 .macosPopupWindow, .tiling, .rootTilingContainer, .shimContainerRelation: break
+                 .macosPopupWindow, .tiling, .rootTilingContainer, .shimContainerRelation:
+                // The window was physically moved away while the workspace was hidden, so force the next layout pass
+                // to re-apply its frame instead of assuming the cached rect is still on screen.
+                lastAppliedLayoutPhysicalRect = nil
         }
 
         self.prevUnhiddenProportionalPositionInsideWorkspaceRect = nil

--- a/Sources/AppBundle/tree/MacWindow.swift
+++ b/Sources/AppBundle/tree/MacWindow.swift
@@ -80,6 +80,7 @@ final class MacWindow: Window {
         if MacWindow.allWindowsMap.removeValue(forKey: windowId) == nil {
             return
         }
+        TabHeaderTitleCache.shared.invalidate(windowId: windowId)
         if !skipClosedWindowsCache { cacheClosedWindowIfNeeded() }
         let parent = unbindFromParent().parent
         let deadWindowWorkspace = parent.nodeWorkspace
@@ -114,6 +115,7 @@ final class MacWindow: Window {
     }
 
     override func closeAxWindow() {
+        TabHeaderTitleCache.shared.invalidate(windowId: windowId)
         garbageCollect(skipClosedWindowsCache: true)
         macApp.closeAndUnregisterAxWindow(windowId)
     }
@@ -176,7 +178,10 @@ final class MacWindow: Window {
 
                 setAxFrame(CGPoint(x: newX, y: newY), nil)
             case .macosNativeFullscreenWindow, .macosNativeHiddenAppWindow, .macosNativeMinimizedWindow,
-                 .macosPopupWindow, .tiling, .rootTilingContainer, .shimContainerRelation: break
+                 .macosPopupWindow, .tiling, .rootTilingContainer, .shimContainerRelation:
+                // The window was physically moved away while the workspace was hidden, so force the next layout pass
+                // to re-apply its frame instead of assuming the cached rect is still on screen.
+                lastAppliedLayoutPhysicalRect = nil
         }
 
         self.prevUnhiddenProportionalPositionInsideWorkspaceRect = nil

--- a/Sources/AppBundle/tree/TilingContainer.swift
+++ b/Sources/AppBundle/tree/TilingContainer.swift
@@ -5,6 +5,11 @@ final class TilingContainer: TreeNode, NonLeafTreeNodeObject { // todo consider 
     fileprivate var _orientation: Orientation
     var orientation: Orientation { _orientation }
     var layout: Layout
+    private var _scrollingIndex: Int = 0
+    var scrollingIndex: Int {
+        get { _scrollingIndex }
+        set { _scrollingIndex = max(0, newValue) }
+    }
 
     @MainActor
     init(parent: NonLeafTreeNodeObject, adaptiveWeight: CGFloat, _ orientation: Orientation, _ layout: Layout, index: Int) {
@@ -26,6 +31,55 @@ final class TilingContainer: TreeNode, NonLeafTreeNodeObject { // todo consider 
 
 extension TilingContainer {
     var isRootContainer: Bool { parent is Workspace }
+    var isScrollingRoot: Bool { isRootContainer && layout == .scrolling }
+
+    var maxScrollingIndex: Int { max(0, children.count - 2) }
+
+    func clampScrollingIndex() {
+        scrollingIndex = isScrollingRoot ? min(scrollingIndex, maxScrollingIndex) : 0
+    }
+
+    @MainActor
+    func reveal(_ window: Window?, preferRightPane: Bool) {
+        guard isScrollingRoot else { return }
+        guard let index = window.flatMap(scrollingPageIndex(for:)) else {
+            clampScrollingIndex()
+            return
+        }
+        scrollingIndex = preferRightPane
+            ? min(max(0, index - 1), maxScrollingIndex)
+            : min(
+                max(
+                    0,
+                    index < scrollingIndex
+                        ? index
+                        : (index > scrollingIndex + 1 ? index - 1 : scrollingIndex),
+                ),
+                maxScrollingIndex,
+            )
+    }
+
+    @MainActor
+    func scroll(in direction: CardinalDirection) -> Window? {
+        guard isScrollingRoot else { return nil }
+        switch direction {
+            case .left:
+                let nextIndex = max(0, scrollingIndex - 1)
+                scrollingIndex = nextIndex
+                return children.getOrNil(atIndex: nextIndex)?.findLeafWindowRecursive(snappedTo: .left)
+            case .right:
+                let nextIndex = min(maxScrollingIndex, scrollingIndex + 1)
+                scrollingIndex = nextIndex
+                return children.getOrNil(atIndex: nextIndex + 1)?.findLeafWindowRecursive(snappedTo: .right)
+            case .up, .down:
+                return nil
+        }
+    }
+
+    @MainActor
+    private func scrollingPageIndex(for window: Window) -> Int? {
+        window.parentsWithSelf.first(where: { $0.parent === self })?.ownIndex
+    }
 
     @MainActor
     func changeOrientation(_ targetOrientation: Orientation) {
@@ -58,6 +112,8 @@ extension TilingContainer {
 enum Layout: String {
     case tiles
     case accordion
+    case scrolling
+    case tabs
 }
 
 extension String {

--- a/Sources/AppBundle/tree/TilingContainer.swift
+++ b/Sources/AppBundle/tree/TilingContainer.swift
@@ -113,6 +113,7 @@ enum Layout: String {
     case tiles
     case accordion
     case scrolling
+    case tabs
 }
 
 extension String {

--- a/Sources/AppBundle/tree/TilingContainer.swift
+++ b/Sources/AppBundle/tree/TilingContainer.swift
@@ -5,6 +5,11 @@ final class TilingContainer: TreeNode, NonLeafTreeNodeObject { // todo consider 
     fileprivate var _orientation: Orientation
     var orientation: Orientation { _orientation }
     var layout: Layout
+    private var _scrollingIndex: Int = 0
+    var scrollingIndex: Int {
+        get { _scrollingIndex }
+        set { _scrollingIndex = max(0, newValue) }
+    }
 
     @MainActor
     init(parent: NonLeafTreeNodeObject, adaptiveWeight: CGFloat, _ orientation: Orientation, _ layout: Layout, index: Int) {
@@ -26,6 +31,55 @@ final class TilingContainer: TreeNode, NonLeafTreeNodeObject { // todo consider 
 
 extension TilingContainer {
     var isRootContainer: Bool { parent is Workspace }
+    var isScrollingRoot: Bool { isRootContainer && layout == .scrolling }
+
+    var maxScrollingIndex: Int { max(0, children.count - 2) }
+
+    func clampScrollingIndex() {
+        scrollingIndex = isScrollingRoot ? min(scrollingIndex, maxScrollingIndex) : 0
+    }
+
+    @MainActor
+    func reveal(_ window: Window?, preferRightPane: Bool) {
+        guard isScrollingRoot else { return }
+        guard let index = window.flatMap(scrollingPageIndex(for:)) else {
+            clampScrollingIndex()
+            return
+        }
+        scrollingIndex = preferRightPane
+            ? min(max(0, index - 1), maxScrollingIndex)
+            : min(
+                max(
+                    0,
+                    index < scrollingIndex
+                        ? index
+                        : (index > scrollingIndex + 1 ? index - 1 : scrollingIndex),
+                ),
+                maxScrollingIndex,
+            )
+    }
+
+    @MainActor
+    func scroll(in direction: CardinalDirection) -> Window? {
+        guard isScrollingRoot else { return nil }
+        switch direction {
+            case .left:
+                let nextIndex = max(0, scrollingIndex - 1)
+                scrollingIndex = nextIndex
+                return children.getOrNil(atIndex: nextIndex)?.findLeafWindowRecursive(snappedTo: .left)
+            case .right:
+                let nextIndex = min(maxScrollingIndex, scrollingIndex + 1)
+                scrollingIndex = nextIndex
+                return children.getOrNil(atIndex: nextIndex + 1)?.findLeafWindowRecursive(snappedTo: .right)
+            case .up, .down:
+                return nil
+        }
+    }
+
+    @MainActor
+    private func scrollingPageIndex(for window: Window) -> Int? {
+        window.parentsWithSelf.first(where: { $0.parent === self })?.ownIndex
+    }
 
     @MainActor
     func changeOrientation(_ targetOrientation: Orientation) {
@@ -58,6 +112,7 @@ extension TilingContainer {
 enum Layout: String {
     case tiles
     case accordion
+    case scrolling
 }
 
 extension String {

--- a/Sources/AppBundle/tree/TreeNode.swift
+++ b/Sources/AppBundle/tree/TreeNode.swift
@@ -87,6 +87,7 @@ open class TreeNode: Equatable, AeroAny {
         newParent._children.insert(self, at: index != INDEX_BIND_LAST ? index : newParent._children.count)
         _parent = newParent
         unboundStacktrace = nil
+        (newParent as? TilingContainer)?.clampScrollingIndex()
         // todo consider disabling automatic mru propogation
         // 1. "floating windows" in FocusCommand break the MRU because of that :(
         // 2. Misbehaved apps that abuse real window as popups https://github.com/nikitabobko/AeroSpace/issues/106 (the
@@ -102,6 +103,7 @@ open class TreeNode: Equatable, AeroAny {
         check(_parent._mruChildren.remove(self))
         self._parent = nil
         unboundStacktrace = getStringStacktrace()
+        (_parent as? TilingContainer)?.clampScrollingIndex()
 
         return BindingData(parent: _parent, adaptiveWeight: adaptiveWeight, index: index)
     }

--- a/Sources/AppBundle/tree/TreeNode.swift
+++ b/Sources/AppBundle/tree/TreeNode.swift
@@ -88,6 +88,7 @@ open class TreeNode: Equatable, AeroAny {
         newParent._children.insert(self, at: index != INDEX_BIND_LAST ? index : newParent._children.count)
         _parent = newParent
         unboundStacktrace = nil
+        (newParent as? TilingContainer)?.clampScrollingIndex()
         // todo consider disabling automatic mru propogation
         // 1. "floating windows" in FocusCommand break the MRU because of that :(
         // 2. Misbehaved apps that abuse real window as popups https://github.com/nikitabobko/AeroSpace/issues/106 (the
@@ -103,6 +104,7 @@ open class TreeNode: Equatable, AeroAny {
         check(_parent._mruChildren.remove(self))
         self._parent = nil
         unboundStacktrace = getStringStacktrace()
+        (_parent as? TilingContainer)?.clampScrollingIndex()
 
         return BindingData(parent: _parent, adaptiveWeight: adaptiveWeight, index: index)
     }

--- a/Sources/AppBundle/tree/Window.swift
+++ b/Sources/AppBundle/tree/Window.swift
@@ -8,6 +8,7 @@ open class Window: TreeNode, Hashable {
     var isFullscreen: Bool = false
     var noOuterGapsInFullscreen: Bool = false
     var layoutReason: LayoutReason = .standard
+    var isHiddenForTabs: Bool = false
 
     @MainActor
     init(id: UInt32, _ app: any AbstractApp, lastFloatingSize: CGSize?, parent: NonLeafTreeNodeObject, adaptiveWeight: CGFloat, index: Int) {

--- a/Sources/AppBundle/tree/WorkspaceEx.swift
+++ b/Sources/AppBundle/tree/WorkspaceEx.swift
@@ -10,7 +10,8 @@ extension Workspace {
                     case .vertical: .v
                     case .auto: workspaceMonitor.then { $0.width >= $0.height } ? .h : .v
                 }
-                return TilingContainer(parent: self, adaptiveWeight: 1, orientation, config.defaultRootContainerLayout, index: INDEX_BIND_LAST)
+                let rootOrientation = config.defaultRootContainerLayout == .scrolling ? .h : orientation
+                return TilingContainer(parent: self, adaptiveWeight: 1, rootOrientation, config.defaultRootContainerLayout, index: INDEX_BIND_LAST)
             case 1:
                 return containers.singleOrNil().orDie()
             default:

--- a/Sources/AppBundle/ui/TabHeadersView.swift
+++ b/Sources/AppBundle/ui/TabHeadersView.swift
@@ -1,0 +1,157 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class TabHeadersPanel: NSPanelHud {
+    private var hostingView = NSHostingView(rootView: AnyView(EmptyView()))
+    private weak var hostingContainerView: NSView?
+
+    override init() {
+        super.init()
+        self.ignoresMouseEvents = false
+        self.hasShadow = false
+        self.backgroundColor = .clear
+        self.isOpaque = false
+        self.contentView = NSView(frame: .zero)
+    }
+
+    func update(snapshot: TabHeaderSnapshot) {
+        let rootView = AnyView(TabHeaderStripView(snapshot: snapshot))
+        if contentView == nil {
+            contentView = NSView(frame: .zero)
+        }
+        guard let contentView else { return }
+        if hostingContainerView !== contentView {
+            hostingView.removeFromSuperview()
+            hostingView = NSHostingView(rootView: rootView)
+            contentView.addSubview(hostingView)
+            hostingContainerView = contentView
+        } else {
+            hostingView.rootView = rootView
+        }
+        hostingView.frame = NSRect(origin: .zero, size: snapshot.headerFrame.size)
+        setFrame(snapshot.headerFrame.nsRect, display: true)
+        orderFrontRegardless()
+    }
+}
+
+@MainActor
+final class TabHeadersPanelController {
+    static let shared = TabHeadersPanelController()
+
+    private var panels: [ObjectIdentifier: TabHeadersPanel] = [:]
+
+    private init() {}
+
+    func refresh(with snapshots: [TabHeaderSnapshot]) {
+        let nextIds = Set(snapshots.map(\.id))
+        for (id, panel) in panels where !nextIds.contains(id) {
+            panel.close()
+            panels.removeValue(forKey: id)
+        }
+        for snapshot in snapshots {
+            let panel: TabHeadersPanel
+            if let existing = panels[snapshot.id] {
+                panel = existing
+            } else {
+                panel = TabHeadersPanel()
+                panels[snapshot.id] = panel
+            }
+            panel.update(snapshot: snapshot)
+        }
+    }
+
+    func closeAll() {
+        for (_, panel) in panels {
+            panel.close()
+        }
+        panels = [:]
+    }
+}
+
+private struct TabHeaderStripView: View {
+    let snapshot: TabHeaderSnapshot
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            RoundedRectangle(cornerRadius: TabHeaderMetrics.cornerRadius, style: .continuous)
+                .fill(Color.black.opacity(0.75))
+            ForEach(snapshot.items) { item in
+                ZStack(alignment: .topLeading) {
+                    RoundedRectangle(cornerRadius: TabHeaderMetrics.cornerRadius, style: .continuous)
+                        .fill(item.isActive ? Color.white.opacity(0.18) : Color.white.opacity(0.08))
+
+                    Text(item.title)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .font(.system(size: 12, weight: item.isActive ? .semibold : .regular))
+                        .foregroundStyle(item.isActive ? Color.white : Color.white.opacity(0.85))
+                        .padding(.leading, TabHeaderMetrics.titleHorizontalInset)
+                        .padding(.trailing, TabHeaderMetrics.titleHorizontalInset)
+                        .frame(
+                            width: item.titleFrame.width,
+                            height: item.titleFrame.height,
+                            alignment: .leading,
+                        )
+                        .offset(
+                            x: item.titleFrame.topLeftX - item.frame.topLeftX,
+                            y: item.titleFrame.topLeftY - item.frame.topLeftY,
+                        )
+
+                    Button {
+                        activate(item.targetWindow)
+                    } label: {
+                        Rectangle()
+                            .fill(Color.white.opacity(0.001))
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .frame(width: item.frame.width, height: item.frame.height)
+
+                    Button {
+                        close(item.targetWindow)
+                    } label: {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 9, weight: .semibold))
+                            .foregroundStyle(item.isActive ? Color.white.opacity(0.92) : Color.white.opacity(0.75))
+                            .frame(width: item.closeButtonFrame.width, height: item.closeButtonFrame.height)
+                            .background(
+                                Circle()
+                                    .fill(item.isActive ? Color.white.opacity(0.12) : Color.clear),
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .offset(
+                        x: item.closeButtonFrame.topLeftX - item.frame.topLeftX,
+                        y: item.closeButtonFrame.topLeftY - item.frame.topLeftY,
+                    )
+                }
+                .frame(width: item.frame.width, height: item.frame.height, alignment: .topLeading)
+                .offset(x: item.frame.topLeftX, y: item.frame.topLeftY)
+            }
+        }
+        .frame(width: snapshot.headerFrame.width, height: snapshot.headerFrame.height, alignment: .topLeading)
+    }
+
+    private func activate(_ window: Window) {
+        Task { @MainActor in
+            guard let token: RunSessionGuard = .isServerEnabled else { return }
+            TabHeaderInteractionState.shared.markInteraction()
+            try await runLightSession(.menuBarButton, token) {
+                guard focus.windowOrNil != window else { return }
+                guard window.focusWindow() else { return }
+                window.nativeFocus()
+            }
+        }
+    }
+
+    private func close(_ window: Window) {
+        Task { @MainActor in
+            guard let token: RunSessionGuard = .isServerEnabled else { return }
+            TabHeaderInteractionState.shared.markInteraction()
+            try await runLightSession(.menuBarButton, token) {
+                window.closeAxWindow()
+            }
+        }
+    }
+}

--- a/Sources/AppBundle/ui/TabHeadersView.swift
+++ b/Sources/AppBundle/ui/TabHeadersView.swift
@@ -1,0 +1,157 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class TabHeadersPanel: NSPanelHud {
+    private var hostingView = NSHostingView(rootView: AnyView(EmptyView()))
+    private weak var hostingContainerView: NSView?
+
+    override init() {
+        super.init()
+        self.ignoresMouseEvents = false
+        self.hasShadow = false
+        self.backgroundColor = .clear
+        self.isOpaque = false
+        self.contentView = NSView(frame: .zero)
+    }
+
+    func update(snapshot: TabHeaderSnapshot) {
+        let rootView = AnyView(TabHeaderStripView(snapshot: snapshot))
+        if contentView == nil {
+            contentView = NSView(frame: .zero)
+        }
+        guard let contentView else { return }
+        if hostingContainerView !== contentView {
+            hostingView.removeFromSuperview()
+            hostingView = NSHostingView(rootView: rootView)
+            contentView.addSubview(hostingView)
+            hostingContainerView = contentView
+        } else {
+            hostingView.rootView = rootView
+        }
+        hostingView.frame = NSRect(origin: .zero, size: snapshot.headerFrame.size)
+        setFrame(snapshot.headerFrame.nsRect, display: true)
+        orderFrontRegardless()
+    }
+}
+
+@MainActor
+final class TabHeadersPanelController {
+    static let shared = TabHeadersPanelController()
+
+    private var panels: [ObjectIdentifier: TabHeadersPanel] = [:]
+
+    private init() {}
+
+    func refresh(with snapshots: [TabHeaderSnapshot]) {
+        let nextIds = Set(snapshots.map(\.id))
+        for (id, panel) in panels where !nextIds.contains(id) {
+            panel.close()
+            panels.removeValue(forKey: id)
+        }
+        for snapshot in snapshots {
+            let panel: TabHeadersPanel
+            if let existing = panels[snapshot.id] {
+                panel = existing
+            } else {
+                panel = TabHeadersPanel()
+                panels[snapshot.id] = panel
+            }
+            panel.update(snapshot: snapshot)
+        }
+    }
+
+    func closeAll() {
+        for (_, panel) in panels {
+            panel.close()
+        }
+        panels = [:]
+    }
+}
+
+private struct TabHeaderStripView: View {
+    let snapshot: TabHeaderSnapshot
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            RoundedRectangle(cornerRadius: TabHeaderMetrics.cornerRadius, style: .continuous)
+                .fill(Color.black.opacity(0.75))
+            ForEach(snapshot.items) { item in
+                ZStack(alignment: .topLeading) {
+                    RoundedRectangle(cornerRadius: TabHeaderMetrics.cornerRadius, style: .continuous)
+                        .fill(item.isActive ? Color.white.opacity(0.18) : Color.white.opacity(0.08))
+
+                    Text(item.title)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .font(.system(size: 12, weight: item.isActive ? .semibold : .regular))
+                        .foregroundStyle(item.isActive ? Color.white : Color.white.opacity(0.85))
+                        .padding(.leading, TabHeaderMetrics.titleHorizontalInset)
+                        .padding(.trailing, TabHeaderMetrics.titleHorizontalInset)
+                        .frame(
+                            width: item.titleFrame.width,
+                            height: item.titleFrame.height,
+                            alignment: .leading,
+                        )
+                        .offset(
+                            x: item.titleFrame.topLeftX - item.frame.topLeftX,
+                            y: item.titleFrame.topLeftY - item.frame.topLeftY,
+                        )
+
+                    Button {
+                        activate(item.targetWindow)
+                    } label: {
+                        Rectangle()
+                            .fill(Color.white.opacity(0.001))
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .frame(width: item.frame.width, height: item.frame.height)
+
+                    Button {
+                        close(item.targetWindow)
+                    } label: {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 9, weight: .semibold))
+                            .foregroundStyle(item.isActive ? Color.white.opacity(0.92) : Color.white.opacity(0.75))
+                            .frame(width: item.closeButtonFrame.width, height: item.closeButtonFrame.height)
+                            .background(
+                                Circle()
+                                    .fill(item.isActive ? Color.white.opacity(0.12) : Color.clear),
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .offset(
+                        x: item.closeButtonFrame.topLeftX - item.frame.topLeftX,
+                        y: item.closeButtonFrame.topLeftY - item.frame.topLeftY,
+                    )
+                }
+                .frame(width: item.frame.width, height: item.frame.height, alignment: .topLeading)
+                .offset(x: item.frame.topLeftX, y: item.frame.topLeftY)
+            }
+        }
+        .frame(width: snapshot.headerFrame.width, height: snapshot.headerFrame.height, alignment: .topLeading)
+    }
+
+    private func activate(_ window: Window) {
+        Task.startUnstructured { @MainActor in
+            guard let token: RunSessionGuard = .isServerEnabled else { return }
+            TabHeaderInteractionState.shared.markInteraction()
+            try await runLightSession(.menuBarButton, token) {
+                guard focus.windowOrNil != window else { return }
+                guard window.focusWindow() else { return }
+                window.nativeFocus()
+            }
+        }
+    }
+
+    private func close(_ window: Window) {
+        Task.startUnstructured { @MainActor in
+            guard let token: RunSessionGuard = .isServerEnabled else { return }
+            TabHeaderInteractionState.shared.markInteraction()
+            try await runLightSession(.menuBarButton, token) {
+                window.closeAxWindow()
+            }
+        }
+    }
+}

--- a/Sources/AppBundleTests/command/MoveCommandTest.swift
+++ b/Sources/AppBundleTests/command/MoveCommandTest.swift
@@ -125,6 +125,26 @@ final class MoveCommandTest: XCTestCase {
         assertEquals(result.exitCode.rawValue, 0)
     }
 
+    func testCreateImplicitContainerFailsInScrollingLayout() async throws {
+        let workspace = Workspace.get(byName: name)
+        workspace.rootTilingContainer.apply {
+            assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)
+            TestWindow.new(id: 2, parent: $0)
+        }
+        workspace.rootTilingContainer.layout = .scrolling
+
+        let result = try await parseCommand("move --boundaries-action create-implicit-container up").cmdOrDie
+            .run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode, 1)
+        assertEquals(result.stderr, ["move --boundaries-action create-implicit-container doesn't support the scrolling layout"])
+        assertEquals(
+            workspace.layoutDescription,
+            .workspace([
+                .scrolling([.window(1), .window(2)]),
+            ]),
+        )
+    }
+
     func testStop_onRootNode() async throws {
         let workspace = Workspace.get(byName: name)
         workspace.rootTilingContainer.apply {
@@ -299,6 +319,8 @@ extension TreeNode {
                         container.orientation == .h
                             ? .h_accordion(container.children.map(\.layoutDescription))
                             : .v_accordion(container.children.map(\.layoutDescription))
+                    case .scrolling:
+                        .scrolling(container.children.map(\.layoutDescription))
                 }
         }
     }
@@ -310,6 +332,7 @@ enum LayoutDescription: Equatable {
     case v_tiles([LayoutDescription])
     case h_accordion([LayoutDescription])
     case v_accordion([LayoutDescription])
+    case scrolling([LayoutDescription])
     case window(UInt32)
     case macosPopupWindowsContainer
     case macosMinimized

--- a/Sources/AppBundleTests/command/MoveCommandTest.swift
+++ b/Sources/AppBundleTests/command/MoveCommandTest.swift
@@ -135,7 +135,7 @@ final class MoveCommandTest: XCTestCase {
 
         let result = try await parseCommand("move --boundaries-action create-implicit-container up").cmdOrDie
             .run(.defaultEnv, .emptyStdin)
-        assertEquals(result.exitCode, 1)
+        assertEquals(result.exitCode.rawValue, 2)
         assertEquals(result.stderr, ["move --boundaries-action create-implicit-container doesn't support the scrolling layout"])
         assertEquals(
             workspace.layoutDescription,
@@ -321,6 +321,8 @@ extension TreeNode {
                             : .v_accordion(container.children.map(\.layoutDescription))
                     case .scrolling:
                         .scrolling(container.children.map(\.layoutDescription))
+                    case .tabs:
+                        .tabs(container.children.map(\.layoutDescription))
                 }
         }
     }
@@ -333,6 +335,7 @@ enum LayoutDescription: Equatable {
     case h_accordion([LayoutDescription])
     case v_accordion([LayoutDescription])
     case scrolling([LayoutDescription])
+    case tabs([LayoutDescription])
     case window(UInt32)
     case macosPopupWindowsContainer
     case macosMinimized

--- a/Sources/AppBundleTests/command/MoveCommandTest.swift
+++ b/Sources/AppBundleTests/command/MoveCommandTest.swift
@@ -167,6 +167,26 @@ final class MoveCommandTest: XCTestCase {
         assertEquals(result.exitCode.rawValue, 0)
     }
 
+    func testCreateImplicitContainerFailsInScrollingLayout() async {
+        let workspace = Workspace.get(byName: name)
+        workspace.rootTilingContainer.apply {
+            assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)
+            TestWindow.new(id: 2, parent: $0)
+        }
+        workspace.rootTilingContainer.layout = .scrolling
+
+        let result = await parseCommand("move --boundaries-action create-implicit-container up").cmdOrDie
+            .run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode.rawValue, 2)
+        assertEquals(result.stderr, ["move --boundaries-action create-implicit-container doesn't support the scrolling layout"])
+        assertEquals(
+            workspace.layoutDescription,
+            .workspace([
+                .scrolling([.window(1), .window(2)]),
+            ]),
+        )
+    }
+
     func testStop_onRootNode() async {
         let workspace = Workspace.get(byName: name)
         workspace.rootTilingContainer.apply {
@@ -342,6 +362,10 @@ extension TreeNode {
                         container.orientation == .h
                             ? .h_accordion(container.children.map(\.layoutDescription))
                             : .v_accordion(container.children.map(\.layoutDescription))
+                    case .scrolling:
+                        .scrolling(container.children.map(\.layoutDescription))
+                    case .tabs:
+                        .tabs(container.children.map(\.layoutDescription))
                 }
         }
     }
@@ -354,6 +378,8 @@ enum LayoutDescription: Equatable {
     case h_accordion([LayoutDescription])
     case v_accordion([LayoutDescription])
     case floatingWindowsContainer([LayoutDescription])
+    case scrolling([LayoutDescription])
+    case tabs([LayoutDescription])
     case window(UInt32)
     case macosPopupWindowsContainer
     case macosMinimized

--- a/Sources/AppBundleTests/command/ScrollCommandTest.swift
+++ b/Sources/AppBundleTests/command/ScrollCommandTest.swift
@@ -19,7 +19,7 @@ final class ScrollCommandTest: XCTestCase {
         }
 
         let result = try await parseCommand("layout scrolling").cmdOrDie.run(.defaultEnv, .emptyStdin)
-        assertEquals(result.exitCode, 0)
+        assertEquals(result.exitCode.rawValue, 0)
         assertEquals(root.layout, .scrolling)
         assertEquals(root.orientation, .h)
         assertEquals(root.scrollingIndex, 0)
@@ -34,7 +34,7 @@ final class ScrollCommandTest: XCTestCase {
         }
 
         let result = try await parseCommand("layout scrolling").cmdOrDie.run(.defaultEnv, .emptyStdin)
-        assertEquals(result.exitCode, 1)
+        assertEquals(result.exitCode.rawValue, 2)
         assertEquals(result.stderr, ["The 'scrolling' layout is only supported for workspace root containers"])
     }
 
@@ -48,7 +48,7 @@ final class ScrollCommandTest: XCTestCase {
         root.layout = .scrolling
         root.scrollingIndex = 1
 
-        try await workspace.layoutWorkspace()
+        _ = try await workspace.layoutWorkspace()
 
         let workspaceRect = workspace.workspaceMonitor.visibleRectPaddedByOuterGaps
         let pageWidth = workspaceRect.width / 2
@@ -80,7 +80,7 @@ final class ScrollCommandTest: XCTestCase {
         assertEquals(root.scrollingIndex, 0)
 
         let scrollRight = try await parseCommand("scroll right").cmdOrDie.run(.defaultEnv, .emptyStdin)
-        assertEquals(scrollRight.exitCode, 0)
+        assertEquals(scrollRight.exitCode.rawValue, 0)
         assertEquals(root.scrollingIndex, 1)
         assertEquals(focus.windowOrNil?.windowId, 3)
 
@@ -109,7 +109,7 @@ final class ScrollCommandTest: XCTestCase {
         assertEquals(root.scrollingIndex, 1)
 
         let result = try await parseCommand("move right").cmdOrDie.run(.defaultEnv, .emptyStdin)
-        assertEquals(result.exitCode, 0)
+        assertEquals(result.exitCode.rawValue, 0)
         assertEquals(root.layoutDescription, .scrolling([.window(1), .window(2), .window(4), .window(3)]))
         assertEquals(root.scrollingIndex, 2)
         assertEquals(focus.windowOrNil?.windowId, 3)
@@ -154,11 +154,11 @@ final class ScrollCommandTest: XCTestCase {
         root.layout = .scrolling
 
         let resizeResult = try await parseCommand("resize smart +10").cmdOrDie.run(.defaultEnv, .emptyStdin)
-        assertEquals(resizeResult.exitCode, 1)
+        assertEquals(resizeResult.exitCode.rawValue, 2)
         assertEquals(resizeResult.stderr, ["resize command doesn't support the scrolling layout"])
 
         let balanceResult = try await parseCommand("balance-sizes").cmdOrDie.run(.defaultEnv, .emptyStdin)
-        assertEquals(balanceResult.exitCode, 1)
+        assertEquals(balanceResult.exitCode.rawValue, 2)
         assertEquals(balanceResult.stderr, ["balance-sizes command doesn't support the scrolling layout"])
     }
 
@@ -170,7 +170,7 @@ final class ScrollCommandTest: XCTestCase {
         }
         root.layout = .scrolling
 
-        let windows = root.allLeafWindowsRecursive.map { AeroObj.window(window: $0, title: "w\($0.windowId)") }
-        assertEquals(windows.format([.interVar("window-layout")]), .success(["scrolling", "scrolling"]))
+        let windows = root.allLeafWindowsRecursive.map { AeroObj.window(.forTest(window: $0, title: "w\($0.windowId)")) }
+        assertSucc(windows.format([.interVar("window-layout")]), ["scrolling", "scrolling"])
     }
 }

--- a/Sources/AppBundleTests/command/ScrollCommandTest.swift
+++ b/Sources/AppBundleTests/command/ScrollCommandTest.swift
@@ -1,0 +1,176 @@
+@testable import AppBundle
+import Common
+import XCTest
+
+@MainActor
+final class ScrollCommandTest: XCTestCase {
+    override func setUp() async throws { setUpWorkspacesForTests() }
+
+    func testParse() {
+        testParseCommandSucc("scroll left", ScrollCmdArgs(rawArgs: [], direction: .left))
+        testParseCommandSucc("scroll right", ScrollCmdArgs(rawArgs: [], direction: .right))
+        testParseCommandSucc("layout scrolling", LayoutCmdArgs(rawArgs: [], toggleBetween: [.scrolling]))
+    }
+
+    func testSwitchRootToScrolling() async throws {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            assertEquals(TestWindow.new(id: 2, parent: $0).focusWindow(), true)
+        }
+
+        let result = try await parseCommand("layout scrolling").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode, 0)
+        assertEquals(root.layout, .scrolling)
+        assertEquals(root.orientation, .h)
+        assertEquals(root.scrollingIndex, 0)
+    }
+
+    func testRejectNestedScrolling() async throws {
+        let workspace = Workspace.get(byName: name)
+        workspace.rootTilingContainer.apply {
+            TilingContainer.newVTiles(parent: $0, adaptiveWeight: 1).apply {
+                assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)
+            }
+        }
+
+        let result = try await parseCommand("layout scrolling").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode, 1)
+        assertEquals(result.stderr, ["The 'scrolling' layout is only supported for workspace root containers"])
+    }
+
+    func testScrollingLayoutGeometry() async throws {
+        let workspace = Workspace.get(byName: name)
+        let root = workspace.rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            TestWindow.new(id: 2, parent: $0)
+            TestWindow.new(id: 3, parent: $0)
+        }
+        root.layout = .scrolling
+        root.scrollingIndex = 1
+
+        try await workspace.layoutWorkspace()
+
+        let workspaceRect = workspace.workspaceMonitor.visibleRectPaddedByOuterGaps
+        let pageWidth = workspaceRect.width / 2
+        let expectedHeight = workspaceRect.height - 1
+        let windows = root.children.compactMap { $0 as? TestWindow }
+
+        let rect1 = windows[0].lastAppliedLayoutPhysicalRect.orDie("window 1 should be laid out")
+        let rect2 = windows[1].lastAppliedLayoutPhysicalRect.orDie("window 2 should be laid out")
+        let rect3 = windows[2].lastAppliedLayoutPhysicalRect.orDie("window 3 should be laid out")
+
+        assertEquals(rect1.topLeftX, workspaceRect.topLeftX - pageWidth)
+        assertEquals(rect1.width, pageWidth)
+        assertEquals(rect2.topLeftX, workspaceRect.topLeftX)
+        assertEquals(rect2.width, pageWidth)
+        assertEquals(rect3.topLeftX, workspaceRect.topLeftX + pageWidth)
+        assertEquals(rect3.width, pageWidth)
+        assertEquals(rect3.height, expectedHeight)
+    }
+
+    func testScrollCommandsMoveViewportAndFocus() async throws {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            TestWindow.new(id: 2, parent: $0)
+            TestWindow.new(id: 3, parent: $0)
+            TestWindow.new(id: 4, parent: $0)
+        }
+        root.layout = .scrolling
+        assertEquals((root.children[1] as! Window).focusWindow(), true)
+        assertEquals(root.scrollingIndex, 0)
+
+        let scrollRight = try await parseCommand("scroll right").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(scrollRight.exitCode, 0)
+        assertEquals(root.scrollingIndex, 1)
+        assertEquals(focus.windowOrNil?.windowId, 3)
+
+        try await parseCommand("scroll right").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(root.scrollingIndex, 2)
+        assertEquals(focus.windowOrNil?.windowId, 4)
+
+        try await parseCommand("scroll right").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(root.scrollingIndex, 2)
+        assertEquals(focus.windowOrNil?.windowId, 4)
+
+        try await parseCommand("scroll left").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(root.scrollingIndex, 1)
+        assertEquals(focus.windowOrNil?.windowId, 2)
+    }
+
+    func testMoveCommandKeepsFocusedWindowVisible() async throws {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            TestWindow.new(id: 2, parent: $0)
+            TestWindow.new(id: 3, parent: $0)
+            TestWindow.new(id: 4, parent: $0)
+        }
+        root.layout = .scrolling
+        assertEquals((root.children[2] as! Window).focusWindow(), true)
+        assertEquals(root.scrollingIndex, 1)
+
+        let result = try await parseCommand("move right").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode, 0)
+        assertEquals(root.layoutDescription, .scrolling([.window(1), .window(2), .window(4), .window(3)]))
+        assertEquals(root.scrollingIndex, 2)
+        assertEquals(focus.windowOrNil?.windowId, 3)
+    }
+
+    func testFocusedWindowAutoRevealsNewestPage() {
+        let root = Workspace.get(byName: name).rootTilingContainer
+        root.layout = .scrolling
+
+        assertEquals(TestWindow.new(id: 1, parent: root).focusWindow(), true)
+        assertEquals(root.scrollingIndex, 0)
+
+        assertEquals(TestWindow.new(id: 2, parent: root).focusWindow(), true)
+        assertEquals(root.scrollingIndex, 0)
+
+        assertEquals(TestWindow.new(id: 3, parent: root).focusWindow(), true)
+        assertEquals(root.scrollingIndex, 1)
+
+        assertEquals(TestWindow.new(id: 4, parent: root).focusWindow(), true)
+        assertEquals(root.scrollingIndex, 2)
+    }
+
+    func testClosingClampsScrollingIndex() {
+        let root = Workspace.get(byName: name).rootTilingContainer
+        root.layout = .scrolling
+        let w1 = TestWindow.new(id: 1, parent: root)
+        let w2 = TestWindow.new(id: 2, parent: root)
+        let w3 = TestWindow.new(id: 3, parent: root)
+        let w4 = TestWindow.new(id: 4, parent: root)
+        _ = [w1, w2, w3]
+        root.scrollingIndex = 2
+
+        w4.closeAxWindow()
+        assertEquals(root.scrollingIndex, 1)
+    }
+
+    func testResizeAndBalanceSizesFailInScrollingLayout() async throws {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)
+            TestWindow.new(id: 2, parent: $0)
+        }
+        root.layout = .scrolling
+
+        let resizeResult = try await parseCommand("resize smart +10").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(resizeResult.exitCode, 1)
+        assertEquals(resizeResult.stderr, ["resize command doesn't support the scrolling layout"])
+
+        let balanceResult = try await parseCommand("balance-sizes").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(balanceResult.exitCode, 1)
+        assertEquals(balanceResult.stderr, ["balance-sizes command doesn't support the scrolling layout"])
+    }
+
+    func testWindowLayoutFormattingReportsScrolling() {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            let nested = TilingContainer.newVTiles(parent: $0, adaptiveWeight: 1)
+            TestWindow.new(id: 1, parent: nested)
+            TestWindow.new(id: 2, parent: $0)
+        }
+        root.layout = .scrolling
+
+        let windows = root.allLeafWindowsRecursive.map { AeroObj.window(window: $0, title: "w\($0.windowId)") }
+        assertEquals(windows.format([.interVar("window-layout")]), .success(["scrolling", "scrolling"]))
+    }
+}

--- a/Sources/AppBundleTests/command/ScrollCommandTest.swift
+++ b/Sources/AppBundleTests/command/ScrollCommandTest.swift
@@ -1,0 +1,180 @@
+@testable import AppBundle
+import Common
+import XCTest
+
+@MainActor
+final class ScrollCommandTest: XCTestCase {
+    override func setUp() async throws { setUpWorkspacesForTests() }
+
+    func testParse() {
+        testParseSingleCommandSucc("scroll left", ScrollCmdArgs(rawArgs: [], direction: .left))
+        testParseSingleCommandSucc("scroll right", ScrollCmdArgs(rawArgs: [], direction: .right))
+        testParseSingleCommandSucc("layout scrolling", LayoutCmdArgs(rawArgs: [], toggleBetween: [.scrolling]))
+    }
+
+    func testSwitchRootToScrolling() async {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            assertEquals(TestWindow.new(id: 2, parent: $0).focusWindow(), true)
+        }
+
+        let result = await parseCommand("layout scrolling").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode.rawValue, 0)
+        assertEquals(root.layout, .scrolling)
+        assertEquals(root.orientation, .h)
+        assertEquals(root.scrollingIndex, 0)
+    }
+
+    func testRejectNestedScrolling() async {
+        let workspace = Workspace.get(byName: name)
+        workspace.rootTilingContainer.apply {
+            TilingContainer.newVTiles(parent: $0, adaptiveWeight: 1).apply {
+                assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)
+            }
+        }
+
+        let result = await parseCommand("layout scrolling").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode.rawValue, 2)
+        assertEquals(result.stderr, ["The 'scrolling' layout is only supported for workspace root containers"])
+    }
+
+    func testScrollingLayoutGeometry() async throws {
+        let workspace = Workspace.get(byName: name)
+        let root = workspace.rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            TestWindow.new(id: 2, parent: $0)
+            TestWindow.new(id: 3, parent: $0)
+        }
+        root.layout = .scrolling
+        root.scrollingIndex = 1
+
+        _ = try await workspace.layoutWorkspace()
+
+        let workspaceRect = workspace.workspaceMonitor.visibleRectPaddedByOuterGaps
+        let pageWidth = workspaceRect.width / 2
+        let expectedHeight = workspaceRect.height - 1
+        let windows = root.children.compactMap { $0 as? TestWindow }
+
+        // Off-screen pages must be hidden, otherwise their negative/overflow
+        // physicalX bleeds onto adjacent monitors.
+        XCTAssertNil(windows[0].lastAppliedLayoutPhysicalRect)
+        assertEquals(windows[0].isHiddenForTabs, true)
+
+        let rect2 = windows[1].lastAppliedLayoutPhysicalRect.orDie("window 2 should be laid out")
+        let rect3 = windows[2].lastAppliedLayoutPhysicalRect.orDie("window 3 should be laid out")
+
+        assertEquals(rect2.topLeftX, workspaceRect.topLeftX)
+        assertEquals(rect2.width, pageWidth)
+        assertEquals(windows[1].isHiddenForTabs, false)
+        assertEquals(rect3.topLeftX, workspaceRect.topLeftX + pageWidth)
+        assertEquals(rect3.width, pageWidth)
+        assertEquals(rect3.height, expectedHeight)
+        assertEquals(windows[2].isHiddenForTabs, false)
+    }
+
+    func testScrollCommandsMoveViewportAndFocus() async {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            TestWindow.new(id: 2, parent: $0)
+            TestWindow.new(id: 3, parent: $0)
+            TestWindow.new(id: 4, parent: $0)
+        }
+        root.layout = .scrolling
+        assertEquals((root.children[1] as! Window).focusWindow(), true)
+        assertEquals(root.scrollingIndex, 0)
+
+        let scrollRight = await parseCommand("scroll right").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(scrollRight.exitCode.rawValue, 0)
+        assertEquals(root.scrollingIndex, 1)
+        assertEquals(focus.windowOrNil?.windowId, 3)
+
+        await parseCommand("scroll right").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(root.scrollingIndex, 2)
+        assertEquals(focus.windowOrNil?.windowId, 4)
+
+        await parseCommand("scroll right").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(root.scrollingIndex, 2)
+        assertEquals(focus.windowOrNil?.windowId, 4)
+
+        await parseCommand("scroll left").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(root.scrollingIndex, 1)
+        assertEquals(focus.windowOrNil?.windowId, 2)
+    }
+
+    func testMoveCommandKeepsFocusedWindowVisible() async {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            TestWindow.new(id: 2, parent: $0)
+            TestWindow.new(id: 3, parent: $0)
+            TestWindow.new(id: 4, parent: $0)
+        }
+        root.layout = .scrolling
+        assertEquals((root.children[2] as! Window).focusWindow(), true)
+        assertEquals(root.scrollingIndex, 1)
+
+        let result = await parseCommand("move right").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode.rawValue, 0)
+        assertEquals(root.layoutDescription, .scrolling([.window(1), .window(2), .window(4), .window(3)]))
+        assertEquals(root.scrollingIndex, 2)
+        assertEquals(focus.windowOrNil?.windowId, 3)
+    }
+
+    func testFocusedWindowAutoRevealsNewestPage() {
+        let root = Workspace.get(byName: name).rootTilingContainer
+        root.layout = .scrolling
+
+        assertEquals(TestWindow.new(id: 1, parent: root).focusWindow(), true)
+        assertEquals(root.scrollingIndex, 0)
+
+        assertEquals(TestWindow.new(id: 2, parent: root).focusWindow(), true)
+        assertEquals(root.scrollingIndex, 0)
+
+        assertEquals(TestWindow.new(id: 3, parent: root).focusWindow(), true)
+        assertEquals(root.scrollingIndex, 1)
+
+        assertEquals(TestWindow.new(id: 4, parent: root).focusWindow(), true)
+        assertEquals(root.scrollingIndex, 2)
+    }
+
+    func testClosingClampsScrollingIndex() {
+        let root = Workspace.get(byName: name).rootTilingContainer
+        root.layout = .scrolling
+        let w1 = TestWindow.new(id: 1, parent: root)
+        let w2 = TestWindow.new(id: 2, parent: root)
+        let w3 = TestWindow.new(id: 3, parent: root)
+        let w4 = TestWindow.new(id: 4, parent: root)
+        _ = [w1, w2, w3]
+        root.scrollingIndex = 2
+
+        w4.closeAxWindow()
+        assertEquals(root.scrollingIndex, 1)
+    }
+
+    func testResizeAndBalanceSizesFailInScrollingLayout() async {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)
+            TestWindow.new(id: 2, parent: $0)
+        }
+        root.layout = .scrolling
+
+        let resizeResult = await parseCommand("resize smart +10").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(resizeResult.exitCode.rawValue, 2)
+        assertEquals(resizeResult.stderr, ["resize command doesn't support the scrolling layout"])
+
+        let balanceResult = await parseCommand("balance-sizes").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(balanceResult.exitCode.rawValue, 2)
+        assertEquals(balanceResult.stderr, ["balance-sizes command doesn't support the scrolling layout"])
+    }
+
+    func testWindowLayoutFormattingReportsScrolling() {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            let nested = TilingContainer.newVTiles(parent: $0, adaptiveWeight: 1)
+            TestWindow.new(id: 1, parent: nested)
+            TestWindow.new(id: 2, parent: $0)
+        }
+        root.layout = .scrolling
+
+        let windows = root.allLeafWindowsRecursive.map { AeroObj.window(.forTest(window: $0, title: "w\($0.windowId)")) }
+        assertSucc(windows.format([.interVar(.formatVar(.window(.windowLayout)))]), ["scrolling", "scrolling"])
+    }
+}

--- a/Sources/AppBundleTests/command/SplitCommandTest.swift
+++ b/Sources/AppBundleTests/command/SplitCommandTest.swift
@@ -69,4 +69,17 @@ final class SplitCommandTest: XCTestCase {
             .window(2),
         ]))
     }
+
+    func testSplitVerticalFailsInScrollingLayout() async throws {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)
+        }
+        root.layout = .scrolling
+
+        let result = try await SplitCommand(args: SplitCmdArgs(rawArgs: [], .vertical)).run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode, 1)
+        assertEquals(result.stderr, ["The scrolling layout is always horizontal"])
+        assertEquals(root.layoutDescription, .scrolling([.window(1)]))
+        assertEquals(root.orientation, .h)
+    }
 }

--- a/Sources/AppBundleTests/command/SplitCommandTest.swift
+++ b/Sources/AppBundleTests/command/SplitCommandTest.swift
@@ -77,7 +77,7 @@ final class SplitCommandTest: XCTestCase {
         root.layout = .scrolling
 
         let result = try await SplitCommand(args: SplitCmdArgs(rawArgs: [], .vertical)).run(.defaultEnv, .emptyStdin)
-        assertEquals(result.exitCode, 1)
+        assertEquals(result.exitCode.rawValue, 2)
         assertEquals(result.stderr, ["The scrolling layout is always horizontal"])
         assertEquals(root.layoutDescription, .scrolling([.window(1)]))
         assertEquals(root.orientation, .h)

--- a/Sources/AppBundleTests/command/SplitCommandTest.swift
+++ b/Sources/AppBundleTests/command/SplitCommandTest.swift
@@ -69,4 +69,17 @@ final class SplitCommandTest: XCTestCase {
             .window(2),
         ]))
     }
+
+    func testSplitVerticalFailsInScrollingLayout() async {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)
+        }
+        root.layout = .scrolling
+
+        let result = await parseCommand("split vertical").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode.rawValue, 2)
+        assertEquals(result.stderr, ["The scrolling layout is always horizontal"])
+        assertEquals(root.layoutDescription, .scrolling([.window(1)]))
+        assertEquals(root.orientation, .h)
+    }
 }

--- a/Sources/AppBundleTests/command/TabsLayoutCommandTest.swift
+++ b/Sources/AppBundleTests/command/TabsLayoutCommandTest.swift
@@ -1,0 +1,244 @@
+@testable import AppBundle
+import Common
+import XCTest
+
+@MainActor
+final class TabsLayoutCommandTest: XCTestCase {
+    override func setUp() async throws {
+        setUpWorkspacesForTests()
+        TabHeaderTitleCache.shared.invalidateAll()
+    }
+
+    func testParse() {
+        testParseCommandSucc("layout tabs", LayoutCmdArgs(rawArgs: [], toggleBetween: [.tabs]))
+    }
+
+    func testSwitchContainerToTabs() async throws {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            assertEquals(TestWindow.new(id: 2, parent: $0).focusWindow(), true)
+        }
+
+        let result = try await parseCommand("layout tabs").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode.rawValue, 0)
+        assertEquals(root.layout, .tabs)
+        assertEquals(root.layoutDescription, .tabs([.window(1), .window(2)]))
+    }
+
+    func testTabsLayoutGeometryKeepsOnlyMostRecentChildVisible() async throws {
+        let workspace = Workspace.get(byName: name)
+        let root = workspace.rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            assertEquals(TestWindow.new(id: 2, parent: $0).focusWindow(), true)
+            TestWindow.new(id: 3, parent: $0)
+        }
+        assertEquals((root.children[1] as! TestWindow).focusWindow(), true)
+        root.layout = .tabs
+
+        _ = try await workspace.layoutWorkspace()
+
+        let workspaceRect = workspace.workspaceMonitor.visibleRectPaddedByOuterGaps
+        let activeRect = (root.mostRecentChild as! TestWindow).lastAppliedLayoutPhysicalRect.orDie()
+        let expectedHeaderHeight = TabHeaderMetrics.height
+
+        assertEquals(activeRect.topLeftCorner, workspaceRect.topLeftCorner + CGPoint(x: 0, y: expectedHeaderHeight))
+        assertEquals(activeRect.width, workspaceRect.width)
+        assertEquals(activeRect.height, workspaceRect.height - 1 - expectedHeaderHeight)
+        assertNil((root.children[0] as! TestWindow).lastAppliedLayoutPhysicalRect)
+    }
+
+    func testTabsLayoutSkipsRedundantFrameUpdates() async throws {
+        let workspace = Workspace.get(byName: name)
+        let root = workspace.rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            assertEquals(TestWindow.new(id: 2, parent: $0).focusWindow(), true)
+        }
+        root.layout = .tabs
+
+        let activeWindow = root.children[1] as! TestWindow
+        let inactiveWindow = root.children[0] as! TestWindow
+
+        _ = try await workspace.layoutWorkspace()
+        let activeCallsAfterFirstLayout = activeWindow.setAxFrameCalls
+        let inactiveCallsAfterFirstLayout = inactiveWindow.setAxFrameCalls
+
+        _ = try await workspace.layoutWorkspace()
+
+        assertEquals(activeWindow.setAxFrameCalls, activeCallsAfterFirstLayout)
+        assertEquals(inactiveWindow.setAxFrameCalls, inactiveCallsAfterFirstLayout)
+    }
+
+    func testLayoutWorkspaceReturnsTabHeaderSnapshot() async throws {
+        let workspace = Workspace.get(byName: name)
+        let root = workspace.rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0, title: "Safari")
+            assertEquals(TestWindow.new(id: 2, parent: $0, title: "Mail").focusWindow(), true)
+            TestWindow.new(id: 3, parent: $0, title: "Notes")
+        }
+        (root.children[1] as! TestWindow).markAsMostRecentChild()
+        root.layout = .tabs
+
+        let snapshots = try await workspace.layoutWorkspace()
+
+        assertEquals(snapshots.count, 1)
+        let snapshot = snapshots[0]
+        assertEquals(snapshot.items.count, 3)
+        assertEquals(snapshot.items.map(\.title), ["Safari", "Mail", "Notes"])
+        assertEquals(snapshot.items.count(where: \.isActive), 1)
+        assertEquals(snapshot.items.first(where: \.isActive)?.targetWindow.windowId, 2)
+        assertEquals(snapshot.headerFrame.height, TabHeaderMetrics.height)
+        for item in snapshot.items {
+            assert(item.closeButtonFrame.width > 0)
+            assert(item.closeButtonFrame.height > 0)
+            assert(item.closeButtonFrame.minX >= item.frame.minX)
+            assert(item.closeButtonFrame.maxX <= item.frame.maxX)
+            assert(item.titleFrame.maxX <= item.closeButtonFrame.minX)
+        }
+    }
+
+    func testTabHeaderTitleFallbacks() async throws {
+        let workspace = Workspace.get(byName: name)
+        let appWithoutName = TestNamelessApp()
+        let root = workspace.rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0, title: "", app: TestApp.shared)
+            TestWindow.new(id: 2, parent: $0, title: "", app: appWithoutName)
+        }
+        root.layout = .tabs
+
+        let snapshots = try await workspace.layoutWorkspace()
+        assertEquals(snapshots.singleOrNil()?.items.map(\.title), [TestApp.shared.name.orDie(), "Window 2"])
+    }
+
+    func testTabHeaderInteractionSuppressionWindow() {
+        let state = TabHeaderInteractionState.shared
+        state.markInteraction()
+
+        assert(state.consumePendingGlobalMouseRefreshSuppression(now: .now))
+        assert(!state.consumePendingGlobalMouseRefreshSuppression(now: .now))
+    }
+
+    func testTabHeaderInteractionSuppressionExpires() {
+        let state = TabHeaderInteractionState.shared
+        state.markInteraction()
+
+        assert(!state.consumePendingGlobalMouseRefreshSuppression(now: .now.addingTimeInterval(1)))
+    }
+
+    func testCloseInvalidatesCachedTabTitle() async throws {
+        let workspace = Workspace.get(byName: name)
+        let window = workspace.rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0, title: "Safari")
+        }.children[0] as! TestWindow
+
+        _ = try await window.tabHeaderTitle()
+        assertEquals(TabHeaderTitleCache.shared.cachedTitle(for: 1), "Safari")
+
+        window.closeAxWindow()
+        assertNil(TabHeaderTitleCache.shared.cachedTitle(for: 1))
+    }
+
+    func testTabTitleCacheRefreshesAfterExpiration() async throws {
+        let workspace = Workspace.get(byName: name)
+        let window = workspace.rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0, title: "Safari")
+        }.children[0] as! TestWindow
+
+        let first = try await TabHeaderTitleCache.shared.title(for: window, now: .distantPast)
+        assertEquals(first, "Safari")
+
+        window.setTitleForTests("Safari 2")
+        let second = try await TabHeaderTitleCache.shared.title(for: window, now: .now)
+        assertEquals(second, "Safari 2")
+    }
+
+    func testFocusMovesBetweenTabs() async throws {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)
+            TestWindow.new(id: 2, parent: $0)
+            TestWindow.new(id: 3, parent: $0)
+        }
+        root.layout = .tabs
+
+        try await FocusCommand.new(direction: .right).run(.defaultEnv, .emptyStdin)
+        assertEquals(focus.windowOrNil?.windowId, 2)
+
+        try await FocusCommand.new(direction: .right).run(.defaultEnv, .emptyStdin)
+        assertEquals(focus.windowOrNil?.windowId, 3)
+
+        try await FocusCommand.new(direction: .left).run(.defaultEnv, .emptyStdin)
+        assertEquals(focus.windowOrNil?.windowId, 2)
+    }
+
+    func testMoveReordersTabs() async throws {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            assertEquals(TestWindow.new(id: 2, parent: $0).focusWindow(), true)
+            TestWindow.new(id: 3, parent: $0)
+        }
+        root.layout = .tabs
+
+        try await MoveCommand(args: MoveCmdArgs(rawArgs: [], .right)).run(.defaultEnv, .emptyStdin)
+        assertEquals(root.layoutDescription, .tabs([.window(1), .window(3), .window(2)]))
+        assertEquals(focus.windowOrNil?.windowId, 2)
+    }
+
+    func testClosingInactiveTabRemovesItFromSnapshot() async throws {
+        let workspace = Workspace.get(byName: name)
+        let root = workspace.rootTilingContainer.apply {
+            assertEquals(TestWindow.new(id: 1, parent: $0, title: "Safari").focusWindow(), true)
+            TestWindow.new(id: 2, parent: $0, title: "Mail")
+            TestWindow.new(id: 3, parent: $0, title: "Notes")
+        }
+        root.layout = .tabs
+
+        (root.children[2] as! TestWindow).closeAxWindow()
+        let snapshots = try await workspace.layoutWorkspace()
+
+        assertEquals(snapshots.count, 1)
+        assertEquals(snapshots[0].items.map(\.title), ["Safari", "Mail"])
+        assertEquals(snapshots[0].items.first(where: \.isActive)?.targetWindow.windowId, 2)
+    }
+
+    func testClosingActiveTabPromotesAnotherTab() async throws {
+        let workspace = Workspace.get(byName: name)
+        let root = workspace.rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0, title: "Safari")
+            assertEquals(TestWindow.new(id: 2, parent: $0, title: "Mail").focusWindow(), true)
+            TestWindow.new(id: 3, parent: $0, title: "Notes")
+        }
+        root.layout = .tabs
+
+        (root.children[1] as! TestWindow).closeAxWindow()
+        let snapshots = try await workspace.layoutWorkspace()
+
+        assertEquals(snapshots.count, 1)
+        let items = snapshots[0].items
+        assertEquals(items.map(\.title), ["Safari", "Notes"])
+        assertEquals(items.count(where: \.isActive), 1)
+        assert(items.contains(where: { $0.isActive && $0.targetWindow.windowId != 2 }))
+    }
+
+    func testClosingLastTabRemovesHeaderSnapshot() async throws {
+        let workspace = Workspace.get(byName: name)
+        let root = workspace.rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0, title: "Safari")
+        }
+        root.layout = .tabs
+
+        (root.children[0] as! TestWindow).closeAxWindow()
+        let snapshots = try await workspace.layoutWorkspace()
+
+        assertEquals(snapshots.count, 0)
+    }
+}
+
+private final class TestNamelessApp: AbstractApp {
+    let pid: Int32 = 42
+    let rawAppBundleId: String? = "test.nameless"
+    let name: String? = nil
+    let execPath: String? = nil
+    let bundlePath: String? = nil
+
+    @MainActor
+    func getFocusedWindow() async throws -> Window? { nil }
+}

--- a/Sources/AppBundleTests/command/TabsLayoutCommandTest.swift
+++ b/Sources/AppBundleTests/command/TabsLayoutCommandTest.swift
@@ -1,0 +1,244 @@
+@testable import AppBundle
+import Common
+import XCTest
+
+@MainActor
+final class TabsLayoutCommandTest: XCTestCase {
+    override func setUp() async throws {
+        setUpWorkspacesForTests()
+        TabHeaderTitleCache.shared.invalidateAll()
+    }
+
+    func testParse() {
+        testParseSingleCommandSucc("layout tabs", LayoutCmdArgs(rawArgs: [], toggleBetween: [.tabs]))
+    }
+
+    func testSwitchContainerToTabs() async {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            assertEquals(TestWindow.new(id: 2, parent: $0).focusWindow(), true)
+        }
+
+        let result = await parseCommand("layout tabs").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode.rawValue, 0)
+        assertEquals(root.layout, .tabs)
+        assertEquals(root.layoutDescription, .tabs([.window(1), .window(2)]))
+    }
+
+    func testTabsLayoutGeometryKeepsOnlyMostRecentChildVisible() async throws {
+        let workspace = Workspace.get(byName: name)
+        let root = workspace.rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            assertEquals(TestWindow.new(id: 2, parent: $0).focusWindow(), true)
+            TestWindow.new(id: 3, parent: $0)
+        }
+        assertEquals((root.children[1] as! TestWindow).focusWindow(), true)
+        root.layout = .tabs
+
+        _ = try await workspace.layoutWorkspace()
+
+        let workspaceRect = workspace.workspaceMonitor.visibleRectPaddedByOuterGaps
+        let activeRect = (root.mostRecentChild as! TestWindow).lastAppliedLayoutPhysicalRect.orDie()
+        let expectedHeaderHeight = TabHeaderMetrics.height
+
+        assertEquals(activeRect.topLeftCorner, workspaceRect.topLeftCorner + CGPoint(x: 0, y: expectedHeaderHeight))
+        assertEquals(activeRect.width, workspaceRect.width)
+        assertEquals(activeRect.height, workspaceRect.height - 1 - expectedHeaderHeight)
+        assertNil((root.children[0] as! TestWindow).lastAppliedLayoutPhysicalRect)
+    }
+
+    func testTabsLayoutSkipsRedundantFrameUpdates() async throws {
+        let workspace = Workspace.get(byName: name)
+        let root = workspace.rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            assertEquals(TestWindow.new(id: 2, parent: $0).focusWindow(), true)
+        }
+        root.layout = .tabs
+
+        let activeWindow = root.children[1] as! TestWindow
+        let inactiveWindow = root.children[0] as! TestWindow
+
+        _ = try await workspace.layoutWorkspace()
+        let activeCallsAfterFirstLayout = activeWindow.setAxFrameCalls
+        let inactiveCallsAfterFirstLayout = inactiveWindow.setAxFrameCalls
+
+        _ = try await workspace.layoutWorkspace()
+
+        assertEquals(activeWindow.setAxFrameCalls, activeCallsAfterFirstLayout)
+        assertEquals(inactiveWindow.setAxFrameCalls, inactiveCallsAfterFirstLayout)
+    }
+
+    func testLayoutWorkspaceReturnsTabHeaderSnapshot() async throws {
+        let workspace = Workspace.get(byName: name)
+        let root = workspace.rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0, title: "Safari")
+            assertEquals(TestWindow.new(id: 2, parent: $0, title: "Mail").focusWindow(), true)
+            TestWindow.new(id: 3, parent: $0, title: "Notes")
+        }
+        (root.children[1] as! TestWindow).markAsMostRecentChild()
+        root.layout = .tabs
+
+        let snapshots = try await workspace.layoutWorkspace()
+
+        assertEquals(snapshots.count, 1)
+        let snapshot = snapshots[0]
+        assertEquals(snapshot.items.count, 3)
+        assertEquals(snapshot.items.map(\.title), ["Safari", "Mail", "Notes"])
+        assertEquals(snapshot.items.count(where: \.isActive), 1)
+        assertEquals(snapshot.items.first(where: \.isActive)?.targetWindow.windowId, 2)
+        assertEquals(snapshot.headerFrame.height, TabHeaderMetrics.height)
+        for item in snapshot.items {
+            assert(item.closeButtonFrame.width > 0)
+            assert(item.closeButtonFrame.height > 0)
+            assert(item.closeButtonFrame.minX >= item.frame.minX)
+            assert(item.closeButtonFrame.maxX <= item.frame.maxX)
+            assert(item.titleFrame.maxX <= item.closeButtonFrame.minX)
+        }
+    }
+
+    func testTabHeaderTitleFallbacks() async throws {
+        let workspace = Workspace.get(byName: name)
+        let appWithoutName = TestNamelessApp()
+        let root = workspace.rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0, title: "", app: TestApp.shared)
+            TestWindow.new(id: 2, parent: $0, title: "", app: appWithoutName)
+        }
+        root.layout = .tabs
+
+        let snapshots = try await workspace.layoutWorkspace()
+        assertEquals(snapshots.singleOrNil()?.items.map(\.title), [TestApp.shared.name.orDie(), "Window 2"])
+    }
+
+    func testTabHeaderInteractionSuppressionWindow() {
+        let state = TabHeaderInteractionState.shared
+        state.markInteraction()
+
+        assert(state.consumePendingGlobalMouseRefreshSuppression(now: .now))
+        assert(!state.consumePendingGlobalMouseRefreshSuppression(now: .now))
+    }
+
+    func testTabHeaderInteractionSuppressionExpires() {
+        let state = TabHeaderInteractionState.shared
+        state.markInteraction()
+
+        assert(!state.consumePendingGlobalMouseRefreshSuppression(now: .now.addingTimeInterval(1)))
+    }
+
+    func testCloseInvalidatesCachedTabTitle() async throws {
+        let workspace = Workspace.get(byName: name)
+        let window = workspace.rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0, title: "Safari")
+        }.children[0] as! TestWindow
+
+        _ = try await window.tabHeaderTitle()
+        assertEquals(TabHeaderTitleCache.shared.cachedTitle(for: 1), "Safari")
+
+        window.closeAxWindow()
+        assertNil(TabHeaderTitleCache.shared.cachedTitle(for: 1))
+    }
+
+    func testTabTitleCacheRefreshesAfterExpiration() async throws {
+        let workspace = Workspace.get(byName: name)
+        let window = workspace.rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0, title: "Safari")
+        }.children[0] as! TestWindow
+
+        let first = try await TabHeaderTitleCache.shared.title(for: window, now: .distantPast)
+        assertEquals(first, "Safari")
+
+        window.setTitleForTests("Safari 2")
+        let second = try await TabHeaderTitleCache.shared.title(for: window, now: .now)
+        assertEquals(second, "Safari 2")
+    }
+
+    func testFocusMovesBetweenTabs() async {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)
+            TestWindow.new(id: 2, parent: $0)
+            TestWindow.new(id: 3, parent: $0)
+        }
+        root.layout = .tabs
+
+        await FocusCommand.new(direction: .right).run(.defaultEnv, .emptyStdin)
+        assertEquals(focus.windowOrNil?.windowId, 2)
+
+        await FocusCommand.new(direction: .right).run(.defaultEnv, .emptyStdin)
+        assertEquals(focus.windowOrNil?.windowId, 3)
+
+        await FocusCommand.new(direction: .left).run(.defaultEnv, .emptyStdin)
+        assertEquals(focus.windowOrNil?.windowId, 2)
+    }
+
+    func testMoveReordersTabs() async {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            assertEquals(TestWindow.new(id: 2, parent: $0).focusWindow(), true)
+            TestWindow.new(id: 3, parent: $0)
+        }
+        root.layout = .tabs
+
+        await parseCommand("move right").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(root.layoutDescription, .tabs([.window(1), .window(3), .window(2)]))
+        assertEquals(focus.windowOrNil?.windowId, 2)
+    }
+
+    func testClosingInactiveTabRemovesItFromSnapshot() async throws {
+        let workspace = Workspace.get(byName: name)
+        let root = workspace.rootTilingContainer.apply {
+            assertEquals(TestWindow.new(id: 1, parent: $0, title: "Safari").focusWindow(), true)
+            TestWindow.new(id: 2, parent: $0, title: "Mail")
+            TestWindow.new(id: 3, parent: $0, title: "Notes")
+        }
+        root.layout = .tabs
+
+        (root.children[2] as! TestWindow).closeAxWindow()
+        let snapshots = try await workspace.layoutWorkspace()
+
+        assertEquals(snapshots.count, 1)
+        assertEquals(snapshots[0].items.map(\.title), ["Safari", "Mail"])
+        assertEquals(snapshots[0].items.first(where: \.isActive)?.targetWindow.windowId, 2)
+    }
+
+    func testClosingActiveTabPromotesAnotherTab() async throws {
+        let workspace = Workspace.get(byName: name)
+        let root = workspace.rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0, title: "Safari")
+            assertEquals(TestWindow.new(id: 2, parent: $0, title: "Mail").focusWindow(), true)
+            TestWindow.new(id: 3, parent: $0, title: "Notes")
+        }
+        root.layout = .tabs
+
+        (root.children[1] as! TestWindow).closeAxWindow()
+        let snapshots = try await workspace.layoutWorkspace()
+
+        assertEquals(snapshots.count, 1)
+        let items = snapshots[0].items
+        assertEquals(items.map(\.title), ["Safari", "Notes"])
+        assertEquals(items.count(where: \.isActive), 1)
+        assert(items.contains(where: { $0.isActive && $0.targetWindow.windowId != 2 }))
+    }
+
+    func testClosingLastTabRemovesHeaderSnapshot() async throws {
+        let workspace = Workspace.get(byName: name)
+        let root = workspace.rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0, title: "Safari")
+        }
+        root.layout = .tabs
+
+        (root.children[0] as! TestWindow).closeAxWindow()
+        let snapshots = try await workspace.layoutWorkspace()
+
+        assertEquals(snapshots.count, 0)
+    }
+}
+
+private final class TestNamelessApp: AbstractApp {
+    let pid: Int32 = 42
+    let rawAppBundleId: String? = "test.nameless"
+    let name: String? = nil
+    let execPath: String? = nil
+    let bundlePath: String? = nil
+
+    @MainActor
+    func getFocusedWindow(_ cm: CancellationMode) async throws -> Window? { nil }
+}

--- a/Sources/AppBundleTests/config/ConfigTest.swift
+++ b/Sources/AppBundleTests/config/ConfigTest.swift
@@ -216,9 +216,9 @@ final class ConfigTest: XCTestCase {
     }
 
     func testParseTiles() {
-        let command = parseCommand("layout tiles h_tiles v_tiles list h_list v_list").cmdOrNil
+        let command = parseCommand("layout tiles h_tiles v_tiles list h_list v_list tabs").cmdOrNil
         XCTAssertTrue(command is LayoutCommand)
-        assertEquals((command as! LayoutCommand).args.toggleBetween.val, [.tiles, .h_tiles, .v_tiles, .tiles, .h_tiles, .v_tiles])
+        assertEquals((command as! LayoutCommand).args.toggleBetween.val, [.tiles, .h_tiles, .v_tiles, .tiles, .h_tiles, .v_tiles, .tabs])
 
         guard case .help = parseCommand("layout tiles -h") else {
             XCTFail()

--- a/Sources/AppBundleTests/config/ConfigTest.swift
+++ b/Sources/AppBundleTests/config/ConfigTest.swift
@@ -254,9 +254,9 @@ final class ConfigTest: XCTestCase {
     }
 
     func testParseTiles() {
-        let command = parseCommand("layout tiles h_tiles v_tiles list h_list v_list").cmdOrNil?.flatten().singleOrNil()
+        let command = parseCommand("layout tiles h_tiles v_tiles list h_list v_list tabs").cmdOrNil?.flatten().singleOrNil()
         XCTAssertTrue(command is LayoutCommand)
-        assertEquals((command as! LayoutCommand).args.toggleBetween.val, [.tiles, .h_tiles, .v_tiles, .tiles, .h_tiles, .v_tiles])
+        assertEquals((command as! LayoutCommand).args.toggleBetween.val, [.tiles, .h_tiles, .v_tiles, .tiles, .h_tiles, .v_tiles, .tabs])
 
         guard case .help = parseCommand("layout tiles -h") else {
             XCTFail()

--- a/Sources/AppBundleTests/tree/TestWindow.swift
+++ b/Sources/AppBundleTests/tree/TestWindow.swift
@@ -3,17 +3,27 @@ import AppKit
 
 final class TestWindow: Window, CustomStringConvertible {
     private var _rect: Rect?
+    private var customTitle: String?
+    private(set) var setAxFrameCalls = 0
 
     @MainActor
-    private init(_ id: UInt32, _ parent: NonLeafTreeNodeObject, _ adaptiveWeight: CGFloat, _ rect: Rect?) {
+    private init(_ id: UInt32, _ app: any AbstractApp, _ parent: NonLeafTreeNodeObject, _ adaptiveWeight: CGFloat, _ rect: Rect?, _ customTitle: String?) {
         _rect = rect
-        super.init(id: id, TestApp.shared, lastFloatingSize: nil, parent: parent, adaptiveWeight: adaptiveWeight, index: INDEX_BIND_LAST)
+        self.customTitle = customTitle
+        super.init(id: id, app, lastFloatingSize: nil, parent: parent, adaptiveWeight: adaptiveWeight, index: INDEX_BIND_LAST)
     }
 
     @discardableResult
     @MainActor
-    static func new(id: UInt32, parent: NonLeafTreeNodeObject, adaptiveWeight: CGFloat = 1, rect: Rect? = nil) -> TestWindow {
-        let wi = TestWindow(id, parent, adaptiveWeight, rect)
+    static func new(
+        id: UInt32,
+        parent: NonLeafTreeNodeObject,
+        adaptiveWeight: CGFloat = 1,
+        rect: Rect? = nil,
+        title: String? = nil,
+        app: any AbstractApp = TestApp.shared,
+    ) -> TestWindow {
+        let wi = TestWindow(id, app, parent, adaptiveWeight, rect, title)
         TestApp.shared._windows.append(wi)
         return wi
     }
@@ -27,13 +37,18 @@ final class TestWindow: Window, CustomStringConvertible {
     }
 
     override func closeAxWindow() {
+        TabHeaderTitleCache.shared.invalidate(windowId: windowId)
         unbindFromParent()
     }
 
     override var title: String {
         get async { // redundant async. todo create bug report to Swift
-            description
+            customTitle ?? description
         }
+    }
+
+    func setTitleForTests(_ newTitle: String?) {
+        customTitle = newTitle
     }
 
     @MainActor override func getAxRect() async throws -> Rect? { // todo change to not Optional
@@ -42,6 +57,7 @@ final class TestWindow: Window, CustomStringConvertible {
 
     override func setAxFrame(_ topLeft: CGPoint?, _ size: CGSize?) {
         guard let topLeft, let size else { return }
+        setAxFrameCalls += 1
         _rect = Rect(topLeftX: topLeft.x, topLeftY: topLeft.y, width: size.width, height: size.height)
     }
 }

--- a/Sources/AppBundleTests/tree/TestWindow.swift
+++ b/Sources/AppBundleTests/tree/TestWindow.swift
@@ -39,4 +39,9 @@ final class TestWindow: Window, CustomStringConvertible {
     @MainActor override func getAxRect() async throws -> Rect? { // todo change to not Optional
         _rect
     }
+
+    override func setAxFrame(_ topLeft: CGPoint?, _ size: CGSize?) {
+        guard let topLeft, let size else { return }
+        _rect = Rect(topLeftX: topLeft.x, topLeftY: topLeft.y, width: size.width, height: size.height)
+    }
 }

--- a/Sources/AppBundleTests/tree/TestWindow.swift
+++ b/Sources/AppBundleTests/tree/TestWindow.swift
@@ -4,17 +4,27 @@ import AppKit
 final class TestWindow: Window, CustomStringConvertible {
     private var _rect: Rect?
     var isMacosFullscreenForTest = false
+    private var customTitle: String?
+    private(set) var setAxFrameCalls = 0
 
     @MainActor
-    private init(_ id: UInt32, _ parent: NonLeafTreeNodeObject, _ adaptiveWeight: CGFloat, _ rect: Rect?) {
+    private init(_ id: UInt32, _ app: any AbstractApp, _ parent: NonLeafTreeNodeObject, _ adaptiveWeight: CGFloat, _ rect: Rect?, _ customTitle: String?) {
         _rect = rect
-        super.init(id: id, TestApp.shared, lastFloatingSize: nil, parent: parent, adaptiveWeight: adaptiveWeight, index: INDEX_BIND_LAST)
+        self.customTitle = customTitle
+        super.init(id: id, app, lastFloatingSize: nil, parent: parent, adaptiveWeight: adaptiveWeight, index: INDEX_BIND_LAST)
     }
 
     @discardableResult
     @MainActor
-    static func new(id: UInt32, parent: NonLeafTreeNodeObject, adaptiveWeight: CGFloat = 1, rect: Rect? = nil) -> TestWindow {
-        let wi = TestWindow(id, parent, adaptiveWeight, rect)
+    static func new(
+        id: UInt32,
+        parent: NonLeafTreeNodeObject,
+        adaptiveWeight: CGFloat = 1,
+        rect: Rect? = nil,
+        title: String? = nil,
+        app: any AbstractApp = TestApp.shared,
+    ) -> TestWindow {
+        let wi = TestWindow(id, app, parent, adaptiveWeight, rect, title)
         TestApp.shared._windows.append(wi)
         return wi
     }
@@ -28,10 +38,15 @@ final class TestWindow: Window, CustomStringConvertible {
     }
 
     override func closeAxWindow() {
+        TabHeaderTitleCache.shared.invalidate(windowId: windowId)
         unbindFromParent()
     }
 
-    override func getTitle(_ cm: CancellationMode) async throws -> String { description }
+    override func getTitle(_ cm: CancellationMode) async throws -> String { customTitle ?? description }
+
+    func setTitleForTests(_ newTitle: String?) {
+        customTitle = newTitle
+    }
 
     @MainActor override func getAxRect(_ cm: CancellationMode) async throws -> Rect? { // todo change to not Optional
         _rect
@@ -42,4 +57,10 @@ final class TestWindow: Window, CustomStringConvertible {
     }
 
     override func isMacosFullscreen(_ cm: CancellationMode) async throws -> Bool { isMacosFullscreenForTest }
+
+    override func setAxFrame(_ topLeft: CGPoint?, _ size: CGSize?) {
+        guard let topLeft, let size else { return }
+        setAxFrameCalls += 1
+        _rect = Rect(topLeftX: topLeft.x, topLeftY: topLeft.y, width: size.width, height: size.height)
+    }
 }

--- a/Sources/Cli/subcommandDescriptionsGenerated.swift
+++ b/Sources/Cli/subcommandDescriptionsGenerated.swift
@@ -32,6 +32,7 @@ let subcommandDescriptions = [
     ["  move", "Move the focused window in the given direction"],
     ["  reload-config", "Reload currently active config"],
     ["  resize", "Resize the focused window"],
+    ["  scroll", "Scroll the viewport of a workspace whose root container uses the scrolling layout"],
     ["  split", "Split focused window"],
     ["  subscribe", "Subscribe to AeroSpace events and receive notifications via socket"],
     ["  summon-workspace", "Move the requested workspace to the focused monitor."],

--- a/Sources/Cli/subcommandDescriptionsGenerated.swift
+++ b/Sources/Cli/subcommandDescriptionsGenerated.swift
@@ -35,6 +35,7 @@ let subcommandDescriptions = [
     ["  reload-config", "Reload currently active config"],
     ["  resize", "Resize the focused window"],
     ["  run-callback", "Run AeroSpace config callbacks on demand"],
+    ["  scroll", "Scroll the viewport of a workspace whose root container uses the scrolling layout"],
     ["  split", "Split focused window"],
     ["  subscribe", "Subscribe to AeroSpace events and receive notifications via socket"],
     ["  summon-workspace", "Move the requested workspace to the focused monitor."],

--- a/Sources/Common/cmdArgs/cmdArgsManifest.swift
+++ b/Sources/Common/cmdArgs/cmdArgsManifest.swift
@@ -33,6 +33,7 @@ public enum CmdKind: String, CaseIterable, Equatable, Sendable {
     case moveWorkspaceToMonitor = "move-workspace-to-monitor"
     case reloadConfig = "reload-config"
     case resize
+    case scroll
     case split
     case subscribe
     case summonWorkspace = "summon-workspace"
@@ -116,6 +117,8 @@ func initSubcommands() -> [String: any SubCommandParserProtocol] {
                 result[kind.rawValue] = SubCommandParser(ReloadConfigCmdArgs.init)
             case .resize:
                 result[kind.rawValue] = SubCommandParser(parseResizeCmdArgs)
+            case .scroll:
+                result[kind.rawValue] = SubCommandParser(parseScrollCmdArgs)
             case .split:
                 result[kind.rawValue] = SubCommandParser(parseSplitCmdArgs)
             case .subscribe:

--- a/Sources/Common/cmdArgs/cmdArgsManifest.swift
+++ b/Sources/Common/cmdArgs/cmdArgsManifest.swift
@@ -37,6 +37,7 @@ public enum CmdKind: String, CaseIterable, Equatable, Sendable {
     case reloadConfig = "reload-config"
     case resize
     case runCallback = "run-callback"
+    case scroll
     case split
     case subscribe
     case summonWorkspace = "summon-workspace"
@@ -128,6 +129,8 @@ func initSubcommands() -> [String: any SubCommandParserProtocol] {
                 result[kind.rawValue] = SubCommandParser(parseResizeCmdArgs)
             case .runCallback:
                 result[kind.rawValue] = SubCommandParser(parseRunCallbackCmdArgs)
+            case .scroll:
+                result[kind.rawValue] = SubCommandParser(parseScrollCmdArgs)
             case .split:
                 result[kind.rawValue] = SubCommandParser(parseSplitCmdArgs)
             case .subscribe:

--- a/Sources/Common/cmdArgs/impl/LayoutCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/LayoutCmdArgs.swift
@@ -19,7 +19,7 @@ public struct LayoutCmdArgs: CmdArgs {
     }
 
     public enum LayoutDescription: String, CaseIterable, Equatable, Sendable {
-        case accordion, tiles, scrolling
+        case accordion, tiles, scrolling, tabs
         case horizontal, vertical
         case h_accordion, v_accordion, h_tiles, v_tiles
         case tiling, floating

--- a/Sources/Common/cmdArgs/impl/LayoutCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/LayoutCmdArgs.swift
@@ -19,7 +19,7 @@ public struct LayoutCmdArgs: CmdArgs {
     }
 
     public enum LayoutDescription: String, CaseIterable, Equatable, Sendable {
-        case accordion, tiles
+        case accordion, tiles, scrolling
         case horizontal, vertical
         case h_accordion, v_accordion, h_tiles, v_tiles
         case tiling, floating

--- a/Sources/Common/cmdArgs/impl/LayoutCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/LayoutCmdArgs.swift
@@ -24,7 +24,7 @@ public struct LayoutCmdArgs: CmdArgs {
     }
 
     public enum LayoutDescription: String, CaseIterable, Equatable, Sendable {
-        case accordion, tiles
+        case accordion, tiles, scrolling, tabs
         case horizontal, vertical
         case h_accordion, v_accordion, h_tiles, v_tiles
         case tiling, floating
@@ -68,7 +68,7 @@ func parseLayoutCmdArgs(_ args: StrArrSlice) -> ParsedCmd<LayoutCmdArgs> {
                     case .floating, .tiling: false
                     case .accordion, .h_accordion, .h_tiles,
                          .horizontal, .tiles, .v_accordion, .v_tiles,
-                         .vertical: true
+                         .vertical, .scrolling, .tabs: true
                 }
             }
         }

--- a/Sources/Common/cmdArgs/impl/ScrollCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/ScrollCmdArgs.swift
@@ -1,0 +1,30 @@
+public struct ScrollCmdArgs: CmdArgs {
+    /*conforms*/ public var commonState: CmdArgsCommonState
+    fileprivate init(rawArgs: StrArrSlice) { self.commonState = .init(rawArgs) }
+    public static let parser: CmdParser<Self> = .init(
+        kind: .scroll,
+        allowInConfig: true,
+        help: scroll_help_generated,
+        flags: [:],
+        posArgs: [newMandatoryPosArgParser(\.direction, parseScrollDirection, placeholder: ScrollDirection.unionLiteral)],
+    )
+
+    public var direction: Lateinit<ScrollDirection> = .uninitialized
+
+    public init(rawArgs: [String], direction: ScrollDirection) {
+        self.commonState = .init(rawArgs.slice)
+        self.direction = .initialized(direction)
+    }
+}
+
+public enum ScrollDirection: String, CaseIterable, Equatable, Sendable {
+    case left, right
+}
+
+private func parseScrollDirection(input: PosArgParserInput) -> ParsedCliArgs<ScrollDirection> {
+    .init(parseEnum(input.arg, ScrollDirection.self), advanceBy: 1)
+}
+
+func parseScrollCmdArgs(_ args: StrArrSlice) -> ParsedCmd<ScrollCmdArgs> {
+    parseSpecificCmdArgs(ScrollCmdArgs(rawArgs: args), args)
+}

--- a/Sources/Common/cmdArgs/impl/ScrollCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/ScrollCmdArgs.swift
@@ -1,0 +1,29 @@
+public struct ScrollCmdArgs: CmdArgs {
+    /*conforms*/ public var commonState: CmdArgsCommonState
+    fileprivate init(rawArgs: StrArrSlice) { self.commonState = .init(rawArgs) }
+    public static let parser: CmdParser<Self> = .init(
+        kind: .scroll,
+        help: scroll_help_generated,
+        flags: [:],
+        posArgs: [newMandatoryPosArgParser(\.direction, parseScrollDirection, placeholder: ScrollDirection.unionLiteral)],
+    )
+
+    public var direction: Lateinit<ScrollDirection> = .uninitialized
+
+    public init(rawArgs: [String], direction: ScrollDirection) {
+        self.commonState = .init(rawArgs.slice)
+        self.direction = .initialized(direction)
+    }
+}
+
+public enum ScrollDirection: String, CaseIterable, Equatable, Sendable {
+    case left, right
+}
+
+private func parseScrollDirection(input: PosArgParserInput) -> ParsedCliArgs<ScrollDirection> {
+    .init(parseEnum(input.arg, ScrollDirection.self), advanceBy: 1)
+}
+
+func parseScrollCmdArgs(_ args: StrArrSlice) -> ParsedCmd<ScrollCmdArgs> {
+    parseSpecificCmdArgs(ScrollCmdArgs(rawArgs: args), args)
+}

--- a/Sources/Common/cmdHelpGenerated.swift
+++ b/Sources/Common/cmdHelpGenerated.swift
@@ -61,7 +61,7 @@ let join_with_help_generated = """
     """
 let layout_help_generated = """
     USAGE: layout [-h|--help] [--window-id <window-id>]
-                  (h_tiles|v_tiles|h_accordion|v_accordion|tiles|accordion|scrolling|horizontal|vertical|tiling|floating)...
+                  (h_tiles|v_tiles|h_accordion|v_accordion|tiles|accordion|scrolling|tabs|horizontal|vertical|tiling|floating)...
     """
 let list_apps_help_generated = """
     USAGE: list-apps [-h|--help] [--macos-native-hidden [no]] [--format <output-format>] [--count] [--json]

--- a/Sources/Common/cmdHelpGenerated.swift
+++ b/Sources/Common/cmdHelpGenerated.swift
@@ -61,7 +61,7 @@ let join_with_help_generated = """
     """
 let layout_help_generated = """
     USAGE: layout [-h|--help] [--window-id <window-id>]
-                  (h_tiles|v_tiles|h_accordion|v_accordion|tiles|accordion|horizontal|vertical|tiling|floating)...
+                  (h_tiles|v_tiles|h_accordion|v_accordion|tiles|accordion|scrolling|horizontal|vertical|tiling|floating)...
     """
 let list_apps_help_generated = """
     USAGE: list-apps [-h|--help] [--macos-native-hidden [no]] [--format <output-format>] [--count] [--json]
@@ -128,6 +128,9 @@ let reload_config_help_generated = """
     """
 let resize_help_generated = """
     USAGE: resize [-h|--help] [--window-id <window-id>] (smart|smart-opposite|width|height) [+|-]<number>
+    """
+let scroll_help_generated = """
+    USAGE: scroll [-h|--help] (left|right)
     """
 let split_help_generated = """
     USAGE: split [-h|--help] [--window-id <window-id>] (horizontal|vertical|opposite)

--- a/Sources/Common/cmdHelpGenerated.swift
+++ b/Sources/Common/cmdHelpGenerated.swift
@@ -143,6 +143,9 @@ let run_callback_help_generated = """
     USAGE: run-callback [-h|--help] [--for-every-window|--window-id <window-id>] on-window-detected
        OR: run-callback [-h|--help] (on-focus-changed|on-focused-monitor-changed)
     """
+let scroll_help_generated = """
+    USAGE: scroll [-h|--help] (left|right)
+    """
 let split_help_generated = """
     USAGE: split [-h|--help] [--window-id <window-id>] (horizontal|vertical|opposite)
     """

--- a/docs/aerospace-layout.adoc
+++ b/docs/aerospace-layout.adoc
@@ -10,7 +10,7 @@ include::util/man-attributes.adoc[]
 [verse]
 // tag::synopsis[]
 aerospace layout [-h|--help] [--window-id <window-id>]
-                 (h_tiles|v_tiles|h_accordion|v_accordion|tiles|accordion|scrolling|horizontal|vertical|tiling|floating)...
+                 (h_tiles|v_tiles|h_accordion|v_accordion|tiles|accordion|scrolling|tabs|horizontal|vertical|tiling|floating)...
 
 // end::synopsis[]
 
@@ -25,6 +25,7 @@ If several arguments are supplied then finds the first argument that doesn't des
 * Change both tiling layout and orientation in one go: `h_tiles|v_tiles|h_accordion|v_accordion`
 * Change tiling layout but preserve orientation: `tiles|accordion`
 * Switch the workspace root container to scrolling layout: `scrolling`
+* Switch the current tiling container to tabs layout: `tabs`
 * Change orientation but preserve layout: `horizontal|vertical`
 * Toggle floating/tiling mode: `tiling|floating`
 

--- a/docs/aerospace-layout.adoc
+++ b/docs/aerospace-layout.adoc
@@ -10,7 +10,7 @@ include::util/man-attributes.adoc[]
 [verse]
 // tag::synopsis[]
 aerospace layout [-h|--help] [--window-id <window-id>]
-                 (h_tiles|v_tiles|h_accordion|v_accordion|tiles|accordion|horizontal|vertical|tiling|floating)...
+                 (h_tiles|v_tiles|h_accordion|v_accordion|tiles|accordion|scrolling|horizontal|vertical|tiling|floating)...
 
 // end::synopsis[]
 
@@ -24,8 +24,11 @@ If several arguments are supplied then finds the first argument that doesn't des
 
 * Change both tiling layout and orientation in one go: `h_tiles|v_tiles|h_accordion|v_accordion`
 * Change tiling layout but preserve orientation: `tiles|accordion`
+* Switch the workspace root container to scrolling layout: `scrolling`
 * Change orientation but preserve layout: `horizontal|vertical`
 * Toggle floating/tiling mode: `tiling|floating`
+
+The `scrolling` layout is only supported on the workspace root container, and it is always horizontal.
 
 // =========================================================== Options
 include::./util/conditional-options-header.adoc[]
@@ -46,6 +49,12 @@ include::util/conditional-examples-header.adoc[]
 
 * Toggle between `tiles` and `accordion` layouts (order of args doesn't matter): +
 `aerospace layout tiles accordion`
+
+* Switch the workspace root container to the scrolling layout: +
+`aerospace layout scrolling`
+
+* Return from scrolling layout to ordinary tiling: +
+`aerospace layout tiles`
 
 * Switch to `tiles` layout. Toggle the layout orientation if already in `tiles` layout: +
 `aerospace layout tiles horizontal vertical`

--- a/docs/aerospace-layout.adoc
+++ b/docs/aerospace-layout.adoc
@@ -48,6 +48,8 @@ Possible values:
 +
 * `h_tiles|v_tiles|h_accordion|v_accordion` - Change both tiling layout and orientation in one go
 * `tiles|accordion` - Change tiling layout but preserve orientation
+* `scrolling` - Switch the workspace root container to the scrolling layout (root container only, always horizontal)
+* `tabs` - Switch the current tiling container to the tabs layout
 * `horizontal|vertical` - Change orientation but preserve layout
 * `tiling|floating` - Toggle between floating/tiling mode
 +
@@ -64,6 +66,12 @@ include::./util/conditional-examples-header.adoc[]
 
 * Toggle between `tiles` and `accordion` layouts (order of args doesn't matter): +
 `aerospace layout tiles accordion`
+
+* Switch the workspace root container to the scrolling layout: +
+`aerospace layout scrolling`
+
+* Return from scrolling layout to ordinary tiling: +
+`aerospace layout tiles`
 
 * Switch to `tiles` layout. Toggle the layout orientation if already in `tiles` layout: +
 `aerospace layout tiles horizontal vertical`

--- a/docs/aerospace-scroll.adoc
+++ b/docs/aerospace-scroll.adoc
@@ -1,0 +1,43 @@
+= aerospace-scroll(1)
+include::util/man-attributes.adoc[]
+:manname: aerospace-scroll
+// tag::purpose[]
+:manpurpose: Scroll the viewport of a workspace whose root container uses the scrolling layout
+// end::purpose[]
+
+== Synopsis
+[verse]
+// tag::synopsis[]
+aerospace scroll [-h|--help] (left|right)
+// end::synopsis[]
+
+== Description
+
+// tag::body[]
+{manpurpose}
+
+The command moves the viewport by one page and focuses the newly revealed window.
+
+This command only works when the focused workspace root container uses the `scrolling` layout.
+
+In the scrolling layout, `focus left|right` keeps its normal directional meaning, while `scroll left|right`
+is the explicit way to move the viewport itself.
+
+include::./util/conditional-options-header.adoc[]
+
+-h, --help:: Print help
+
+include::util/conditional-examples-header.adoc[]
+
+* Scroll one page to the left: +
+`aerospace scroll left`
+
+* Scroll one page to the right: +
+`aerospace scroll right`
+
+* Example bindings for the scrolling layout: +
+`alt-left = 'scroll left'` +
+`alt-right = 'scroll right'`
+// end::body[]
+
+include::util/man-footer.adoc[]

--- a/docs/commands.adoc
+++ b/docs/commands.adoc
@@ -161,6 +161,13 @@ include::aerospace-resize.adoc[tags=synopsis]
 include::aerospace-resize.adoc[tags=purpose]
 include::aerospace-resize.adoc[tags=body]
 
+== scroll
+----
+include::aerospace-scroll.adoc[tags=synopsis]
+----
+include::aerospace-scroll.adoc[tags=purpose]
+include::aerospace-scroll.adoc[tags=body]
+
 == split
 ----
 include::aerospace-split.adoc[tags=synopsis]

--- a/docs/commands.adoc
+++ b/docs/commands.adoc
@@ -245,6 +245,13 @@ include::aerospace-run-callback.adoc[tags=synopsis]
 include::aerospace-run-callback.adoc[tags=purpose]
 include::aerospace-run-callback.adoc[tags=body]
 
+== scroll
+----
+include::aerospace-scroll.adoc[tags=synopsis]
+----
+include::aerospace-scroll.adoc[tags=purpose]
+include::aerospace-scroll.adoc[tags=body]
+
 == split
 ----
 include::aerospace-split.adoc[tags=synopsis]

--- a/docs/config-examples/default-config.toml
+++ b/docs/config-examples/default-config.toml
@@ -25,7 +25,7 @@ enable-normalization-opposite-orientation-for-nested-containers = true
 # You can set 0 to disable the padding feature
 accordion-padding = 30
 
-# Possible values: tiles|accordion
+# Possible values: tiles|accordion|scrolling
 default-root-container-layout = 'tiles'
 
 # Possible values: horizontal|vertical|auto
@@ -115,6 +115,9 @@ on-mode-changed = []
     # See: https://nikitabobko.github.io/AeroSpace/commands#layout
     alt-slash = 'layout tiles horizontal vertical'
     alt-comma = 'layout accordion horizontal vertical'
+    # Useful when you switch a workspace to the scrolling layout with `layout scrolling`
+    alt-left = 'scroll left'
+    alt-right = 'scroll right'
 
     # See: https://nikitabobko.github.io/AeroSpace/commands#focus
     alt-h = 'focus left'

--- a/docs/config-examples/default-config.toml
+++ b/docs/config-examples/default-config.toml
@@ -26,7 +26,7 @@ enable-normalization-opposite-orientation-for-nested-containers = true
 # You can set 0 to disable the padding feature
 accordion-padding = 30
 
-# Possible values: tiles|accordion
+# Possible values: tiles|accordion|scrolling
 default-root-container-layout = 'tiles'
 
 # Possible values: horizontal|vertical|auto
@@ -112,6 +112,9 @@ gaps.outer.right =      0
     # See: https://nikitabobko.github.io/AeroSpace/commands#layout
     alt-slash = 'layout tiles horizontal vertical'
     alt-comma = 'layout accordion horizontal vertical'
+    # Useful when you switch a workspace to the scrolling layout with `layout scrolling`
+    alt-left = 'scroll left'
+    alt-right = 'scroll right'
 
     # See: https://nikitabobko.github.io/AeroSpace/commands#focus
     alt-h = 'focus left'

--- a/docs/guide.adoc
+++ b/docs/guide.adoc
@@ -256,12 +256,13 @@ The tree structure can be changed with three commands:
 [#layouts]
 === Layouts
 
-In total, AeroSpace provides 4 possible layouts:
+In total, AeroSpace provides 5 possible layouts:
 
 - `h_tiles` horizontal tiles (in i3, it’s called "horizontal split")
 - `v_tiles` vertical tiles (in i3, it’s called "vertical split")
 - `h_accordion` horizontal accordion (analog of i3’s "tabbed layout")
 - `v_accordion` vertical accordion (analog of i3’s "stacked layout")
+- `tabs` tabs layout where only the most recently focused child is visible
 
 <<tree,From the previous section>>, you’re already familiar with the `tiles` layout.
 
@@ -282,6 +283,9 @@ You can navigate the windows in an `h_accordion` by using the `focus (left|right
 While in a `v_accordion`, you can navigate the windows using the `focus (up|down)` command.
 
 Accordion padding is configurable via `accordion-padding` option.
+
+Tabs layout shows only one child at a time.
+The visible child is selected by focus history of the container.
 
 [#normalization]
 === Normalization

--- a/docs/guide.adoc
+++ b/docs/guide.adoc
@@ -323,12 +323,13 @@ The tree structure can be changed with three commands:
 [#layouts]
 === Layouts
 
-In total, AeroSpace provides 4 possible layouts:
+In total, AeroSpace provides 5 possible layouts:
 
 - `h_tiles` horizontal tiles (in i3, it’s called "horizontal split")
 - `v_tiles` vertical tiles (in i3, it’s called "vertical split")
 - `h_accordion` horizontal accordion (analog of i3’s "tabbed layout")
 - `v_accordion` vertical accordion (analog of i3’s "stacked layout")
+- `tabs` tabs layout where only the most recently focused child is visible
 
 <<tree,From the previous section>>, you’re already familiar with the `tiles` layout.
 
@@ -349,6 +350,9 @@ You can navigate the windows in an `h_accordion` by using the `focus (left|right
 While in a `v_accordion`, you can navigate the windows using the `focus (up|down)` command.
 
 Accordion padding is configurable via `accordion-padding` option.
+
+Tabs layout shows only one child at a time.
+The visible child is selected by focus history of the container.
 
 [#normalization]
 === Normalization

--- a/grammar/commands-bnf-grammar.txt
+++ b/grammar/commands-bnf-grammar.txt
@@ -39,7 +39,7 @@ aerospace -h;
 
     | join-with [--window-id <window_id>] (left|down|up|right)
 
-    | layout [--window-id <window_id>] (h_tiles|v_tiles|h_accordion|v_accordion|tiles|accordion|horizontal|vertical|tiling|floating)...
+    | layout [--window-id <window_id>] (h_tiles|v_tiles|h_accordion|v_accordion|tiles|accordion|scrolling|horizontal|vertical|tiling|floating)...
 
     | macos-native-fullscreen [--fail-if-noop|--window-id <window_id>]... [on|off] [--fail-if-noop|--window-id <window_id>]...
 
@@ -63,6 +63,8 @@ aerospace -h;
     | reload-config [--no-gui | --dry-run]...
 
     | resize [--window-id <window_id>] (smart|smart-opposite|width|height) [+|-]<number> [--window-id <window_id>]
+
+    | scroll (left|right)
 
     | split [--window-id <window_id>] (horizontal|vertical|opposite) [--window-id <window_id>]
 

--- a/grammar/commands-bnf-grammar.txt
+++ b/grammar/commands-bnf-grammar.txt
@@ -78,6 +78,8 @@ aerospace -h;
     | run-callback [--for-every-window|--window-id <window_id>]... on-window-detected [--for-every-window|--window-id <window_id>]...
     | run-callback (on-focus-changed|on-focused-monitor-changed)
 
+    | scroll (left|right)
+
     | split [--window-id <window_id>] (horizontal|vertical|opposite) [--window-id <window_id>]
 
     | swap [--swap-focus|--wrap-around|--window-id <window_id>]... (left|down|up|right|dfs-next|dfs-prev) [--swap-focus|--wrap-around|--window-id <window_id>]...
@@ -124,7 +126,7 @@ aerospace -h;
 <workspace> ::= {{{ aerospace list-workspaces --monitor all --empty no }}};
 <number> ::= {{{ true }}};
 <monitor_pattern> ::= {{{ true }}};
-<layouts> ::= h_tiles|v_tiles|h_accordion|v_accordion|tiles|accordion|horizontal|vertical|tiling|floating;
+<layouts> ::= h_tiles|v_tiles|h_accordion|v_accordion|tiles|accordion|scrolling|tabs|horizontal|vertical|tiling|floating;
 
 <list_workspaces1_flag> ::= --visible [no] | --empty [no] | --format <output_format> | --format <output_format> | --count | --json;
 


### PR DESCRIPTION
This adds two new workspace layout styles: scrolling and tabs.

These layouts are useful for people who want to keep several windows in one workspace without giving each one permanent screen space. Scrolling is a good fit for moving through a linear stack of windows, while tabs is useful when you want one main window visible at a time with quick switching between related windows.

Example from my local config:
```toml
default-root-container-layout = 'scrolling'
default-root-container-orientation = 'auto'

[mode.main.binding]
alt-slash = 'layout tiles horizontal vertical'
alt-comma = 'layout accordion horizontal vertical'
alt-g = 'layout tabs tiles'
alt-left = 'focus left'
alt-right = 'focus right'
```

This PR supersedes #2044.

Tabs look like this: 

<img width="2940" height="290" alt="image" src="https://github.com/user-attachments/assets/27666b73-1ef1-4af4-bcb8-b0fbb6a9059a" />


## Validation
- swift test
