### PR TITLE
ui: Make workspace indicators (rounded rectangles) smaller

### DIFF
--- a/Sources/AppBundle/ui/MenuBarLabel.swift
+++ b/Sources/AppBundle/ui/MenuBarLabel.swift
@@ -10,7 +10,7 @@ struct MenuBarLabel: View {
     let style: MenuBarStyle?
 
     let hStackSpacing = CGFloat(6)
-    let itemSize = CGFloat(40)
+    let itemSize = CGFloat(33)
     let itemBorderSize = CGFloat(3)
     let itemCornerRadius = CGFloat(6)
 


### PR DESCRIPTION
## Goal
The workspace indicators (rounded rectangles) are slightly too large compared to other macOS native menu bar components (e.g. input methods, control center, etc).

This commit changes itemSize from 40 to 33 so that it looks more aesthetically pleasing.

## Before
<img width="599" height="34" alt="Screenshot 2026-04-20 at 8 38 41 PM" src="https://github.com/user-attachments/assets/79d3859b-085f-4c6f-8773-f14e7554d3e4" />

## After
<img width="606" height="35" alt="Screenshot 2026-04-20 at 9 11 20 PM" src="https://github.com/user-attachments/assets/08ae0913-2450-4962-af1f-614f0e80de07" />


## PR checklist

- [x] Explain your changes in the relevant commit messages rather than in the PR description. The PR description must not contain more information than the commit messages (except for images and other media).
- [x] Each commit must explain what/why/how and motivation in its description. https://cbea.ms/git-commit/
- [x] Don't forget to link the appropriate issues/discussions in commit messages (if applicable).
- [x] Each commit must be an atomic change (a PR may contain several commits). Don't introduce new functional changes together with refactorings in the same commit.
- [x] `./test.sh` exits with non-zero exit code.
- [x] Avoid merge commits, always rebase and force push.

Failure to follow the checklist with no apparent reasons will result in silent PR rejection.
