### PR TITLE
Add support for `app-id-regex-substring` in `on-window-detected` configuration

### DIFF
--- a/Sources/AppBundle/config/parseOnWindowDetected.swift
+++ b/Sources/AppBundle/config/parseOnWindowDetected.swift
@@ -26,6 +26,7 @@ struct WindowDetectedCallback: ConvenienceCopyable, Equatable {
 
 struct WindowDetectedCallbackMatcher: ConvenienceCopyable, Equatable {
     var appId: String?
+    var appIdRegexSubstring: CaseInsensitiveRegex?
     var appNameRegexSubstring: CaseInsensitiveRegex?
     var windowTitleRegexSubstring: CaseInsensitiveRegex?
     var workspace: String?
@@ -35,6 +36,9 @@ struct WindowDetectedCallbackMatcher: ConvenienceCopyable, Equatable {
         var resultParts: [String] = []
         if let appId {
             resultParts.append("appId=\"\(appId)\"")
+        }
+        if let appIdRegexSubstring {
+            resultParts.append("appIdRegexSubstring=\"\(appIdRegexSubstring.origin)\"")
         }
         if let appNameRegexSubstring {
             resultParts.append("appNameRegexSubstring=\"\(appNameRegexSubstring.origin)\"")
@@ -61,8 +65,9 @@ private let windowDetectedParser: [String: any ParserProtocol<WindowDetectedCall
 private let matcherParsers: [String: any ParserProtocol<WindowDetectedCallbackMatcher>] = [
     "app-id": Parser(\.appId, upcast(parseString)),
     "workspace": Parser(\.workspace, upcast(parseString)),
-    "app-name-regex-substring": Parser(\.appNameRegexSubstring, upcast(parseCasInsensitiveRegex)),
-    "window-title-regex-substring": Parser(\.windowTitleRegexSubstring, upcast(parseCasInsensitiveRegex)),
+    "app-id-regex-substring": Parser(\.appIdRegexSubstring, upcast(parseCaseInsensitiveRegex)),
+    "app-name-regex-substring": Parser(\.appNameRegexSubstring, upcast(parseCaseInsensitiveRegex)),
+    "window-title-regex-substring": Parser(\.windowTitleRegexSubstring, upcast(parseCaseInsensitiveRegex)),
     "during-aerospace-startup": Parser(\.duringAeroSpaceStartup, upcast(parseBool)),
 ]
 
@@ -81,7 +86,7 @@ func parseOnWindowDetectedArray(_ raw: Json, _ backtrace: ConfigBacktrace, _ err
     }
 }
 
-private func parseCasInsensitiveRegex(_ raw: Json, _ backtrace: ConfigBacktrace) -> ParsedConfig<CaseInsensitiveRegex> {
+private func parseCaseInsensitiveRegex(_ raw: Json, _ backtrace: ConfigBacktrace) -> ParsedConfig<CaseInsensitiveRegex> {
     parseString(raw, backtrace).flatMap { CaseInsensitiveRegex.new($0).toParsedConfig(backtrace) }
 }
 

--- a/Sources/AppBundle/tree/MacWindow.swift
+++ b/Sources/AppBundle/tree/MacWindow.swift
@@ -279,6 +279,9 @@ extension WindowDetectedCallback {
         if let appId = matcher.appId, appId != window.app.rawAppBundleId {
             return false
         }
+        if let regex = matcher.appIdRegexSubstring, !(window.app.rawAppBundleId ?? "").contains(caseInsensitiveRegex: regex) {
+            return false
+        }
         if let regex = matcher.appNameRegexSubstring, !(window.app.name ?? "").contains(caseInsensitiveRegex: regex) {
             return false
         }

--- a/docs/guide.adoc
+++ b/docs/guide.adoc
@@ -478,6 +478,7 @@ Here is a showcase example that uses all the possible configurations:
 ----
 [[on-window-detected]]
     if.app-id = 'com.apple.systempreferences'
+    if.app-id-regex-substring = '^com\.apple\..+$'
     if.app-name-regex-substring = 'settings'
     if.window-title-regex-substring = 'substring'
     if.workspace = 'workspace-name'
@@ -502,6 +503,9 @@ Available window conditions are:
 
 |`if.app-id`
 |Application ID exact match of the detected window
+
+|`if.app-id-regex-substring`
+|Application ID case insensitive regex substring of the detected window
 
 |`if.app-name-regex-substring`
 |Application name case insensitive regex substring of the detected window


### PR DESCRIPTION
- Introduced `appIdRegexSubstring` to `WindowDetectedCallbackMatcher` for regex matching of application IDs.
- Updated parsing logic to handle the new regex substring.
- Updated documentation to include usage examples for the new configuration option.
- Fixed typo in `parseCaseInsensitiveRegex` function

## PR checklist

- [x] Explain your changes in the relevant commit messages rather than in the PR description. The PR description must not contain more information than the commit messages (except for images and other media).
- [x] Each commit must explain what/why/how and motivation in its description. https://cbea.ms/git-commit/
- [ ] Don't forget to link the appropriate issues/discussions in commit messages (if applicable).
- [x] Each commit must be an atomic change (a PR may contain several commits). Don't introduce new functional changes together with refactorings in the same commit.
- [ ] `./test.sh` exits with non-zero exit code.
- [x] Avoid merge commits, always rebase and force push.

Failure to follow the checklist with no apparent reasons will result in silent PR rejection.
