### PR TITLE
Add per-app exceptions for automatic unhide

### DIFF
--- a/Sources/AppBundle/GlobalObserver.swift
+++ b/Sources/AppBundle/GlobalObserver.swift
@@ -25,17 +25,21 @@ enum GlobalObserver {
             guard let token: RunSessionGuard = .isServerEnabled else { return }
             try await runLightSession(.globalObserver(notifName), token) {
                 if config.automaticallyUnhideMacosHiddenApps {
+                    let hiddenNonExceptionCount = MacApp.allAppsMap.values.count(where: {
+                        $0.nsApp.isHidden && !$0.isExcludedFromAutoUnhide
+                    })
                     if let w = prevFocus?.windowOrNil,
                        w.macAppUnsafe.nsApp.isHidden,
+                       !w.macAppUnsafe.isExcludedFromAutoUnhide,
                        // "Hide others" (cmd-alt-h) -> don't force focus
                        // "Hide app" (cmd-h) -> force focus
-                       MacApp.allAppsMap.values.count(where: { $0.nsApp.isHidden }) == 1
+                       hiddenNonExceptionCount == 1
                     {
                         // Force focus
                         _ = w.focusWindow()
                         w.nativeFocus()
                     }
-                    for app in MacApp.allAppsMap.values {
+                    for app in MacApp.allAppsMap.values where !app.isExcludedFromAutoUnhide {
                         app.nsApp.unhide()
                     }
                 }

--- a/Sources/AppBundle/config/Config.swift
+++ b/Sources/AppBundle/config/Config.swift
@@ -44,6 +44,7 @@ struct Config: ConvenienceCopyable {
     var startAtLogin: Bool = false
     var autoReloadConfig: Bool = false
     var automaticallyUnhideMacosHiddenApps: Bool = false
+    var automaticallyUnhideMacosHiddenAppsExceptions: Set<String> = []
     var accordionPadding: Int = 30
     var enableNormalizationOppositeOrientationForNestedContainers: Bool = true
     var persistentWorkspaces: OrderedSet<String> = []

--- a/Sources/AppBundle/config/parseConfig.swift
+++ b/Sources/AppBundle/config/parseConfig.swift
@@ -113,6 +113,7 @@ private let configParser: [String: any ParserProtocol<Config>] = [
     "start-at-login": Parser(\.startAtLogin, parseBool),
     "auto-reload-config": Parser(\.autoReloadConfig, parseBool),
     "automatically-unhide-macos-hidden-apps": Parser(\.automaticallyUnhideMacosHiddenApps, parseBool),
+    "automatically-unhide-macos-hidden-apps-exceptions": Parser(\.automaticallyUnhideMacosHiddenAppsExceptions, parseAutomaticallyUnhideMacosHiddenAppsExceptions),
     "accordion-padding": Parser(\.accordionPadding, parseInt),
     persistentWorkspacesKey: Parser(\.persistentWorkspaces, parsePersistentWorkspaces),
     "exec-on-workspace-change": Parser(\.execOnWorkspaceChange, parseArrayOfStrings),
@@ -245,6 +246,13 @@ func tomlAnyToParsedConfigRecursive(any: Any, _ backtrace: ConfigBacktrace) -> P
             .toOrderedSet()
     }
 
+    if !config.automaticallyUnhideMacosHiddenApps && !config.automaticallyUnhideMacosHiddenAppsExceptions.isEmpty {
+        errors += [.semantic(
+            .rootKey("automatically-unhide-macos-hidden-apps-exceptions"),
+            "'automatically-unhide-macos-hidden-apps-exceptions' is meaningful only when 'automatically-unhide-macos-hidden-apps' is true",
+        )]
+    }
+
     if config.enableNormalizationFlattenContainers {
         let containsSplitCommand = config.modes.values.lazy.flatMap { $0.bindings.values }
             .flatMap { $0.commands }
@@ -343,6 +351,10 @@ private func parseLayout(_ raw: Json, _ backtrace: ConfigBacktrace) -> ParsedCon
 
 private func skipParsing<T: Sendable>(_ value: T) -> @Sendable (_ raw: Json, _ backtrace: ConfigBacktrace) -> ParsedConfig<T> {
     { _, _ in .success(value) }
+}
+
+private func parseAutomaticallyUnhideMacosHiddenAppsExceptions(_ raw: Json, _ backtrace: ConfigBacktrace) -> ParsedConfig<Set<String>> {
+    parseArrayOfStrings(raw, backtrace).map { Set($0) }
 }
 
 private func parsePersistentWorkspaces(_ raw: Json, _ backtrace: ConfigBacktrace) -> ParsedConfig<OrderedSet<String>> {

--- a/Sources/AppBundle/normalizeLayoutReason.swift
+++ b/Sources/AppBundle/normalizeLayoutReason.swift
@@ -26,7 +26,8 @@ private func _normalizeLayoutReason(workspace: Workspace, windows: [Window]) asy
         let isMacosFullscreen = try await window.isMacosFullscreen
         let isMacosMinimized = try await (!isMacosFullscreen).andAsync { @MainActor @Sendable in try await window.isMacosMinimized }
         let isMacosWindowOfHiddenApp = !isMacosFullscreen && !isMacosMinimized &&
-            !config.automaticallyUnhideMacosHiddenApps && window.macAppUnsafe.nsApp.isHidden
+            window.macAppUnsafe.nsApp.isHidden &&
+            (!config.automaticallyUnhideMacosHiddenApps || window.macAppUnsafe.isExcludedFromAutoUnhide)
         switch window.layoutReason {
             case .standard:
                 guard let parent = window.parent else { continue }

--- a/Sources/AppBundle/tree/AbstractApp.swift
+++ b/Sources/AppBundle/tree/AbstractApp.swift
@@ -29,3 +29,11 @@ extension AbstractApp {
 extension Window {
     var macAppUnsafe: MacApp { app as! MacApp }
 }
+
+extension AbstractApp {
+    @MainActor
+    var isExcludedFromAutoUnhide: Bool {
+        guard let bundleId = rawAppBundleId else { return false }
+        return config.automaticallyUnhideMacosHiddenAppsExceptions.contains(bundleId)
+    }
+}

--- a/Sources/AppBundleTests/config/ConfigTest.swift
+++ b/Sources/AppBundleTests/config/ConfigTest.swift
@@ -56,6 +56,52 @@ final class ConfigTest: XCTestCase {
         assertEquals(errors, ["persistent-workspaces: This config option is only available since \'config-version = 2\'"])
     }
 
+    func testParseAutomaticallyUnhideMacosHiddenAppsExceptions() {
+        let (config, errors) = parseConfig(
+            """
+            automatically-unhide-macos-hidden-apps = true
+            automatically-unhide-macos-hidden-apps-exceptions = ['com.hnc.Discord', 'com.ubnt.UniFi']
+            """,
+        )
+        assertEquals(errors, [])
+        assertEquals(config.automaticallyUnhideMacosHiddenAppsExceptions, ["com.hnc.Discord", "com.ubnt.UniFi"])
+    }
+
+    func testAutomaticallyUnhideMacosHiddenAppsExceptionsRequiresAutoUnhideEnabled() {
+        let (_, errors) = parseConfig(
+            """
+            automatically-unhide-macos-hidden-apps-exceptions = ['com.hnc.Discord']
+            """,
+        )
+        assertEquals(
+            errors,
+            ["automatically-unhide-macos-hidden-apps-exceptions: 'automatically-unhide-macos-hidden-apps-exceptions' is meaningful only when 'automatically-unhide-macos-hidden-apps' is true"],
+        )
+    }
+
+    func testAutomaticallyUnhideMacosHiddenAppsExceptionsTypeError() {
+        let (_, errors) = parseConfig(
+            """
+            automatically-unhide-macos-hidden-apps = true
+            automatically-unhide-macos-hidden-apps-exceptions = ['com.hnc.Discord', 1]
+            """,
+        )
+        assertEquals(
+            errors,
+            ["automatically-unhide-macos-hidden-apps-exceptions[1]: Expected type is \'string\'. But actual type is \'int\'"],
+        )
+    }
+
+    func testEmptyExceptionsListWithAutoUnhideDisabledIsAllowed() {
+        let (_, errors) = parseConfig(
+            """
+            automatically-unhide-macos-hidden-apps = false
+            automatically-unhide-macos-hidden-apps-exceptions = []
+            """,
+        )
+        assertEquals(errors, [])
+    }
+
     func testQueryCantBeUsedInConfig() {
         let (_, errors) = parseConfig(
             """

--- a/docs/config-examples/default-config.toml
+++ b/docs/config-examples/default-config.toml
@@ -45,6 +45,14 @@ on-focused-monitor-changed = ['move-mouse monitor-lazy-center']
 # Also see: https://nikitabobko.github.io/AeroSpace/goodies#disable-hide-app
 automatically-unhide-macos-hidden-apps = false
 
+# Bundle IDs that are excluded from `automatically-unhide-macos-hidden-apps`.
+# Useful for apps that misuse "hide application" to close windows
+# (e.g. Discord, Raycast, UniFi Network).
+# Specifying a non-empty list while `automatically-unhide-macos-hidden-apps = false`
+# is a config error.
+# Fallback value (if you omit the key): automatically-unhide-macos-hidden-apps-exceptions = []
+automatically-unhide-macos-hidden-apps-exceptions = []
+
 # List of workspaces that should stay alive even when they contain no windows,
 # even when they are invisible.
 # This config option is only available since 'config-version = 2'

--- a/docs/goodies.adoc
+++ b/docs/goodies.adoc
@@ -220,6 +220,22 @@ If `automatically-unhide-macos-hidden-apps` isn't enough, you can disable `cmd-h
     cmd-alt-h = [] # Disable "hide others"
 ----
 
+[#unhide-exceptions]
+== Exclude misbehaving apps from `automatically-unhide-macos-hidden-apps`
+
+Some apps (such as Discord, Raycast, or the UniFi Network app) misuse macOS "hide application" feature to close their windows. With `automatically-unhide-macos-hidden-apps = true` they would keep popping back up immediately. Use `automatically-unhide-macos-hidden-apps-exceptions` to list bundle IDs that should remain hidden:
+
+.~/.aerospace.toml
+[source,toml]
+----
+automatically-unhide-macos-hidden-apps = true
+automatically-unhide-macos-hidden-apps-exceptions = [
+    'com.hnc.Discord',
+    'com.raycast.macos',
+    'com.ubnt.unifiac',
+]
+----
+
 [#screenshoot-shortcut]
 == Take screenshots to clipboard using keyboard shortcut
 


### PR DESCRIPTION
Some apps misuse the macOS "hide application" feature as their close- window shortcut: Discord on cmd-W, Raycast on its toggle hotkey, the UniFi Network app, and others. With
`automatically-unhide-macos-hidden-apps = true` the user gets the convenience of preserving workspace assignment when they intentionally cmd-h, but those misbehaving apps then keep popping back up on every cmd-W — the close intent is silently inverted.

Until now the only workarounds were to either disable auto-unhide globally (loses workspace preservation for well-behaved apps) or to move the offending apps to a dedicated "hide" workspace.

Add a per-bundle-id exclusion list, exactly as proposed in the issue:

    automatically-unhide-macos-hidden-apps = true
    automatically-unhide-macos-hidden-apps-exceptions = ['com.hnc.Discord']

Apps in the list are skipped by `GlobalObserver.onHideApp`'s unhide loop, are excluded from the count of hidden apps that drives the "single-hidden -> force focus" branch, and have their windows kept in `MacosHiddenAppsWindowsContainer` by `normalizeLayoutReason` even when auto-unhide is on. They therefore behave as if auto-unhide were off, while every other app keeps the auto-unhide convenience.

Specifying a non-empty exceptions list while
`automatically-unhide-macos-hidden-apps = false` is reported as a config error, as called out in the issue — it would have no effect and is almost certainly a misconfiguration.

Closes #1041

## PR checklist

- [x] Explain your changes in the relevant commit messages rather than in the PR description. The PR description must not contain more information than the commit messages (except for images and other media).
- [x] Each commit must explain what/why/how and motivation in its description. https://cbea.ms/git-commit/
- [x] Don't forget to link the appropriate issues/discussions in commit messages (if applicable).
- [x] Each commit must be an atomic change (a PR may contain several commits). Don't introduce new functional changes together with refactorings in the same commit.
- [x] `./test.sh` exits with non-zero exit code.
- [x] Avoid merge commits, always rebase and force push.

Failure to follow the checklist with no apparent reasons will result in silent PR rejection.
