### PR TITLE
Add new window `tiling-filter` option to ignore desired apps from tiling

### DIFF
--- a/Sources/AppBundle/config/Config.swift
+++ b/Sources/AppBundle/config/Config.swift
@@ -56,6 +56,7 @@ struct Config: ConvenienceCopyable {
     var onFocusedMonitorChanged: [any Command] = []
 
     var gaps: Gaps = .zero
+    var tilingFilter: WindowTilingFilter = .none
     var workspaceToMonitorForceAssignment: [String: [MonitorDescription]] = [:]
     var modes: [String: Mode] = [:]
     var onWindowDetected: [WindowDetectedCallback] = []
@@ -64,4 +65,25 @@ struct Config: ConvenienceCopyable {
 
 enum DefaultContainerOrientation: String {
     case horizontal, vertical, auto
+}
+
+enum WindowTilingFilterMode: String {
+    case none, include, exclude
+}
+
+struct WindowTilingFilter: ConvenienceCopyable {
+    var mode: WindowTilingFilterMode = .none
+    var apps: [String] = []
+
+    static let none = WindowTilingFilter()
+
+    func shouldTile(appName: String?) -> Bool {
+        let normalizedName = appName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let isListed = apps.contains(normalizedName)
+        return switch mode {
+            case .none: true
+            case .include: isListed
+            case .exclude: !isListed
+        }
+    }
 }

--- a/Sources/AppBundle/config/parseConfig.swift
+++ b/Sources/AppBundle/config/parseConfig.swift
@@ -89,6 +89,7 @@ struct Parser<S: ConvenienceCopyable, T>: ParserProtocol {
 private let keyMappingConfigRootKey = "key-mapping"
 private let modeConfigRootKey = "mode"
 private let persistentWorkspacesKey = "persistent-workspaces"
+private let tilingFilterConfigRootKey = "tiling-filter"
 
 // For every new config option you add, think:
 // 1. Does it make sense to have different value
@@ -122,12 +123,18 @@ private let configParser: [String: any ParserProtocol<Config>] = [
     modeConfigRootKey: Parser(\.modes, skipParsing(Config().modes)), // Parsed manually
 
     "gaps": Parser(\.gaps, parseGaps),
+    tilingFilterConfigRootKey: Parser(\.tilingFilter, parseWindowTilingFilter),
     "workspace-to-monitor-force-assignment": Parser(\.workspaceToMonitorForceAssignment, parseWorkspaceToMonitorAssignment),
     "on-window-detected": Parser(\.onWindowDetected, parseOnWindowDetectedArray),
 
     // Deprecated
     "non-empty-workspaces-root-containers-layout-on-startup": Parser(\._nonEmptyWorkspacesRootContainersLayoutOnStartup, parseStartupRootContainerLayout),
     "indent-for-nested-containers-with-the-same-orientation": Parser(\._indentForNestedContainersWithTheSameOrientation, parseIndentForNestedContainersWithTheSameOrientation),
+]
+
+private let windowTilingFilterParser: [String: any ParserProtocol<WindowTilingFilter>] = [
+    "mode": Parser(\.mode, parseWindowTilingFilterMode),
+    "apps": Parser(\.apps, parseArrayOfStrings),
 ]
 
 extension ParsedCmd where T == any Command {
@@ -351,6 +358,17 @@ private func parsePersistentWorkspaces(_ raw: Json, _ backtrace: ConfigBacktrace
             let set = arr.toOrderedSet()
             return set.count == arr.count ? .success(set) : .failure(.semantic(backtrace, "Contains duplicated workspace names"))
         }
+}
+
+private func parseWindowTilingFilter(_ raw: Json, _ backtrace: ConfigBacktrace, _ errors: inout [ConfigParseError]) -> WindowTilingFilter {
+    parseTable(raw, .none, windowTilingFilterParser, backtrace, &errors)
+}
+
+private func parseWindowTilingFilterMode(_ raw: Json, _ backtrace: ConfigBacktrace) -> ParsedConfig<WindowTilingFilterMode> {
+    parseString(raw, backtrace).flatMap {
+        WindowTilingFilterMode(rawValue: $0)
+            .orFailure(.semantic(backtrace, "Can't parse tiling filter mode '\($0)'"))
+    }
 }
 
 private func parseArrayOfStrings(_ raw: Json, _ backtrace: ConfigBacktrace) -> ParsedConfig<[String]> {

--- a/Sources/AppBundle/config/parseConfig.swift
+++ b/Sources/AppBundle/config/parseConfig.swift
@@ -89,7 +89,6 @@ struct Parser<S: ConvenienceCopyable, T>: ParserProtocol {
 private let keyMappingConfigRootKey = "key-mapping"
 private let modeConfigRootKey = "mode"
 private let persistentWorkspacesKey = "persistent-workspaces"
-private let tilingFilterConfigRootKey = "tiling-filter"
 
 // For every new config option you add, think:
 // 1. Does it make sense to have different value
@@ -123,7 +122,7 @@ private let configParser: [String: any ParserProtocol<Config>] = [
     modeConfigRootKey: Parser(\.modes, skipParsing(Config().modes)), // Parsed manually
 
     "gaps": Parser(\.gaps, parseGaps),
-    tilingFilterConfigRootKey: Parser(\.tilingFilter, parseWindowTilingFilter),
+    "tiling-filter": Parser(\.tilingFilter, parseWindowTilingFilter),
     "workspace-to-monitor-force-assignment": Parser(\.workspaceToMonitorForceAssignment, parseWorkspaceToMonitorAssignment),
     "on-window-detected": Parser(\.onWindowDetected, parseOnWindowDetectedArray),
 

--- a/Sources/AppBundle/tree/MacWindow.swift
+++ b/Sources/AppBundle/tree/MacWindow.swift
@@ -215,7 +215,10 @@ private func unbindAndGetBindingDataForNewWindow(_ windowId: UInt32, _ macApp: M
     return switch try await macApp.getAxUiElementWindowType(windowId, windowLevel) {
         case .popup: BindingData(parent: macosPopupWindowsContainer, adaptiveWeight: WEIGHT_AUTO, index: INDEX_BIND_LAST)
         case .dialog: BindingData(parent: workspace, adaptiveWeight: WEIGHT_AUTO, index: INDEX_BIND_LAST)
-        case .window: unbindAndGetBindingDataForNewTilingWindow(workspace, window: window)
+        case .window:
+            config.tilingFilter.shouldTile(appName: macApp.name)
+                ? unbindAndGetBindingDataForNewTilingWindow(workspace, window: window)
+                : BindingData(parent: workspace, adaptiveWeight: WEIGHT_AUTO, index: INDEX_BIND_LAST)
     }
 }
 

--- a/Sources/AppBundleTests/config/ConfigTest.swift
+++ b/Sources/AppBundleTests/config/ConfigTest.swift
@@ -454,6 +454,33 @@ final class ConfigTest: XCTestCase {
         ])
     }
 
+    func testParseWindowTilingFilter() {
+        let (config, errors) = parseConfig(
+            """
+            [tiling-filter]
+                mode = 'exclude'
+                apps = ['Google Chrome', 'System Settings']
+            """,
+        )
+        assertEquals(errors, [])
+        assertEquals(config.tilingFilter.mode, .exclude)
+        assertEquals(config.tilingFilter.apps, ["Google Chrome", "System Settings"])
+    }
+
+    func testParseWindowTilingFilterErrors() {
+        let (_, errors) = parseConfig(
+            """
+            [tiling-filter]
+                mode = 'blacklist'
+                apps = ['Safari', 1]
+            """,
+        )
+        assertEquals(errors, [
+            "tiling-filter.apps[1]: Expected type is \'string\'. But actual type is \'int\'",
+            "tiling-filter.mode: Can\'t parse tiling filter mode \'blacklist\'",
+        ])
+    }
+
     func testParseKeyMapping() {
         let (config, errors) = parseConfig(
             """

--- a/docs/config-examples/default-config.toml
+++ b/docs/config-examples/default-config.toml
@@ -79,6 +79,17 @@ on-mode-changed = []
     outer.top =        0
     outer.right =      0
 
+# Filter tiling by app name (localized application name from macOS)
+# Windows filtered out from tiling are still managed as floating windows,
+# so they can be moved between workspaces with usual commands/keybindings.
+# Possible values:
+    # - none:    Disable filtering and tile all regular windows
+    # - include: Tile only listed apps
+    # - exclude: Tile all apps except listed ones
+[tiling-filter]
+    mode = 'none'
+    apps = []
+
 # 'main' binding mode declaration
 # See: https://nikitabobko.github.io/AeroSpace/guide#binding-modes
 # 'main' binding mode must be always presented

--- a/docs/guide.adoc
+++ b/docs/guide.adoc
@@ -357,6 +357,28 @@ The floating window parent container is determined as the smallest tiling contai
 
 This technique eliminates the need for an additional binding for focusing floating windows.
 
+[#tiling-filter]
+=== Tiling filter
+
+You can control which applications participate in tiling with `tiling-filter`.
+
+[source,toml]
+----
+[tiling-filter]
+    mode = 'exclude'
+    apps = ['Finder', 'Mail']
+----
+
+`tiling-filter.mode` supports:
+
+* `none` - disable filtering and tile all regular windows
+* `include` - tile only apps listed in `tiling-filter.apps`
+* `exclude` - tile all regular windows except apps listed in `tiling-filter.apps`
+
+`tiling-filter.apps` is an array of application names (exact match, case-sensitive), for example values returned by xref:commands.adoc#list-apps[`aerospace list-apps`].
+
+Windows excluded from tiling by this filter are still managed as floating windows, therefore commands like xref:commands.adoc#move-node-to-workspace[`move-node-to-workspace`] continue to work for them.
+
 [#emulation-of-virtual-workspaces]
 == Emulation of virtual workspaces
 


### PR DESCRIPTION
Introduce a new `tiling-filter` property in the `Config` struct to manage which applications participate in window tiling. Implement parsing for the `tiling-filter` configuration in TOML format, allowing modes for inclusion and exclusion of specific apps. Update the window binding logic to respect the tiling filter settings. Add tests for parsing the new configuration and handling errors. Update documentation to reflect the new feature.

## Demo


https://github.com/user-attachments/assets/9657916f-aa4e-4a09-ba30-d07bc22eb393



## PR checklist

- [x] Explain your changes in the relevant commit messages rather than in the PR description. The PR description must not contain more information than the commit messages (except for images and other media).
- [x] Each commit must explain what/why/how and motivation in its description. https://cbea.ms/git-commit/
- [ ] Don't forget to link the appropriate issues/discussions in commit messages (if applicable).
- [x] Each commit must be an atomic change (a PR may contain several commits). Don't introduce new functional changes together with refactorings in the same commit.
- [ ] `./test.sh` exits with non-zero exit code.
- [x] Avoid merge commits, always rebase and force push.

Failure to follow the checklist with no apparent reasons will result in silent PR rejection.
