### PR TITLE
Don't pick hidden-app windows when picking focus

### DIFF
--- a/Sources/AppBundle/focus.swift
+++ b/Sources/AppBundle/focus.swift
@@ -93,7 +93,11 @@ extension Workspace {
     func toLiveFocus() -> LiveFocus {
         // todo unfortunately mostRecentWindowRecursive may recursively reach empty rootTilingContainer
         //      while floating or macos unconventional windows might be presented
-        if let wd = mostRecentWindowRecursive ?? anyLeafWindowRecursive {
+        // Skip windows of macOS-hidden apps. Focusing them would `nsApp.activate()` and force-unhide,
+        // which is what users with `automatically-unhide-macos-hidden-apps = false` (or with the app in
+        // `automatically-unhide-macos-hidden-apps-exceptions`) explicitly want to avoid.
+        // https://github.com/nikitabobko/AeroSpace/issues/503
+        if let wd = mostRecentFocusableWindowRecursive ?? anyFocusableLeafWindowRecursive {
             LiveFocus(windowOrNil: wd, workspace: self)
         } else {
             LiveFocus(windowOrNil: nil, workspace: self) // emptyWorkspace

--- a/Sources/AppBundle/tree/TreeNodeEx.swift
+++ b/Sources/AppBundle/tree/TreeNodeEx.swift
@@ -61,6 +61,27 @@ extension TreeNode {
         return nil
     }
 
+    /// Like `mostRecentWindowRecursive`, but skips windows of macOS-hidden apps.
+    /// Focusing such windows would `nsApp.activate()` the hidden app and force-unhide it.
+    /// See https://github.com/nikitabobko/AeroSpace/issues/503
+    var mostRecentFocusableWindowRecursive: Window? {
+        if self is MacosHiddenAppsWindowsContainer { return nil }
+        return self as? Window ?? mostRecentChild?.mostRecentFocusableWindowRecursive
+    }
+
+    var anyFocusableLeafWindowRecursive: Window? {
+        if self is MacosHiddenAppsWindowsContainer { return nil }
+        if let window = self as? Window {
+            return window
+        }
+        for child in children {
+            if let window = child.anyFocusableLeafWindowRecursive {
+                return window
+            }
+        }
+        return nil
+    }
+
     // Doesn't contain at least one window
     var isEffectivelyEmpty: Bool {
         anyLeafWindowRecursive == nil

--- a/Sources/AppBundleTests/tree/TreeNodeTest.swift
+++ b/Sources/AppBundleTests/tree/TreeNodeTest.swift
@@ -72,6 +72,24 @@ final class TreeNodeTest: XCTestCase {
         assertEquals(workspace.rootTilingContainer.children.count, 0)
     }
 
+    func testToLiveFocusSkipsHiddenAppWindows() {
+        // https://github.com/nikitabobko/AeroSpace/issues/503
+        // Focusing a window in MacosHiddenAppsWindowsContainer would call nsApp.activate()
+        // which force-unhides the app — the exact thing the user wanted to avoid.
+        let workspace = Workspace.get(byName: name)
+        TestWindow.new(id: 1, parent: workspace.macOsNativeHiddenAppsWindowsContainer)
+
+        XCTAssertNil(workspace.toLiveFocus().windowOrNil, "Hidden-app windows must not be focus targets")
+    }
+
+    func testToLiveFocusPrefersVisibleOverHidden() {
+        let workspace = Workspace.get(byName: name)
+        TestWindow.new(id: 1, parent: workspace.macOsNativeHiddenAppsWindowsContainer)
+        TestWindow.new(id: 2, parent: workspace.rootTilingContainer)
+
+        assertEquals(workspace.toLiveFocus().windowOrNil?.windowId, 2)
+    }
+
     func testNormalizeContainers_flattenContainers() {
         let workspace = Workspace.get(byName: name) // Don't cache root node
         workspace.rootTilingContainer.apply {


### PR DESCRIPTION
Switching back to a workspace whose only windows belong to a "hide-on- close" app (Discord, UniFi Network, ...) made the just-hidden window pop back up — even with `automatically-unhide-macos-hidden-apps = false`, which is supposed to leave hidden apps alone.

The trigger lives in `Workspace.toLiveFocus()`, which falls back from `mostRecentWindowRecursive` to `anyLeafWindowRecursive`. Both walk every child of the workspace, including `MacosHiddenAppsWindowsContainer`. When that container is the only place that has windows, the picked focus target is a hidden-app window. The surrounding refresh session then runs `nativeFocus()` on it, which calls `nsApp.activate()`. macOS treats activation of a hidden app as an unhide request, so the window comes back and the user's setting is silently ignored.

Add `mostRecentFocusableWindowRecursive` and
`anyFocusableLeafWindowRecursive` that short-circuit when they reach a `MacosHiddenAppsWindowsContainer`, and switch `toLiveFocus()` to use them. The other call sites of the original variants — focus tracking, MRU bookkeeping in commands, binding-data computation — are left alone because they don't activate the returned window and therefore don't exhibit the same problem.

Refs #503

## PR checklist

- [x] Explain your changes in the relevant commit messages rather than in the PR description. The PR description must not contain more information than the commit messages (except for images and other media).
- [x] Each commit must explain what/why/how and motivation in its description. https://cbea.ms/git-commit/
- [x] Don't forget to link the appropriate issues/discussions in commit messages (if applicable).
- [x] Each commit must be an atomic change (a PR may contain several commits). Don't introduce new functional changes together with refactorings in the same commit.
- [x] `./test.sh` exits with non-zero exit code.
- [x] Avoid merge commits, always rebase and force push.

Failure to follow the checklist with no apparent reasons will result in silent PR rejection.
