### PR TITLE
Treat Emacs floating child frames as popups

### DIFF
--- a/Sources/AppBundle/model/AxUiElementWindowType.swift
+++ b/Sources/AppBundle/model/AxUiElementWindowType.swift
@@ -17,6 +17,10 @@ enum AxUiElementWindowType: String {
 
 // Covered by tests in ./axDumps in the repo root
 extension AxUiElementMock {
+    private func isEmacsFloatingChildFrame(_ id: KnownBundleId?) -> Bool {
+        id == .emacs && get(Ax.subroleAttr) == kAXFloatingWindowSubrole
+    }
+
     // 'isDialogHeuristic' function name is referenced in the guide
     func isDialogHeuristic(
         _ id: KnownBundleId?,
@@ -30,6 +34,12 @@ extension AxUiElementMock {
 
         if id == .iphonesimulator {
             return true
+        }
+
+        // Emacs child frames (posframe, lsp-ui-doc, etc.) are regular windows from AX
+        // perspective, but they are transient UI surfaces that should stay unmanaged.
+        if isEmacsFloatingChildFrame(id) {
+            return false
         }
 
         // Don't tile:
@@ -116,6 +126,10 @@ extension AxUiElementMock {
         // https://github.com/nikitabobko/AeroSpace/issues/103
         // https://github.com/ghostty-org/ghostty/discussions/3512
         if id == .ghostty && get(Ax.identifierAttr) == "com.mitchellh.ghostty.quickTerminal" {
+            return false
+        }
+
+        if isEmacsFloatingChildFrame(id) {
             return false
         }
 

--- a/Sources/AppBundle/util/AxUiElementMock.swift
+++ b/Sources/AppBundle/util/AxUiElementMock.swift
@@ -1,5 +1,4 @@
 import AppKit
-import Common
 
 /// Alternative name: AttrAddressibleStorage
 protocol AxUiElementMock {

--- a/Sources/AppBundleTests/AxUiElementWindowTypeTest.swift
+++ b/Sources/AppBundleTests/AxUiElementWindowTypeTest.swift
@@ -6,6 +6,38 @@ final class AxWindowKindTest: XCTestCase {
     func test() throws {
         try checkAxDumpsRecursive(projectRoot.appending(path: "./axDumps"))
     }
+
+    func testEmacsFloatingChildFrameIsPopup() {
+        let window = syntheticWindow(
+            windowId: 11964,
+            subrole: kAXFloatingWindowSubrole,
+            title: "CodexChildFrame",
+        )
+        let app = syntheticApp(focusedWindowId: 11963)
+
+        XCTAssertEqual(
+            window.getWindowType(axApp: app, .emacs, .regular, .normalWindow),
+            .popup,
+        )
+        XCTAssertEqual(window.isDialogHeuristic(.emacs, .normalWindow), false)
+    }
+
+    func testEmacsStandardWindowRemainsWindow() {
+        let window = syntheticWindow(
+            windowId: 11963,
+            subrole: kAXStandardWindowSubrole,
+            title: "Emacs  —  (182 × 58)",
+            isFocused: true,
+            isMain: true,
+        )
+        let app = syntheticApp(focusedWindowId: 11963)
+
+        XCTAssertEqual(
+            window.getWindowType(axApp: app, .emacs, .regular, .normalWindow),
+            .window,
+        )
+        XCTAssertEqual(window.isDialogHeuristic(.emacs, .normalWindow), false)
+    }
 }
 
 func checkAxDumpsRecursive(_ dir: URL) throws {
@@ -33,6 +65,36 @@ func checkAxDumpsRecursive(_ dir: URL) throws {
             additionalMsg: "\(file.path()):0:0: AxUiElementWindowType_isDialogHeuristic doesn't match",
         )
     }
+}
+
+private func syntheticWindow(
+    windowId: UInt32,
+    subrole: String,
+    title: String,
+    isFocused: Bool = false,
+    isMain: Bool = false,
+) -> [String: Json] {
+    [
+        kAXAeroSynthetic: .bool(true),
+        "Aero.axWindowId": .int(windowId),
+        kAXSubroleAttribute: .string(subrole),
+        kAXTitleAttribute: .string(title),
+        kAXFocusedAttribute: .bool(isFocused),
+        kAXMainAttribute: .bool(isMain),
+        kAXCloseButtonAttribute: .null,
+        kAXFullScreenButtonAttribute: .null,
+        kAXZoomButtonAttribute: .null,
+        kAXMinimizeButtonAttribute: .null,
+    ]
+}
+
+private func syntheticApp(focusedWindowId: UInt32) -> [String: Json] {
+    [
+        kAXAeroSynthetic: .bool(true),
+        kAXFocusedWindowAttribute: .string(
+            "AXUIElement(AxWindowId=\(focusedWindowId), title=\"Emacs\", role=\"AXWindow\", subrole=\"AXStandardWindow\")",
+        ),
+    ]
 }
 
 extension [String: Json]: AxUiElementMock {


### PR DESCRIPTION
Emacs child frames such as posframe and vertico-posframe can be reported by AX as windows with AXSubrole =
AXFloatingWindow.

AeroSpace previously treated non-standard Emacs AX windows as dialogs, which made transient Emacs UI get managed as
normal layout content.

Detect org.gnu.Emacs floating child frames before the generic dialog and window heuristics and classify them as popups
instead. Keep standard Emacs windows classified as normal windows.

Tested with:
- swift build --disable-sandbox
- live vertico-posframe smoke test

## PR checklist

- [x] Explain your changes in the relevant commit messages rather than in the PR description. The PR description must not contain more information than the commit messages (except for images and other media).
- [x] Each commit must explain what/why/how and motivation in its description. https://cbea.ms/git-commit/
- [x] Don't forget to link the appropriate issues/discussions in commit messages (if applicable).
- [x] Each commit must be an atomic change (a PR may contain several commits). Don't introduce new functional changes together with refactorings in the same commit.
- [ ] `./test.sh` exits with non-zero exit code.
- [x] Avoid merge commits, always rebase and force push.

Failure to follow the checklist with no apparent reasons will result in silent PR rejection.
