### PR TITLE
Performance: throttle failed app registration retries

### DIFF
--- a/Sources/AppBundle/tree/MacApp.swift
+++ b/Sources/AppBundle/tree/MacApp.swift
@@ -26,6 +26,8 @@ final class MacApp: AbstractApp {
     //      and make deinitialization automatic in deinit
     @MainActor static var allAppsMap: [pid_t: MacApp] = [:]
     @MainActor private static var wipPids: [pid_t: AwaitableOneTimeBroadcastLatch] = [:]
+    @MainActor private static var failedRegistrationRetryAfter: [pid_t: Date] = [:]
+    private static let failedRegistrationRetryDelay: TimeInterval = 5
 
     private init(_ nsApp: NSRunningApplication, _ axApp: AXUIElement, _ axSubscriptions: [AxSubscription], _ thread: Thread) {
         self.nsApp = nsApp
@@ -50,6 +52,10 @@ final class MacApp: AbstractApp {
 
         while true {
             if let existing = allAppsMap[pid] { return existing }
+            if let retryAfter = failedRegistrationRetryAfter[pid] {
+                if retryAfter > Date() { return nil }
+                failedRegistrationRetryAfter[pid] = nil
+            }
             try checkCancellation()
             if let wip = wipPids[pid] {
                 try await wip.await()
@@ -69,7 +75,12 @@ final class MacApp: AbstractApp {
                     let isGood = !subscriptions.isEmpty
                     let app = isGood ? MacApp(nsApp, axApp, subscriptions, Thread.current) : nil
                     Task { @MainActor in
-                        allAppsMap[pid] = app
+                        if let app {
+                            allAppsMap[pid] = app
+                            failedRegistrationRetryAfter[pid] = nil
+                        } else {
+                            failedRegistrationRetryAfter[pid] = Date().addingTimeInterval(failedRegistrationRetryDelay)
+                        }
                         await wip.signalToAll()
                         wipPids[pid] = nil
                     }
@@ -300,7 +311,10 @@ final class MacApp: AbstractApp {
     }
 
     private func destroy() async {
-        _ = await Task { @MainActor [pid] in _ = MacApp.allAppsMap.removeValue(forKey: pid) }.result
+        _ = await Task { @MainActor [pid] in
+            _ = MacApp.allAppsMap.removeValue(forKey: pid)
+            MacApp.failedRegistrationRetryAfter[pid] = nil
+        }.result
         for (_, job) in setFrameJobs {
             job.cancel()
         }


### PR DESCRIPTION
## Summary

- add a short negative retry cache for failed AX app registrations in `MacApp.getOrRegister`
- clear the retry cache when registration later succeeds
- clear the retry cache when an app is destroyed/unregistered

## Context

Potential bug discussion: https://github.com/nikitabobko/AeroSpace/discussions/2084

The observed CPU spike came from repeatedly creating short-lived `AxAppThread` instances for an app whose AX subscription registration failed, seen locally as thousands of `AxAppThread PID: 797 ID: com.apple.dock` entries in a sample.

This PR is intentionally separate from #2048 and does not include any custom-app, AeroMux, or local config changes.

## Validation

- `git diff --check origin/main...HEAD`
- `./build-debug.sh -Xswiftc -warnings-as-errors`
- `make swift-test`
- `./test.sh`

Local live validation from the discussion:

- before fix: `avg=57.8%`, `max=67.8%`, `high50=257/300`
- after fix without helper polling: `avg=0.9%`, `max=23.7%`, `high50=0/180`
- after fix with helper polling: `avg=9.5%`, `max=35.6%`, `high50=0/120`

Prepared with Codex under my supervision.