### PR TITLE
feat: support per-workspace gaps

### DIFF
--- a/Sources/AppBundle/GlobalObserver.swift
+++ b/Sources/AppBundle/GlobalObserver.swift
@@ -44,6 +44,26 @@ enum GlobalObserver {
     }
 
     @MainActor
+    fileprivate static func joinDraggedIntoTarget(
+        dragged: Window,
+        target: Window,
+        targetParent: TilingContainer,
+        cfg: MouseDragJoinConfig,
+        mouseLocation: CGPoint,
+    ) {
+        let after: Bool = if let rect = target.lastAppliedLayoutPhysicalRect {
+            mouseLocation.getProjection(targetParent.orientation) >= rect.center.getProjection(targetParent.orientation)
+        } else {
+            true
+        }
+        dragged.unbindFromParent()
+        let targetIndex = target.ownIndex.orDie()
+        dragged.bind(to: targetParent, adaptiveWeight: WEIGHT_AUTO, index: after ? targetIndex + 1 : targetIndex)
+        targetParent.layout = cfg.layout
+        targetParent.changeOrientation(cfg.orientation)
+    }
+
+    @MainActor
     static func initObserver() {
         let nc = NSWorkspace.shared.notificationCenter
         nc.addObserver(forName: NSWorkspace.didLaunchApplicationNotification, object: nil, queue: .main, using: onNotif)
@@ -53,14 +73,31 @@ enum GlobalObserver {
         nc.addObserver(forName: NSWorkspace.activeSpaceDidChangeNotification, object: nil, queue: .main, using: onNotif)
         nc.addObserver(forName: NSWorkspace.didTerminateApplicationNotification, object: nil, queue: .main, using: onNotif)
 
-        NSEvent.addGlobalMonitorForEvents(matching: .leftMouseUp) { _ in
+        NSEvent.addGlobalMonitorForEvents(matching: .leftMouseUp) { event in
             // todo reduce number of refreshSession in the callback
             //  resetManipulatedWithMouseIfPossible might call its own refreshSession
             //  The end of the callback calls refreshSession
+            let modifierFlags = event.modifierFlags
             Task { @MainActor in
                 guard let token: RunSessionGuard = .isServerEnabled else { return }
+                let draggedWindowId = currentlyManipulatedWithMouseWindowId
                 try await resetManipulatedWithMouseIfPossible()
                 let mouseLocation = mouseLocation
+                if let cfg = config.mouseDragJoin,
+                   modifierFlags.contains(cfg.modifier),
+                   let id = draggedWindowId,
+                   let dragged = Window.get(byId: id)
+                {
+                    let targetWorkspace = mouseLocation.monitorApproximation.activeWorkspace
+                    if let target = mouseLocation.findIn(tree: targetWorkspace.rootTilingContainer, virtual: false)?.takeIf({ $0 != dragged }),
+                       let targetParent = target.parent as? TilingContainer
+                    {
+                        _ = try await runLightSession(.globalObserverLeftMouseUp, token) {
+                            joinDraggedIntoTarget(dragged: dragged, target: target, targetParent: targetParent, cfg: cfg, mouseLocation: mouseLocation)
+                        }
+                        return
+                    }
+                }
                 let clickedMonitor = mouseLocation.monitorApproximation
                 switch true {
                     // Detect clicks on desktop of different monitors

--- a/Sources/AppBundle/GlobalObserver.swift
+++ b/Sources/AppBundle/GlobalObserver.swift
@@ -51,16 +51,26 @@ enum GlobalObserver {
         cfg: MouseDragJoinConfig,
         mouseLocation: CGPoint,
     ) {
+        // Decide before/after using the target's pre-drop center, since the target
+        // hasn't moved during an Alt-drag (the swap path was suppressed).
         let after: Bool = if let rect = target.lastAppliedLayoutPhysicalRect {
-            mouseLocation.getProjection(targetParent.orientation) >= rect.center.getProjection(targetParent.orientation)
+            mouseLocation.getProjection(cfg.orientation) >= rect.center.getProjection(cfg.orientation)
         } else {
             true
         }
+        // Detach dragged first so its old container can later be flattened by
+        // normalization without interfering with target's index computation.
         dragged.unbindFromParent()
-        let targetIndex = target.ownIndex.orDie()
-        dragged.bind(to: targetParent, adaptiveWeight: WEIGHT_AUTO, index: after ? targetIndex + 1 : targetIndex)
-        targetParent.layout = cfg.layout
-        targetParent.changeOrientation(cfg.orientation)
+        let targetBinding = target.unbindFromParent()
+        let newContainer = TilingContainer(
+            parent: targetParent,
+            adaptiveWeight: targetBinding.adaptiveWeight,
+            cfg.orientation,
+            cfg.layout,
+            index: targetBinding.index,
+        )
+        target.bind(to: newContainer, adaptiveWeight: WEIGHT_AUTO, index: 0)
+        dragged.bind(to: newContainer, adaptiveWeight: WEIGHT_AUTO, index: after ? 1 : 0)
     }
 
     @MainActor

--- a/Sources/AppBundle/command/impl/MacosNativeFullscreenCommand.swift
+++ b/Sources/AppBundle/command/impl/MacosNativeFullscreenCommand.swift
@@ -37,8 +37,8 @@ struct MacosNativeFullscreenCommand: Command {
             window.bind(to: workspace.macOsNativeFullscreenWindowsContainer, adaptiveWeight: 1, index: INDEX_BIND_LAST)
         } else { // Exit fullscreen
             switch window.layoutReason {
-                case .macos(let prevParentKind):
-                    try await exitMacOsNativeUnconventionalState(window: window, prevParentKind: prevParentKind, workspace: workspace)
+                case .macos(let prev):
+                    try await exitMacOsNativeUnconventionalState(window: window, prev: prev, workspace: workspace)
                 default:
                     try await window.relayoutWindow(on: workspace)
             }

--- a/Sources/AppBundle/config/Config.swift
+++ b/Sources/AppBundle/config/Config.swift
@@ -60,8 +60,14 @@ struct Config: ConvenienceCopyable {
     var modes: [String: Mode] = [:]
     var onWindowDetected: [WindowDetectedCallback] = []
     var onModeChanged: [any Command] = []
+    var pairNewWindowWithFocused: PairNewWindowWithFocused = .disabled
 }
 
 enum DefaultContainerOrientation: String {
     case horizontal, vertical, auto
+}
+
+enum PairNewWindowWithFocused: Equatable, Sendable {
+    case disabled
+    case wrap(orientation: Orientation, layout: Layout)
 }

--- a/Sources/AppBundle/config/Config.swift
+++ b/Sources/AppBundle/config/Config.swift
@@ -61,6 +61,7 @@ struct Config: ConvenienceCopyable {
     var onWindowDetected: [WindowDetectedCallback] = []
     var onModeChanged: [any Command] = []
     var pairNewWindowWithFocused: PairNewWindowWithFocused = .disabled
+    var mouseDragJoin: MouseDragJoinConfig? = nil
 }
 
 enum DefaultContainerOrientation: String {
@@ -70,4 +71,10 @@ enum DefaultContainerOrientation: String {
 enum PairNewWindowWithFocused: Equatable, Sendable {
     case disabled
     case wrap(orientation: Orientation, layout: Layout)
+}
+
+struct MouseDragJoinConfig: ConvenienceCopyable, Equatable {
+    var modifier: NSEvent.ModifierFlags
+    var orientation: Orientation
+    var layout: Layout
 }

--- a/Sources/AppBundle/config/DynamicConfigValue.swift
+++ b/Sources/AppBundle/config/DynamicConfigValue.swift
@@ -6,14 +6,21 @@ struct PerMonitorValue<Value: Equatable>: Equatable {
 }
 extension PerMonitorValue: Sendable where Value: Sendable {}
 
+struct PerWorkspaceValue<Value: Equatable>: Equatable {
+    let workspaceName: String
+    let value: Value
+}
+extension PerWorkspaceValue: Sendable where Value: Sendable {}
+
 enum DynamicConfigValue<Value: Equatable>: Equatable {
     case constant(Value)
     case perMonitor([PerMonitorValue<Value>], default: Value)
+    case perWorkspace([PerWorkspaceValue<Value>], default: Value)
 }
 extension DynamicConfigValue: Sendable where Value: Sendable {}
 
 extension DynamicConfigValue {
-    @MainActor func getValue(for monitor: any Monitor) -> Value {
+    @MainActor func getValue(for monitor: any Monitor, workspace: String? = nil) -> Value {
         switch self {
             case .constant(let value): return value
             case .perMonitor(let array, let defaultValue):
@@ -26,6 +33,9 @@ extension DynamicConfigValue {
                             : nil
                     }
                     .first ?? defaultValue
+            case .perWorkspace(let array, let defaultValue):
+                guard let workspace else { return defaultValue }
+                return array.first { $0.workspaceName == workspace }?.value ?? defaultValue
         }
     }
 }
@@ -51,16 +61,48 @@ func parseDynamicValue<T>(
         }
 
         if array.dropLast().isEmpty {
-            errors.append(.semantic(backtrace, "The array must contain at least one monitor pattern"))
+            errors.append(.semantic(backtrace, "The array must contain at least one monitor or workspace pattern"))
             return .constant(fallback)
         }
 
-        let rules: [PerMonitorValue<T>] = parsePerMonitorValues(array.dropLast(), backtrace, &errors)
-
-        return .perMonitor(rules, default: defaultValue)
+        let rules = Array(array.dropLast())
+        if let first = rules.first, first.asDictOrNil?.keys.contains("workspace") == true {
+            let workspaceRules: [PerWorkspaceValue<T>] = parsePerWorkspaceValues(rules, backtrace, &errors)
+            return .perWorkspace(workspaceRules, default: defaultValue)
+        } else {
+            let monitorRules: [PerMonitorValue<T>] = parsePerMonitorValues(rules, backtrace, &errors)
+            return .perMonitor(monitorRules, default: defaultValue)
+        }
     } else {
         errors.append(.semantic(backtrace, "Unsupported type: \(raw.tomlType), expected: \(valueType) or array"))
         return .constant(fallback)
+    }
+}
+
+func parsePerWorkspaceValues<T>(_ array: Json.JsonArray, _ backtrace: ConfigBacktrace, _ errors: inout [ConfigParseError]) -> [PerWorkspaceValue<T>] {
+    array.enumerated().compactMap { (index: Int, raw: Json) -> PerWorkspaceValue<T>? in
+        var backtrace = backtrace + .index(index)
+
+        guard let (workspaceName, value) = raw.unwrapTableWithSingleKey(expectedKey: "workspace", &backtrace)
+            .flatMap({ $0.value.unwrapTableWithSingleKey(expectedKey: nil, &backtrace) })
+            .getOrNil(appendErrorTo: &errors)
+        else {
+            return nil
+        }
+
+        switch WorkspaceName.parse(workspaceName) {
+            case .failure(let err):
+                errors.append(.semantic(backtrace, err))
+                return nil
+            case .success: break
+        }
+
+        guard let value = parseSimpleType(value, ofType: T.self) else {
+            errors.append(.semantic(backtrace, "Expected type is '\(T.self)'. But actual type is '\(value.tomlType)'"))
+            return nil
+        }
+
+        return PerWorkspaceValue(workspaceName: workspaceName, value: value)
     }
 }
 

--- a/Sources/AppBundle/config/parseConfig.swift
+++ b/Sources/AppBundle/config/parseConfig.swift
@@ -111,6 +111,7 @@ private let configParser: [String: any ParserProtocol<Config>] = [
     "default-root-container-orientation": Parser(\.defaultRootContainerOrientation, parseDefaultContainerOrientation),
 
     "pair-new-window-with-focused": Parser(\.pairNewWindowWithFocused, parsePairNewWindowWithFocused),
+    "mouse-drag-join": Parser(\.mouseDragJoin, parseMouseDragJoin),
 
     "start-at-login": Parser(\.startAtLogin, parseBool),
     "auto-reload-config": Parser(\.autoReloadConfig, parseBool),
@@ -254,6 +255,13 @@ func tomlAnyToParsedConfigRecursive(any: Any, _ backtrace: ConfigBacktrace) -> P
         )]
     }
 
+    if config.mouseDragJoin != nil && config.enableNormalizationOppositeOrientationForNestedContainers {
+        errors += [.semantic(
+            .rootKey("mouse-drag-join"),
+            "'mouse-drag-join' requires 'enable-normalization-opposite-orientation-for-nested-containers = false', because changing a container's orientation cascades up the tree when this normalization is enabled.",
+        )]
+    }
+
     if config.enableNormalizationFlattenContainers {
         let containsSplitCommand = config.modes.values.lazy.flatMap { $0.bindings.values }
             .flatMap { $0.commands }
@@ -379,14 +387,52 @@ private func parseDefaultContainerOrientation(_ raw: Json, _ backtrace: ConfigBa
 }
 
 private func parsePairNewWindowWithFocused(_ raw: Json, _ backtrace: ConfigBacktrace) -> ParsedConfig<PairNewWindowWithFocused> {
-    parseString(raw, backtrace).flatMap { str in
-        switch str {
-            case "disabled": .success(.disabled)
-            case "h_accordion", "h-accordion": .success(.wrap(orientation: .h, layout: .accordion))
-            case "v_accordion", "v-accordion": .success(.wrap(orientation: .v, layout: .accordion))
-            case "h_tiles", "h-tiles", "h_list", "h-list": .success(.wrap(orientation: .h, layout: .tiles))
-            case "v_tiles", "v-tiles", "v_list", "v-list": .success(.wrap(orientation: .v, layout: .tiles))
-            default: .failure(.semantic(backtrace, "Can't parse '\(str)'. Possible values: disabled|h_accordion|v_accordion|h_tiles|v_tiles"))
+    parseString(raw, backtrace).flatMap { str -> ParsedConfig<PairNewWindowWithFocused> in
+        if str == "disabled" { return .success(.disabled) }
+        guard let (orientation, layout) = parseOrientedLayout(str) else {
+            return .failure(.semantic(backtrace, "Can't parse '\(str)'. Possible values: disabled|h_accordion|v_accordion|h_tiles|v_tiles"))
+        }
+        return .success(.wrap(orientation: orientation, layout: layout))
+    }
+}
+
+private func parseOrientedLayout(_ str: String) -> (Orientation, Layout)? {
+    switch str {
+        case "h_accordion", "h-accordion": (.h, .accordion)
+        case "v_accordion", "v-accordion": (.v, .accordion)
+        case "h_tiles", "h-tiles", "h_list", "h-list": (.h, .tiles)
+        case "v_tiles", "v-tiles", "v_list", "v-list": (.v, .tiles)
+        default: nil
+    }
+}
+
+private func parseMouseDragJoin(_ raw: Json, _ backtrace: ConfigBacktrace) -> ParsedConfig<MouseDragJoinConfig?> {
+    guard let dict = raw.asDictOrNil else {
+        return .failure(expectedActualTypeError(expected: .table, actual: raw.tomlType, backtrace))
+    }
+    var allowedKeys = Set(["modifier", "layout"])
+    for key in dict.keys where !allowedKeys.contains(key) {
+        return .failure(unknownKeyError(backtrace + .key(key)))
+    }
+    guard let modifierRaw = dict["modifier"] else {
+        return .failure(.semantic(backtrace, "Missing required key 'modifier'"))
+    }
+    guard let layoutRaw = dict["layout"] else {
+        return .failure(.semantic(backtrace, "Missing required key 'layout'"))
+    }
+    let modifierResult = parseString(modifierRaw, backtrace + .key("modifier")).flatMap { str in
+        modifiersMap[str].map { ParsedConfig<NSEvent.ModifierFlags>.success($0) }
+            ?? .failure(.semantic(backtrace + .key("modifier"), "Can't parse modifier '\(str)'. Possible values: \(modifiersMap.keys.sorted().joined(separator: "|"))"))
+    }
+    let layoutResult = parseString(layoutRaw, backtrace + .key("layout")).flatMap { str -> ParsedConfig<(Orientation, Layout)> in
+        if let pair = parseOrientedLayout(str) {
+            return .success(pair)
+        }
+        return .failure(.semantic(backtrace + .key("layout"), "Can't parse '\(str)'. Possible values: h_accordion|v_accordion|h_tiles|v_tiles"))
+    }
+    return modifierResult.flatMap { modifier in
+        layoutResult.map { (orientation, layout) in
+            MouseDragJoinConfig(modifier: modifier, orientation: orientation, layout: layout)
         }
     }
 }

--- a/Sources/AppBundle/config/parseConfig.swift
+++ b/Sources/AppBundle/config/parseConfig.swift
@@ -110,6 +110,8 @@ private let configParser: [String: any ParserProtocol<Config>] = [
     "default-root-container-layout": Parser(\.defaultRootContainerLayout, parseLayout),
     "default-root-container-orientation": Parser(\.defaultRootContainerOrientation, parseDefaultContainerOrientation),
 
+    "pair-new-window-with-focused": Parser(\.pairNewWindowWithFocused, parsePairNewWindowWithFocused),
+
     "start-at-login": Parser(\.startAtLogin, parseBool),
     "auto-reload-config": Parser(\.autoReloadConfig, parseBool),
     "automatically-unhide-macos-hidden-apps": Parser(\.automaticallyUnhideMacosHiddenApps, parseBool),
@@ -245,6 +247,13 @@ func tomlAnyToParsedConfigRecursive(any: Any, _ backtrace: ConfigBacktrace) -> P
             .toOrderedSet()
     }
 
+    if config.pairNewWindowWithFocused != .disabled && config.enableNormalizationOppositeOrientationForNestedContainers {
+        errors += [.semantic(
+            .rootKey("pair-new-window-with-focused"),
+            "'pair-new-window-with-focused' requires 'enable-normalization-opposite-orientation-for-nested-containers = false', because the normalization may flip the orientation of the newly created container right after it is built.",
+        )]
+    }
+
     if config.enableNormalizationFlattenContainers {
         let containsSplitCommand = config.modes.values.lazy.flatMap { $0.bindings.values }
             .flatMap { $0.commands }
@@ -366,6 +375,19 @@ private func parseDefaultContainerOrientation(_ raw: Json, _ backtrace: ConfigBa
     parseString(raw, backtrace).flatMap {
         DefaultContainerOrientation(rawValue: $0)
             .orFailure(.semantic(backtrace, "Can't parse default container orientation '\($0)'"))
+    }
+}
+
+private func parsePairNewWindowWithFocused(_ raw: Json, _ backtrace: ConfigBacktrace) -> ParsedConfig<PairNewWindowWithFocused> {
+    parseString(raw, backtrace).flatMap { str in
+        switch str {
+            case "disabled": .success(.disabled)
+            case "h_accordion", "h-accordion": .success(.wrap(orientation: .h, layout: .accordion))
+            case "v_accordion", "v-accordion": .success(.wrap(orientation: .v, layout: .accordion))
+            case "h_tiles", "h-tiles", "h_list", "h-list": .success(.wrap(orientation: .h, layout: .tiles))
+            case "v_tiles", "v-tiles", "v_list", "v-list": .success(.wrap(orientation: .v, layout: .tiles))
+            default: .failure(.semantic(backtrace, "Can't parse '\(str)'. Possible values: disabled|h_accordion|v_accordion|h_tiles|v_tiles"))
+        }
     }
 }
 

--- a/Sources/AppBundle/config/parseGaps.swift
+++ b/Sources/AppBundle/config/parseGaps.swift
@@ -67,17 +67,17 @@ struct ResolvedGaps {
         let right: Int
     }
 
-    @MainActor init(gaps: Gaps, monitor: any Monitor) {
+    @MainActor init(gaps: Gaps, monitor: any Monitor, workspace: String? = nil) {
         inner = .init(
-            vertical: gaps.inner.vertical.getValue(for: monitor),
-            horizontal: gaps.inner.horizontal.getValue(for: monitor),
+            vertical: gaps.inner.vertical.getValue(for: monitor, workspace: workspace),
+            horizontal: gaps.inner.horizontal.getValue(for: monitor, workspace: workspace),
         )
 
         outer = .init(
-            left: gaps.outer.left.getValue(for: monitor),
-            bottom: gaps.outer.bottom.getValue(for: monitor),
-            top: gaps.outer.top.getValue(for: monitor),
-            right: gaps.outer.right.getValue(for: monitor),
+            left: gaps.outer.left.getValue(for: monitor, workspace: workspace),
+            bottom: gaps.outer.bottom.getValue(for: monitor, workspace: workspace),
+            top: gaps.outer.top.getValue(for: monitor, workspace: workspace),
+            right: gaps.outer.right.getValue(for: monitor, workspace: workspace),
         )
     }
 }

--- a/Sources/AppBundle/layout/layoutRecursive.swift
+++ b/Sources/AppBundle/layout/layoutRecursive.swift
@@ -4,7 +4,7 @@ extension Workspace {
     @MainActor
     func layoutWorkspace() async throws {
         if isEffectivelyEmpty { return }
-        let rect = workspaceMonitor.visibleRectPaddedByOuterGaps
+        let rect = workspaceMonitor.visibleRectPaddedByOuterGapsForWorkspace(name)
         // If monitors are aligned vertically and the monitor below has smaller width, then macOS may not allow the
         // window on the upper monitor to take full width. rect.height - 1 resolves this problem
         // But I also faced this problem in monitors horizontal configuration. ¯\_(ツ)_/¯
@@ -61,7 +61,7 @@ private struct LayoutContext {
     @MainActor
     init(_ workspace: Workspace) {
         self.workspace = workspace
-        self.resolvedGaps = ResolvedGaps(gaps: config.gaps, monitor: workspace.workspaceMonitor)
+        self.resolvedGaps = ResolvedGaps(gaps: config.gaps, monitor: workspace.workspaceMonitor, workspace: workspace.name)
     }
 }
 

--- a/Sources/AppBundle/layout/refresh.swift
+++ b/Sources/AppBundle/layout/refresh.swift
@@ -119,6 +119,14 @@ func refreshModel() {
     normalizeContainers()
 }
 
+/// One refresh of tolerance before garbage-collecting a window. macOS AX
+/// briefly returns nil for `containingWindowId()` of unrelated windows while
+/// another app enters or exits native fullscreen; without tolerance the
+/// refresh loop would gc those windows and the next refresh would re-register
+/// them as brand new, scrambling tile order via pair-new-window-with-focused.
+@MainActor private var missingRefreshCount: [UInt32: Int] = [:]
+private let gcTolerance = 1
+
 @MainActor
 private func refresh() async throws {
     // Garbage collect terminated apps and windows before working with all windows
@@ -127,7 +135,15 @@ private func refresh() async throws {
 
     for window in MacWindow.allWindows {
         if !aliveWindowIds.contains(window.windowId) {
-            window.garbageCollect(skipClosedWindowsCache: false)
+            let count = (missingRefreshCount[window.windowId] ?? 0) + 1
+            if count > gcTolerance {
+                missingRefreshCount.removeValue(forKey: window.windowId)
+                window.garbageCollect(skipClosedWindowsCache: false)
+            } else {
+                missingRefreshCount[window.windowId] = count
+            }
+        } else {
+            missingRefreshCount.removeValue(forKey: window.windowId)
         }
     }
     for (app, windowIds) in mapping {

--- a/Sources/AppBundle/layout/refresh.swift
+++ b/Sources/AppBundle/layout/refresh.swift
@@ -119,13 +119,18 @@ func refreshModel() {
     normalizeContainers()
 }
 
-/// One refresh of tolerance before garbage-collecting a window. macOS AX
-/// briefly returns nil for `containingWindowId()` of unrelated windows while
-/// another app enters or exits native fullscreen; without tolerance the
-/// refresh loop would gc those windows and the next refresh would re-register
-/// them as brand new, scrambling tile order via pair-new-window-with-focused.
-@MainActor private var missingRefreshCount: [UInt32: Int] = [:]
-private let gcTolerance = 1
+/// Last time we saw each known window alive. macOS AX returns nil for
+/// `containingWindowId()` on unrelated windows for the entire duration of
+/// another app's native fullscreen transition -- often several refresh cycles.
+/// Without tolerance the refresh loop gc's them, the next refresh
+/// re-registers them as brand new, and pair-new-window-with-focused wraps
+/// them in an h_accordion container with whatever was MRU.
+@MainActor private var lastSeenAlive: [UInt32: Date] = [:]
+/// Tolerate a window being briefly absent for this long before garbage-
+/// collecting it. Covers the entire macOS fullscreen-transition animation
+/// plus a margin; significantly shorter than the user could deliberately
+/// close-and-reopen a window.
+private let gcGracePeriod: TimeInterval = 8.0
 
 @MainActor
 private func refresh() async throws {
@@ -133,17 +138,16 @@ private func refresh() async throws {
     let mapping = try await MacApp.refreshAllAndGetAliveWindowIds(frontmostAppBundleId: NSWorkspace.shared.frontmostApplication?.bundleIdentifier)
     let aliveWindowIds = mapping.values.flatMap(id).toSet()
 
+    let now = Date.now
     for window in MacWindow.allWindows {
-        if !aliveWindowIds.contains(window.windowId) {
-            let count = (missingRefreshCount[window.windowId] ?? 0) + 1
-            if count > gcTolerance {
-                missingRefreshCount.removeValue(forKey: window.windowId)
-                window.garbageCollect(skipClosedWindowsCache: false)
-            } else {
-                missingRefreshCount[window.windowId] = count
-            }
-        } else {
-            missingRefreshCount.removeValue(forKey: window.windowId)
+        if aliveWindowIds.contains(window.windowId) {
+            lastSeenAlive[window.windowId] = now
+            continue
+        }
+        let lastSeen = lastSeenAlive[window.windowId] ?? .distantPast
+        if lastSeen.distance(to: now) > gcGracePeriod {
+            lastSeenAlive.removeValue(forKey: window.windowId)
+            window.garbageCollect(skipClosedWindowsCache: false)
         }
     }
     for (app, windowIds) in mapping {

--- a/Sources/AppBundle/model/KnownBundleId.swift
+++ b/Sources/AppBundle/model/KnownBundleId.swift
@@ -8,6 +8,7 @@ enum KnownBundleId: String, Equatable {
     case cleanshotx = "pl.maketheweb.cleanshotx"
     case emacs = "org.gnu.Emacs"
     case finder = "com.apple.finder"
+    case fork = "com.DanPristupov.Fork"
     case ghostty = "com.mitchellh.ghostty"
     case gimp = "org.gimp.gimp-2.10"
     case iphonesimulator = "com.apple.iphonesimulator"
@@ -39,5 +40,13 @@ enum KnownBundleId: String, Equatable {
 
     var isVscode: Bool {
         self == .vscode || self == .vscodium
+    }
+
+    /// True for apps that expose each native macOS tab as a separate AXWindow whose
+    /// AX object stays valid after the tab is hidden. AeroSpace must trust the app's
+    /// `AXWindows` (rather than the per-element `containingWindowId()`) to know which
+    /// tabs are actually visible right now.
+    var hasTabsAsWindows: Bool {
+        self == .fork || self == .ghostty
     }
 }

--- a/Sources/AppBundle/model/MonitorEx.swift
+++ b/Sources/AppBundle/model/MonitorEx.swift
@@ -1,8 +1,13 @@
 extension Monitor {
     @MainActor
     var visibleRectPaddedByOuterGaps: Rect {
+        visibleRectPaddedByOuterGapsForWorkspace(nil)
+    }
+
+    @MainActor
+    func visibleRectPaddedByOuterGapsForWorkspace(_ workspace: String?) -> Rect {
         let topLeft = visibleRect.topLeftCorner
-        let gaps = ResolvedGaps(gaps: config.gaps, monitor: self)
+        let gaps = ResolvedGaps(gaps: config.gaps, monitor: self, workspace: workspace)
         return Rect(
             topLeftX: topLeft.x + gaps.outer.left.toDouble(),
             topLeftY: topLeft.y + gaps.outer.top.toDouble(),

--- a/Sources/AppBundle/mouse/moveWithMouse.swift
+++ b/Sources/AppBundle/mouse/moveWithMouse.swift
@@ -51,6 +51,13 @@ private func moveFloatingWindow(_ window: Window) async throws {
 private func moveTilingWindow(_ window: Window) {
     currentlyManipulatedWithMouseWindowId = window.windowId
     window.lastAppliedLayoutPhysicalRect = nil
+    // When the join modifier is held, defer all tree updates until mouseUp so the
+    // user can preview the drop without continuous swaps reshuffling the layout.
+    if let joinModifier = config.mouseDragJoin?.modifier,
+       NSEvent.modifierFlags.contains(joinModifier)
+    {
+        return
+    }
     let mouseLocation = mouseLocation
     let targetWorkspace = mouseLocation.monitorApproximation.activeWorkspace
     let swapTarget = mouseLocation.findIn(tree: targetWorkspace.rootTilingContainer, virtual: false)?.takeIf { $0 != window }

--- a/Sources/AppBundle/normalizeLayoutReason.swift
+++ b/Sources/AppBundle/normalizeLayoutReason.swift
@@ -1,3 +1,5 @@
+import CoreGraphics
+
 @MainActor
 func normalizeLayoutReason() async throws {
     for workspace in Workspace.all {
@@ -29,31 +31,50 @@ private func _normalizeLayoutReason(workspace: Workspace, windows: [Window]) asy
             !config.automaticallyUnhideMacosHiddenApps && window.macAppUnsafe.nsApp.isHidden
         switch window.layoutReason {
             case .standard:
-                guard let parent = window.parent else { continue }
+                guard window.parent != nil else { continue }
                 switch true {
                     case isMacosFullscreen:
-                        window.layoutReason = .macos(prevParentKind: parent.kind)
-                        window.bind(to: workspace.macOsNativeFullscreenWindowsContainer, adaptiveWeight: WEIGHT_DOESNT_MATTER, index: INDEX_BIND_LAST)
+                        enterMacOsUnconventionalState(window: window, newParent: workspace.macOsNativeFullscreenWindowsContainer, newWeight: WEIGHT_DOESNT_MATTER)
                     case isMacosMinimized:
-                        window.layoutReason = .macos(prevParentKind: parent.kind)
-                        window.bind(to: macosMinimizedWindowsContainer, adaptiveWeight: 1, index: INDEX_BIND_LAST)
+                        enterMacOsUnconventionalState(window: window, newParent: macosMinimizedWindowsContainer, newWeight: 1)
                     case isMacosWindowOfHiddenApp:
-                        window.layoutReason = .macos(prevParentKind: parent.kind)
-                        window.bind(to: workspace.macOsNativeHiddenAppsWindowsContainer, adaptiveWeight: WEIGHT_DOESNT_MATTER, index: INDEX_BIND_LAST)
+                        enterMacOsUnconventionalState(window: window, newParent: workspace.macOsNativeHiddenAppsWindowsContainer, newWeight: WEIGHT_DOESNT_MATTER)
                     default: break
                 }
-            case .macos(let prevParentKind):
+            case .macos(let prev):
                 if !isMacosFullscreen && !isMacosMinimized && !isMacosWindowOfHiddenApp {
-                    try await exitMacOsNativeUnconventionalState(window: window, prevParentKind: prevParentKind, workspace: workspace)
+                    try await exitMacOsNativeUnconventionalState(window: window, prev: prev, workspace: workspace)
                 }
         }
     }
 }
 
 @MainActor
-func exitMacOsNativeUnconventionalState(window: Window, prevParentKind: NonLeafTreeNodeKind, workspace: Workspace) async throws {
+private func enterMacOsUnconventionalState(window: Window, newParent: NonLeafTreeNodeObject, newWeight: CGFloat) {
+    guard let oldParent = window.parent, let oldIndex = window.ownIndex else { return }
+    let oldWeight: CGFloat = (oldParent as? TilingContainer)
+        .map { window.getWeight($0.orientation) } ?? WEIGHT_DOESNT_MATTER
+    window.layoutReason = .macos(prev: MacosPrev(parent: oldParent, index: oldIndex, adaptiveWeight: oldWeight))
+    window.bind(to: newParent, adaptiveWeight: newWeight, index: INDEX_BIND_LAST)
+}
+
+@MainActor
+func exitMacOsNativeUnconventionalState(window: Window, prev: MacosPrev, workspace: Workspace) async throws {
     window.layoutReason = .standard
-    switch prevParentKind {
+
+    // Preferred path: restore to the exact container the window came from, at the
+    // same slot. This preserves nested splits the user set up before fullscreen.
+    if let prevParent = prev.parent, prevParent.nodeWorkspace === workspace {
+        window.unbindFromParent()
+        let clampedIndex = min(prev.index, prevParent.children.count)
+        window.bind(to: prevParent, adaptiveWeight: prev.adaptiveWeight, index: clampedIndex)
+        return
+    }
+
+    // Fallback: previous parent was gc'd (e.g. flattened away while the window
+    // was fullscreen) or moved to another workspace. Use the previous kind to
+    // pick a reasonable destination.
+    switch prev.parentKind {
         case .workspace:
             window.bindAsFloatingWindow(to: workspace)
         case .tilingContainer:

--- a/Sources/AppBundle/normalizeLayoutReason.swift
+++ b/Sources/AppBundle/normalizeLayoutReason.swift
@@ -71,13 +71,17 @@ func exitMacOsNativeUnconventionalState(window: Window, prev: MacosPrev, workspa
     // same slot. This preserves nested splits the user set up before fullscreen.
     if let prevParent = prev.parent, prevParent.nodeWorkspace === workspace {
         window.unbindFromParent()
-        let clampedIndex = min(prev.index, prevParent.children.count)
+        // Sibling anchors are more robust than the raw saved index because the
+        // parent's children list may have shifted while the window was in the
+        // unconventional container (e.g., another sibling briefly gc'd and
+        // re-registered, or another sibling also entered and exited fullscreen).
+        let restoreIndex = prev.resolveIndex(in: prevParent)
         // Use WEIGHT_AUTO so the window picks up the current average sibling weight.
         // Saving prev.adaptiveWeight is wrong because while this window was in the
         // unconventional container, its siblings' weights were rebalanced to fill
         // the freed space; restoring the old absolute weight makes this window
         // noticeably smaller than its siblings after the rebalance.
-        window.bind(to: prevParent, adaptiveWeight: WEIGHT_AUTO, index: clampedIndex)
+        window.bind(to: prevParent, adaptiveWeight: WEIGHT_AUTO, index: restoreIndex)
         // Same reason as in enterMacOsUnconventionalState: the cached world from when
         // this window was still in the unconventional container is now stale and
         // would re-float this window if restoration fires.

--- a/Sources/AppBundle/normalizeLayoutReason.swift
+++ b/Sources/AppBundle/normalizeLayoutReason.swift
@@ -56,6 +56,11 @@ private func enterMacOsUnconventionalState(window: Window, newParent: NonLeafTre
         .map { window.getWeight($0.orientation) } ?? WEIGHT_DOESNT_MATTER
     window.layoutReason = .macos(prev: MacosPrev(parent: oldParent, index: oldIndex, adaptiveWeight: oldWeight))
     window.bind(to: newParent, adaptiveWeight: newWeight, index: INDEX_BIND_LAST)
+    // The layout just changed: any cached "world" from earlier (which would mark
+    // this window as still-tiled) is now stale and would re-tile this window if
+    // restoration fires for unrelated reasons (e.g. transient browser popup gets
+    // gc'd and re-registered).
+    resetClosedWindowsCache()
 }
 
 @MainActor
@@ -67,9 +72,19 @@ func exitMacOsNativeUnconventionalState(window: Window, prev: MacosPrev, workspa
     if let prevParent = prev.parent, prevParent.nodeWorkspace === workspace {
         window.unbindFromParent()
         let clampedIndex = min(prev.index, prevParent.children.count)
-        window.bind(to: prevParent, adaptiveWeight: prev.adaptiveWeight, index: clampedIndex)
+        // Use WEIGHT_AUTO so the window picks up the current average sibling weight.
+        // Saving prev.adaptiveWeight is wrong because while this window was in the
+        // unconventional container, its siblings' weights were rebalanced to fill
+        // the freed space; restoring the old absolute weight makes this window
+        // noticeably smaller than its siblings after the rebalance.
+        window.bind(to: prevParent, adaptiveWeight: WEIGHT_AUTO, index: clampedIndex)
+        // Same reason as in enterMacOsUnconventionalState: the cached world from when
+        // this window was still in the unconventional container is now stale and
+        // would re-float this window if restoration fires.
+        resetClosedWindowsCache()
         return
     }
+    resetClosedWindowsCache()
 
     // Fallback: previous parent was gc'd (e.g. flattened away while the window
     // was fullscreen) or moved to another workspace. Use the previous kind to

--- a/Sources/AppBundle/normalizeLayoutReason.swift
+++ b/Sources/AppBundle/normalizeLayoutReason.swift
@@ -24,6 +24,14 @@ private func validateStillPopups() async throws {
 
 @MainActor
 private func _normalizeLayoutReason(workspace: Workspace, windows: [Window]) async throws {
+    // Collect transitions first so we can run the exits in the saved-index
+    // order. When two siblings of the same tiling container come back from
+    // unconventional state in the same refresh (e.g. one was fullscreened and
+    // the other got hidden because macOS hides non-fullscreen apps), the
+    // leftmost one must rebind first or the second one's anchor look-up will
+    // collide with the first and the two will swap.
+    var exits: [(window: Window, prev: MacosPrev)] = []
+    var enters: [() -> Void] = []
     for window in windows {
         let isMacosFullscreen = try await window.isMacosFullscreen
         let isMacosMinimized = try await (!isMacosFullscreen).andAsync { @MainActor @Sendable in try await window.isMacosMinimized }
@@ -34,18 +42,26 @@ private func _normalizeLayoutReason(workspace: Workspace, windows: [Window]) asy
                 guard window.parent != nil else { continue }
                 switch true {
                     case isMacosFullscreen:
-                        enterMacOsUnconventionalState(window: window, newParent: workspace.macOsNativeFullscreenWindowsContainer, newWeight: WEIGHT_DOESNT_MATTER)
+                        enters.append { enterMacOsUnconventionalState(window: window, newParent: workspace.macOsNativeFullscreenWindowsContainer, newWeight: WEIGHT_DOESNT_MATTER) }
                     case isMacosMinimized:
-                        enterMacOsUnconventionalState(window: window, newParent: macosMinimizedWindowsContainer, newWeight: 1)
+                        enters.append { enterMacOsUnconventionalState(window: window, newParent: macosMinimizedWindowsContainer, newWeight: 1) }
                     case isMacosWindowOfHiddenApp:
-                        enterMacOsUnconventionalState(window: window, newParent: workspace.macOsNativeHiddenAppsWindowsContainer, newWeight: WEIGHT_DOESNT_MATTER)
+                        enters.append { enterMacOsUnconventionalState(window: window, newParent: workspace.macOsNativeHiddenAppsWindowsContainer, newWeight: WEIGHT_DOESNT_MATTER) }
                     default: break
                 }
             case .macos(let prev):
                 if !isMacosFullscreen && !isMacosMinimized && !isMacosWindowOfHiddenApp {
-                    try await exitMacOsNativeUnconventionalState(window: window, prev: prev, workspace: workspace)
+                    exits.append((window, prev))
                 }
         }
+    }
+    // Run enters first; later exits are based on the resulting tree.
+    for action in enters { action() }
+    // Exits in saved-index order so adjacent windows rebind left-to-right and
+    // each later exit can anchor against the already-restored earlier ones.
+    exits.sort { $0.prev.index < $1.prev.index }
+    for (window, prev) in exits {
+        try await exitMacOsNativeUnconventionalState(window: window, prev: prev, workspace: workspace)
     }
 }
 

--- a/Sources/AppBundle/tree/MacApp.swift
+++ b/Sources/AppBundle/tree/MacApp.swift
@@ -135,6 +135,10 @@ final class MacApp: AbstractApp {
         for id in staleIds {
             guard let stale = MacWindow.allWindowsMap.removeValue(forKey: id) else { continue }
             let bindingData = stale.unbindFromParent()
+            // Same reason as MacWindow.garbageCollect: if this id comes back as a
+            // re-registration shortly after, restore it to the same slot rather
+            // than treating it as a new window.
+            MacWindow.recordGcdBinding(id, bindingData)
             if inheritedBinding == nil, bindingData.parent is TilingContainer {
                 inheritedBinding = bindingData
             }
@@ -310,6 +314,7 @@ final class MacApp: AbstractApp {
             var alive: [UInt32: AxWindow] = windows.threadGuarded
             var dead = [UInt32: AxWindow]()
             let axWindowsList = axApp.threadGuarded.get(Ax.windowsAttr) ?? []
+            let axWindowsIds = Set(axWindowsList.map(\.windowId))
             // Some apps (e.g. Fork) expose each tab as a separate AXWindow whose AX
             // object stays valid after the tab is hidden, so containingWindowId() alone
             // keeps stale tabs alive. Opt-in: AXWindows excludes windows on inactive Spaces.
@@ -319,14 +324,19 @@ final class MacApp: AbstractApp {
             // the filter would drop the old tab without being able to add the
             // new one and would briefly leave the app with zero tracked windows.
             let trustAxWindowsAsAliveSet: Set<UInt32>? = (appId?.hasTabsAsWindows == true && !isLeftMouseButtonDown)
-                ? Set(axWindowsList.map(\.windowId))
+                ? axWindowsIds
                 : nil
             // Second line of defence against lock screen. See the first line of defence: closedWindowsCache
             // Second and third lines of defence are technically needed only to avoid potential flickering
             if frontmostAppBundleId != lockScreenAppBundleId {
                 (alive, dead) = try alive.partition { (id, window) in
                     try job.checkCancellation()
-                    if window.ax.containingWindowId() == nil { return false }
+                    // `containingWindowId()` transiently returns nil during other apps'
+                    // native fullscreen transitions even for windows that are still
+                    // alive and listed in `axWindowsList`. Treat the window as alive in
+                    // that case to avoid spurious gc + re-register, which scrambles
+                    // tile order via the pair-new-window-with-focused heuristic.
+                    if window.ax.containingWindowId() == nil && !axWindowsIds.contains(id) { return false }
                     if let trustAxWindowsAsAliveSet, !trustAxWindowsAsAliveSet.contains(id) { return false }
                     return true
                 }

--- a/Sources/AppBundle/tree/MacApp.swift
+++ b/Sources/AppBundle/tree/MacApp.swift
@@ -126,10 +126,11 @@ final class MacApp: AbstractApp {
             return (focused.windowId, staleIds)
         }
         guard let (windowId, staleIds) = result else { return nil }
-        // Capture the binding location of the stale MacWindow so the new tab can
-        // inherit the same tile slot. Without this, GCing the old tab and creating
-        // the new one through MRU placement can put the replacement in a different
-        // slot, which the user sees as a layout flicker.
+        // Unbind stale MacWindows and capture one's BindingData so the new tab can
+        // inherit the same tile slot. The full unbind -> bind dance MUST be done
+        // without awaiting anything in between, otherwise the cancellable refresh
+        // task can be cancelled mid-await and leave the workspace tree with a gap
+        // that the user sees as a layout flicker.
         var inheritedBinding: BindingData? = nil
         for id in staleIds {
             guard let stale = MacWindow.allWindowsMap.removeValue(forKey: id) else { continue }
@@ -138,7 +139,10 @@ final class MacApp: AbstractApp {
                 inheritedBinding = bindingData
             }
         }
-        return try await MacWindow.getOrRegister(windowId: windowId, macApp: self, inheritedBinding: inheritedBinding)
+        if let inheritedBinding {
+            return MacWindow.registerWithInheritedBinding(windowId: windowId, macApp: self, binding: inheritedBinding)
+        }
+        return try await MacWindow.getOrRegister(windowId: windowId, macApp: self)
     }
 
     @MainActor func nativeFocus(_ windowId: UInt32) {

--- a/Sources/AppBundle/tree/MacApp.swift
+++ b/Sources/AppBundle/tree/MacApp.swift
@@ -104,10 +104,17 @@ final class MacApp: AbstractApp {
     func getFocusedWindow() async throws -> Window? {
         let result: (UInt32, [UInt32])? = try await thread?.runInLoop { [nsApp, axApp, windows, appId] job in
             guard let focused = try axApp.threadGuarded.get(Ax.focusedWindowAttr) else { return nil }
-            // For tab-based apps (e.g. Fork): atomically prune stale tab AX windows
-            // when the focused tab changes. Without this, the new tab is registered
-            // before the old one is GC'd, briefly producing two MacWindows that
-            // re-tile the workspace and cause a visible layout flicker.
+            // Register the focused window first. If it can't be registered (e.g.
+            // `isLeftMouseButtonDown` makes `getOrRegisterAxWindow` skip new
+            // registrations), bail out without touching anything else.
+            guard try windows.threadGuarded.getOrRegisterAxWindow(windowId: focused.windowId, focused.ax.cast, nsApp, job) != nil else {
+                return nil
+            }
+            // For tab-based apps (e.g. Fork): only after the new focused tab is in
+            // the dict, prune stale tab AX windows. Doing this in the opposite order
+            // would empty the dict during a click (mouse-down skips registration)
+            // and the next refresh would GC the only Fork MacWindow, briefly
+            // collapsing its tile -- which the user sees as a layout flicker.
             var staleIds: [UInt32] = []
             if appId?.hasTabsAsWindows == true {
                 let valid = Set((axApp.threadGuarded.get(Ax.windowsAttr) ?? []).map(\.windowId))
@@ -115,9 +122,6 @@ final class MacApp: AbstractApp {
                 for id in staleIds {
                     windows.threadGuarded.removeValue(forKey: id)
                 }
-            }
-            guard try windows.threadGuarded.getOrRegisterAxWindow(windowId: focused.windowId, focused.ax.cast, nsApp, job) != nil else {
-                return nil
             }
             return (focused.windowId, staleIds)
         }
@@ -305,7 +309,12 @@ final class MacApp: AbstractApp {
             // Some apps (e.g. Fork) expose each tab as a separate AXWindow whose AX
             // object stays valid after the tab is hidden, so containingWindowId() alone
             // keeps stale tabs alive. Opt-in: AXWindows excludes windows on inactive Spaces.
-            let trustAxWindowsAsAliveSet: Set<UInt32>? = appId?.hasTabsAsWindows == true
+            // For tab-based apps, intersect the alive set with `AXWindows`. Skip
+            // this filter while the left mouse button is down: in that state
+            // `getOrRegisterAxWindow` refuses to add new windows, so applying
+            // the filter would drop the old tab without being able to add the
+            // new one and would briefly leave the app with zero tracked windows.
+            let trustAxWindowsAsAliveSet: Set<UInt32>? = (appId?.hasTabsAsWindows == true && !isLeftMouseButtonDown)
                 ? Set(axWindowsList.map(\.windowId))
                 : nil
             // Second line of defence against lock screen. See the first line of defence: closedWindowsCache

--- a/Sources/AppBundle/tree/MacApp.swift
+++ b/Sources/AppBundle/tree/MacApp.swift
@@ -102,13 +102,39 @@ final class MacApp: AbstractApp {
 
     // todo merge together with detectNewWindows
     func getFocusedWindow() async throws -> Window? {
-        let windowId = try await thread?.runInLoop { [nsApp, axApp, windows] job in
-            try axApp.threadGuarded.get(Ax.focusedWindowAttr)
-                .flatMap { try windows.threadGuarded.getOrRegisterAxWindow(windowId: $0.windowId, $0.ax.cast, nsApp, job) }?
-                .windowId
+        let result: (UInt32, [UInt32])? = try await thread?.runInLoop { [nsApp, axApp, windows, appId] job in
+            guard let focused = try axApp.threadGuarded.get(Ax.focusedWindowAttr) else { return nil }
+            // For tab-based apps (e.g. Fork): atomically prune stale tab AX windows
+            // when the focused tab changes. Without this, the new tab is registered
+            // before the old one is GC'd, briefly producing two MacWindows that
+            // re-tile the workspace and cause a visible layout flicker.
+            var staleIds: [UInt32] = []
+            if appId?.hasTabsAsWindows == true {
+                let valid = Set((axApp.threadGuarded.get(Ax.windowsAttr) ?? []).map(\.windowId))
+                staleIds = windows.threadGuarded.keys.filter { !valid.contains($0) && $0 != focused.windowId }
+                for id in staleIds {
+                    windows.threadGuarded.removeValue(forKey: id)
+                }
+            }
+            guard try windows.threadGuarded.getOrRegisterAxWindow(windowId: focused.windowId, focused.ax.cast, nsApp, job) != nil else {
+                return nil
+            }
+            return (focused.windowId, staleIds)
         }
-        guard let windowId else { return nil }
-        return try await MacWindow.getOrRegister(windowId: windowId, macApp: self)
+        guard let (windowId, staleIds) = result else { return nil }
+        // Capture the binding location of the stale MacWindow so the new tab can
+        // inherit the same tile slot. Without this, GCing the old tab and creating
+        // the new one through MRU placement can put the replacement in a different
+        // slot, which the user sees as a layout flicker.
+        var inheritedBinding: BindingData? = nil
+        for id in staleIds {
+            guard let stale = MacWindow.allWindowsMap.removeValue(forKey: id) else { continue }
+            let bindingData = stale.unbindFromParent()
+            if inheritedBinding == nil, bindingData.parent is TilingContainer {
+                inheritedBinding = bindingData
+            }
+        }
+        return try await MacWindow.getOrRegister(windowId: windowId, macApp: self, inheritedBinding: inheritedBinding)
     }
 
     @MainActor func nativeFocus(_ windowId: UInt32) {
@@ -272,19 +298,28 @@ final class MacApp: AbstractApp {
             return []
         }
         guard let thread else { return [] }
-        let (alive, dead) = try await thread.runInLoop { [nsApp, windows, axApp] (job) -> ([UInt32], [UInt32]) in
+        let (alive, dead) = try await thread.runInLoop { [nsApp, windows, axApp, appId] (job) -> ([UInt32], [UInt32]) in
             var alive: [UInt32: AxWindow] = windows.threadGuarded
             var dead = [UInt32: AxWindow]()
+            let axWindowsList = axApp.threadGuarded.get(Ax.windowsAttr) ?? []
+            // Some apps (e.g. Fork) expose each tab as a separate AXWindow whose AX
+            // object stays valid after the tab is hidden, so containingWindowId() alone
+            // keeps stale tabs alive. Opt-in: AXWindows excludes windows on inactive Spaces.
+            let trustAxWindowsAsAliveSet: Set<UInt32>? = appId?.hasTabsAsWindows == true
+                ? Set(axWindowsList.map(\.windowId))
+                : nil
             // Second line of defence against lock screen. See the first line of defence: closedWindowsCache
             // Second and third lines of defence are technically needed only to avoid potential flickering
             if frontmostAppBundleId != lockScreenAppBundleId {
-                (alive, dead) = try alive.partition {
+                (alive, dead) = try alive.partition { (id, window) in
                     try job.checkCancellation()
-                    return $0.value.ax.containingWindowId() != nil
+                    if window.ax.containingWindowId() == nil { return false }
+                    if let trustAxWindowsAsAliveSet, !trustAxWindowsAsAliveSet.contains(id) { return false }
+                    return true
                 }
             }
 
-            for (id, window) in axApp.threadGuarded.get(Ax.windowsAttr) ?? [] {
+            for (id, window) in axWindowsList {
                 try job.checkCancellation()
                 try alive.getOrRegisterAxWindow(windowId: id, window, nsApp, job)
             }

--- a/Sources/AppBundle/tree/MacWindow.swift
+++ b/Sources/AppBundle/tree/MacWindow.swift
@@ -39,6 +39,7 @@ final class MacWindow: Window {
                 ? (rect?.center.monitorApproximation ?? mainMonitor).activeWorkspace
                 : focus.workspace,
             window: nil,
+            isNewWindow: true,
         )
 
         // atomic synchronous section
@@ -215,28 +216,49 @@ extension Window {
     @MainActor
     func relayoutWindow(on workspace: Workspace, forceTile: Bool = false) async throws {
         let data = forceTile
-            ? unbindAndGetBindingDataForNewTilingWindow(workspace, window: self)
-            : try await unbindAndGetBindingDataForNewWindow(self.asMacWindow().windowId, self.asMacWindow().macApp, workspace, window: self)
+            ? unbindAndGetBindingDataForNewTilingWindow(workspace, window: self, isNewWindow: false)
+            : try await unbindAndGetBindingDataForNewWindow(self.asMacWindow().windowId, self.asMacWindow().macApp, workspace, window: self, isNewWindow: false)
         bind(to: data.parent, adaptiveWeight: data.adaptiveWeight, index: data.index)
     }
 }
 
 // The function is private because it's unsafe. It leaves the window in unbound state
 @MainActor
-private func unbindAndGetBindingDataForNewWindow(_ windowId: UInt32, _ macApp: MacApp, _ workspace: Workspace, window: Window?) async throws -> BindingData {
+private func unbindAndGetBindingDataForNewWindow(_ windowId: UInt32, _ macApp: MacApp, _ workspace: Workspace, window: Window?, isNewWindow: Bool) async throws -> BindingData {
     let windowLevel = getWindowLevel(for: windowId)
     return switch try await macApp.getAxUiElementWindowType(windowId, windowLevel) {
         case .popup: BindingData(parent: macosPopupWindowsContainer, adaptiveWeight: WEIGHT_AUTO, index: INDEX_BIND_LAST)
         case .dialog: BindingData(parent: workspace, adaptiveWeight: WEIGHT_AUTO, index: INDEX_BIND_LAST)
-        case .window: unbindAndGetBindingDataForNewTilingWindow(workspace, window: window)
+        case .window: unbindAndGetBindingDataForNewTilingWindow(workspace, window: window, isNewWindow: isNewWindow)
     }
 }
 
 // The function is private because it's unsafe. It leaves the window in unbound state
 @MainActor
-private func unbindAndGetBindingDataForNewTilingWindow(_ workspace: Workspace, window: Window?) -> BindingData {
+private func unbindAndGetBindingDataForNewTilingWindow(_ workspace: Workspace, window: Window?, isNewWindow: Bool) -> BindingData {
     window?.unbindFromParent() // It's important to unbind to get correct data from below
     let mruWindow = workspace.mostRecentWindowRecursive
+
+    // Wrap the new window together with the MRU (previously focused) window in a fresh
+    // container of the configured layout. The new container takes the MRU's slot in its
+    // original parent, and the MRU + new window become its only children.
+    if isNewWindow,
+       case let .wrap(orientation, layout) = config.pairNewWindowWithFocused,
+       let mruWindow,
+       let mruParent = mruWindow.parent as? TilingContainer
+    {
+        let mruBinding = mruWindow.unbindFromParent()
+        let newContainer = TilingContainer(
+            parent: mruParent,
+            adaptiveWeight: mruBinding.adaptiveWeight,
+            orientation,
+            layout,
+            index: mruBinding.index,
+        )
+        mruWindow.bind(to: newContainer, adaptiveWeight: WEIGHT_AUTO, index: 0)
+        return BindingData(parent: newContainer, adaptiveWeight: WEIGHT_AUTO, index: 1)
+    }
+
     if let mruWindow, let tilingParent = mruWindow.parent as? TilingContainer {
         return BindingData(
             parent: tilingParent,

--- a/Sources/AppBundle/tree/MacWindow.swift
+++ b/Sources/AppBundle/tree/MacWindow.swift
@@ -14,23 +14,32 @@ final class MacWindow: Window {
     @MainActor static var allWindowsMap: [UInt32: MacWindow] = [:]
     @MainActor static var allWindows: [MacWindow] { Array(allWindowsMap.values) }
 
+    /// Synchronous swap-registration used during a tab swap in tab-based apps.
+    /// Doing this without awaits ensures the workspace tree is never observed in a
+    /// "gap" state (between the stale tab being unbound and the new tab being bound),
+    /// which is critical because the refresh task can be cancelled mid-await and
+    /// leave the tree without a tile until the next refresh -- a visible flicker.
+    @MainActor
+    static func registerWithInheritedBinding(windowId: UInt32, macApp: MacApp, binding: BindingData) -> MacWindow {
+        if let existing = allWindowsMap[windowId] { return existing }
+        let window = MacWindow(windowId, macApp, lastFloatingSize: nil, parent: binding.parent, adaptiveWeight: binding.adaptiveWeight, index: binding.index)
+        allWindowsMap[windowId] = window
+        return window
+    }
+
     @MainActor
     @discardableResult
-    static func getOrRegister(windowId: UInt32, macApp: MacApp, inheritedBinding: BindingData? = nil) async throws -> MacWindow {
+    static func getOrRegister(windowId: UInt32, macApp: MacApp) async throws -> MacWindow {
         if let existing = allWindowsMap[windowId] { return existing }
         let rect = try await macApp.getAxRect(windowId)
-        let data: BindingData = if let inheritedBinding {
-            inheritedBinding
-        } else {
-            try await unbindAndGetBindingDataForNewWindow(
-                windowId,
-                macApp,
-                isStartup
-                    ? (rect?.center.monitorApproximation ?? mainMonitor).activeWorkspace
-                    : focus.workspace,
-                window: nil,
-            )
-        }
+        let data = try await unbindAndGetBindingDataForNewWindow(
+            windowId,
+            macApp,
+            isStartup
+                ? (rect?.center.monitorApproximation ?? mainMonitor).activeWorkspace
+                : focus.workspace,
+            window: nil,
+        )
 
         // atomic synchronous section
         if let existing = allWindowsMap[windowId] { return existing }

--- a/Sources/AppBundle/tree/MacWindow.swift
+++ b/Sources/AppBundle/tree/MacWindow.swift
@@ -16,17 +16,21 @@ final class MacWindow: Window {
 
     @MainActor
     @discardableResult
-    static func getOrRegister(windowId: UInt32, macApp: MacApp) async throws -> MacWindow {
+    static func getOrRegister(windowId: UInt32, macApp: MacApp, inheritedBinding: BindingData? = nil) async throws -> MacWindow {
         if let existing = allWindowsMap[windowId] { return existing }
         let rect = try await macApp.getAxRect(windowId)
-        let data = try await unbindAndGetBindingDataForNewWindow(
-            windowId,
-            macApp,
-            isStartup
-                ? (rect?.center.monitorApproximation ?? mainMonitor).activeWorkspace
-                : focus.workspace,
-            window: nil,
-        )
+        let data: BindingData = if let inheritedBinding {
+            inheritedBinding
+        } else {
+            try await unbindAndGetBindingDataForNewWindow(
+                windowId,
+                macApp,
+                isStartup
+                    ? (rect?.center.monitorApproximation ?? mainMonitor).activeWorkspace
+                    : focus.workspace,
+                window: nil,
+            )
+        }
 
         // atomic synchronous section
         if let existing = allWindowsMap[windowId] { return existing }

--- a/Sources/AppBundle/tree/MacWindow.swift
+++ b/Sources/AppBundle/tree/MacWindow.swift
@@ -5,30 +5,52 @@ import Common
 final class RecentBinding {
     weak var parent: NonLeafTreeNodeObject?
     /// `index` is captured at gc time, but the parent's children can shift between
-    /// gc and re-registration (e.g., another sibling enters native fullscreen).
-    /// `prevSiblingWindowId` is a stable anchor: the id of the sibling that was
-    /// immediately before this window. We look it up at restore time and place
-    /// this window right after it, falling back to the saved index if the anchor
-    /// is gone.
+    /// gc and re-registration. Sibling anchors are stable references: the ids of
+    /// the immediate neighbors of this window at gc time. On restore we look them
+    /// up in the parent's current children to insert the window in the same
+    /// relative position. `index` is only a last-resort fallback.
     let index: Int
+    let nextSiblingWindowId: UInt32?
     let prevSiblingWindowId: UInt32?
     let adaptiveWeight: CGFloat
     init(_ binding: BindingData) {
         self.parent = binding.parent
         self.index = binding.index
-        let priorIdx = binding.index - 1
-        self.prevSiblingWindowId = priorIdx >= 0 && priorIdx < binding.parent.children.count
-            ? (binding.parent.children[priorIdx] as? Window)?.windowId
+        // `binding.index` is the slot this window occupied right before being
+        // unbound. The parent's `children` already excludes this window, so
+        // `children[index]` is what was immediately AFTER, and `children[index-1]`
+        // is what was immediately BEFORE.
+        let nextIdx = binding.index
+        let prevIdx = binding.index - 1
+        self.nextSiblingWindowId = nextIdx < binding.parent.children.count
+            ? (binding.parent.children[nextIdx] as? Window)?.windowId
+            : nil
+        self.prevSiblingWindowId = prevIdx >= 0 && prevIdx < binding.parent.children.count
+            ? (binding.parent.children[prevIdx] as? Window)?.windowId
             : nil
         self.adaptiveWeight = binding.adaptiveWeight
     }
 
     @MainActor
     func resolveIndex(in parent: NonLeafTreeNodeObject) -> Int {
-        if let prevId = prevSiblingWindowId,
-           let anchor = parent.children.firstIndex(where: { ($0 as? Window)?.windowId == prevId })
+        // Prefer the next sibling: inserting before it pushes it down and
+        // preserves the ordering of whatever comes after.
+        if let nextId = nextSiblingWindowId,
+           let nextIdx = parent.children.firstIndex(where: { ($0 as? Window)?.windowId == nextId })
         {
-            return anchor + 1
+            return nextIdx
+        }
+        // No next sibling was saved means this window was at the end of its
+        // parent's children at gc time. Insert at the end now -- this avoids
+        // colliding with another restoring sibling whose prev anchor is the
+        // same window as ours.
+        if nextSiblingWindowId == nil {
+            return parent.children.count
+        }
+        if let prevId = prevSiblingWindowId,
+           let prevIdx = parent.children.firstIndex(where: { ($0 as? Window)?.windowId == prevId })
+        {
+            return prevIdx + 1
         }
         return min(index, parent.children.count)
     }

--- a/Sources/AppBundle/tree/MacWindow.swift
+++ b/Sources/AppBundle/tree/MacWindow.swift
@@ -41,9 +41,7 @@ final class RecentBinding {
             return nextIdx
         }
         // No next sibling was saved means this window was at the end of its
-        // parent's children at gc time. Insert at the end now -- this avoids
-        // colliding with another restoring sibling whose prev anchor is the
-        // same window as ours.
+        // parent's children at gc time. Insert at the end now.
         if nextSiblingWindowId == nil {
             return parent.children.count
         }

--- a/Sources/AppBundle/tree/MacWindow.swift
+++ b/Sources/AppBundle/tree/MacWindow.swift
@@ -1,6 +1,39 @@
 import AppKit
 import Common
 
+@MainActor
+final class RecentBinding {
+    weak var parent: NonLeafTreeNodeObject?
+    /// `index` is captured at gc time, but the parent's children can shift between
+    /// gc and re-registration (e.g., another sibling enters native fullscreen).
+    /// `prevSiblingWindowId` is a stable anchor: the id of the sibling that was
+    /// immediately before this window. We look it up at restore time and place
+    /// this window right after it, falling back to the saved index if the anchor
+    /// is gone.
+    let index: Int
+    let prevSiblingWindowId: UInt32?
+    let adaptiveWeight: CGFloat
+    init(_ binding: BindingData) {
+        self.parent = binding.parent
+        self.index = binding.index
+        let priorIdx = binding.index - 1
+        self.prevSiblingWindowId = priorIdx >= 0 && priorIdx < binding.parent.children.count
+            ? (binding.parent.children[priorIdx] as? Window)?.windowId
+            : nil
+        self.adaptiveWeight = binding.adaptiveWeight
+    }
+
+    @MainActor
+    func resolveIndex(in parent: NonLeafTreeNodeObject) -> Int {
+        if let prevId = prevSiblingWindowId,
+           let anchor = parent.children.firstIndex(where: { ($0 as? Window)?.windowId == prevId })
+        {
+            return anchor + 1
+        }
+        return min(index, parent.children.count)
+    }
+}
+
 final class MacWindow: Window {
     let macApp: MacApp
     private var prevUnhiddenProportionalPositionInsideWorkspaceRect: CGPoint?
@@ -13,6 +46,64 @@ final class MacWindow: Window {
 
     @MainActor static var allWindowsMap: [UInt32: MacWindow] = [:]
     @MainActor static var allWindows: [MacWindow] { Array(allWindowsMap.values) }
+
+    /// Window ids that were garbage-collected very recently. Some AX state changes
+    /// (e.g., another app entering native fullscreen) momentarily make a window's
+    /// `containingWindowId()` return nil, so the refresh loop gc's it and then
+    /// re-registers it on the next refresh. Without this set, `getOrRegister`
+    /// would treat the re-registration as a brand-new window and trigger
+    /// `pair-new-window-with-focused`, wrapping the re-registered window in an
+    /// h_accordion container with whatever is MRU -- visually hiding the window.
+    @MainActor static var recentlyGcdAt: [UInt32: Date] = [:]
+    @MainActor static var recentlyGcdBindings: [UInt32: RecentBinding] = [:]
+    /// Longer than typical AX transient (~few seconds) but short enough that the
+    /// bookkeeping doesn't grow unbounded. Window position recovery only matters
+    /// while the window is briefly dead during a fullscreen transition.
+    private static let recentlyGcdWindow: TimeInterval = 60.0
+
+    /// Any window id this AeroSpace instance has ever registered. A windowId
+    /// that's been seen before is by definition not a "new window" -- it's the
+    /// same window returning from a transient AX state. Without this,
+    /// pair-new-window-with-focused triggers for windows that briefly vanish
+    /// during another app's native fullscreen and wraps them in an h_accordion
+    /// container, visually hiding them behind whatever was MRU.
+    @MainActor private static var everSeenWindowIds: Set<UInt32> = []
+    @MainActor static func wasEverSeen(_ windowId: UInt32) -> Bool { everSeenWindowIds.contains(windowId) }
+    @MainActor static func markSeen(_ windowId: UInt32) { everSeenWindowIds.insert(windowId) }
+
+    /// AeroSpace fires multiple refresh sessions back-to-back when it launches:
+    /// some have `isStartup=true`, some don't (AX-event-triggered refreshes that
+    /// ran outside the startup TaskLocal scope). Treat anything within this
+    /// grace window as pre-existing.
+    @MainActor static let aerospaceStartedAt: Date = .now
+    private static let startupGraceWindow: TimeInterval = 5.0
+    @MainActor static var isWithinStartupGrace: Bool {
+        aerospaceStartedAt.distance(to: .now) < startupGraceWindow
+    }
+
+    @MainActor static func wasRecentlyGcd(_ windowId: UInt32) -> Bool {
+        guard let when = recentlyGcdAt[windowId] else { return false }
+        if when.distance(to: .now) > recentlyGcdWindow {
+            recentlyGcdAt.removeValue(forKey: windowId)
+            recentlyGcdBindings.removeValue(forKey: windowId)
+            return false
+        }
+        return true
+    }
+
+    @MainActor static func popRecentlyGcdBinding(_ windowId: UInt32) -> RecentBinding? {
+        guard wasRecentlyGcd(windowId) else { return nil }
+        defer {
+            recentlyGcdAt.removeValue(forKey: windowId)
+            recentlyGcdBindings.removeValue(forKey: windowId)
+        }
+        return recentlyGcdBindings[windowId]
+    }
+
+    @MainActor static func recordGcdBinding(_ windowId: UInt32, _ binding: BindingData) {
+        recentlyGcdAt[windowId] = .now
+        recentlyGcdBindings[windowId] = RecentBinding(binding)
+    }
 
     /// Synchronous swap-registration used during a tab swap in tab-based apps.
     /// Doing this without awaits ensures the workspace tree is never observed in a
@@ -32,6 +123,32 @@ final class MacWindow: Window {
     static func getOrRegister(windowId: UInt32, macApp: MacApp) async throws -> MacWindow {
         if let existing = allWindowsMap[windowId] { return existing }
         let rect = try await macApp.getAxRect(windowId)
+
+        // If this id was gc'd very recently, it's the same window briefly bouncing
+        // through an AX transient state (e.g., another app entering native
+        // fullscreen). Restore it to the exact slot it occupied before, instead
+        // of re-classifying it as a new window and placing it next to the MRU.
+        if let saved = popRecentlyGcdBinding(windowId),
+           let savedParent = saved.parent,
+           savedParent.nodeWorkspace != nil
+        {
+            let window = MacWindow(windowId, macApp, lastFloatingSize: rect?.size, parent: savedParent, adaptiveWeight: WEIGHT_AUTO, index: saved.resolveIndex(in: savedParent))
+            allWindowsMap[windowId] = window
+            markSeen(windowId)
+            return window
+        }
+
+        // Falling back to classification means we don't have a saved binding to
+        // restore from. The window is genuinely new only if all of these are true:
+        //  - AeroSpace is not in startup discovery (TaskLocal or grace window).
+        //  - AeroSpace has never registered this windowId before.
+        // Otherwise it's the same window returning from a transient AX state
+        // (e.g., re-classified during another app's native fullscreen
+        // transition) and we must not run pair-new-window-with-focused on it.
+        let isGenuinelyNew = !isStartup
+            && !MacWindow.isWithinStartupGrace
+            && !MacWindow.wasEverSeen(windowId)
+        MacWindow.markSeen(windowId)
         let data = try await unbindAndGetBindingDataForNewWindow(
             windowId,
             macApp,
@@ -39,7 +156,7 @@ final class MacWindow: Window {
                 ? (rect?.center.monitorApproximation ?? mainMonitor).activeWorkspace
                 : focus.workspace,
             window: nil,
-            isNewWindow: true,
+            isNewWindow: isGenuinelyNew,
         )
 
         // atomic synchronous section
@@ -94,7 +211,12 @@ final class MacWindow: Window {
             return
         }
         if !skipClosedWindowsCache { cacheClosedWindowIfNeeded() }
-        let parent = unbindFromParent().parent
+        let binding = unbindFromParent()
+        let parent = binding.parent
+        // Remember the exact slot so a near-immediate re-registration (transient
+        // AX state, not the user opening a new window) can be placed back in
+        // the same spot rather than being re-classified as a new window.
+        if !skipClosedWindowsCache { MacWindow.recordGcdBinding(windowId, binding) }
         let deadWindowWorkspace = parent.nodeWorkspace
         let focus = focus
         if let deadWindowWorkspace, deadWindowWorkspace == focus.workspace ||

--- a/Sources/AppBundle/tree/TilingContainer.swift
+++ b/Sources/AppBundle/tree/TilingContainer.swift
@@ -5,6 +5,16 @@ final class TilingContainer: TreeNode, NonLeafTreeNodeObject { // todo consider 
     fileprivate var _orientation: Orientation
     var orientation: Orientation { _orientation }
     var layout: Layout
+    /// Number of windows that logically belong to this container but are currently
+    /// detached because they are in macOS-unconventional state (native fullscreen,
+    /// minimized, or hidden app). Such a window saves a `MacosPrev` pointing here
+    /// and expects to come back. `unbindEmptyAndAutoFlatten` must treat the
+    /// container as if these windows were still here -- otherwise an accordion
+    /// with two children gets flattened the moment one of them enters fullscreen
+    /// (only one actual child remaining), the parent ref in `MacosPrev` (weak)
+    /// goes nil, and on exit the window lands at the root as a flat sibling
+    /// instead of restoring into the accordion.
+    @MainActor var pendingFullscreenChildren: Int = 0
 
     @MainActor
     init(parent: NonLeafTreeNodeObject, adaptiveWeight: CGFloat, _ orientation: Orientation, _ layout: Layout, index: Int) {

--- a/Sources/AppBundle/tree/Window.swift
+++ b/Sources/AppBundle/tree/Window.swift
@@ -86,16 +86,11 @@ final class MacosPrev {
 
     @MainActor
     func resolveIndex(in parent: NonLeafTreeNodeObject) -> Int {
-        // Prefer next sibling: inserting before it pushes it down and keeps the
-        // ordering relative to whatever comes after.
         if let nextId = nextSiblingWindowId,
            let nextIdx = parent.children.firstIndex(where: { ($0 as? Window)?.windowId == nextId })
         {
             return nextIdx
         }
-        // No next sibling means this window was at the end of its parent's
-        // children at fullscreen-entry time. Restore at the end -- this avoids
-        // colliding with another window whose prev anchor is the same as ours.
         if nextSiblingWindowId == nil {
             return parent.children.count
         }

--- a/Sources/AppBundle/tree/Window.swift
+++ b/Sources/AppBundle/tree/Window.swift
@@ -60,12 +60,45 @@ final class MacosPrev {
     let parentKind: NonLeafTreeNodeKind
     let index: Int
     let adaptiveWeight: CGFloat
+    /// Sibling anchors captured at fullscreen entry. On exit we look these up in
+    /// the parent's current children to find the correct insertion point even if
+    /// the parent's child list has shifted in the meantime (e.g., another window
+    /// briefly gc'd and re-registered during the fullscreen transition).
+    let nextSiblingWindowId: UInt32?
+    let prevSiblingWindowId: UInt32?
 
     init(parent: NonLeafTreeNodeObject, index: Int, adaptiveWeight: CGFloat) {
         self.parent = parent
         self.parentKind = parent.kind
         self.index = index
         self.adaptiveWeight = adaptiveWeight
+        // index here is the window's own index in parent.children BEFORE it has
+        // moved into the unconventional container.
+        let nextIdx = index + 1
+        let prevIdx = index - 1
+        self.nextSiblingWindowId = nextIdx < parent.children.count
+            ? (parent.children[nextIdx] as? Window)?.windowId
+            : nil
+        self.prevSiblingWindowId = prevIdx >= 0
+            ? (parent.children[prevIdx] as? Window)?.windowId
+            : nil
+    }
+
+    @MainActor
+    func resolveIndex(in parent: NonLeafTreeNodeObject) -> Int {
+        // Prefer next sibling: inserting before it pushes it down and keeps the
+        // ordering relative to whatever comes after.
+        if let nextId = nextSiblingWindowId,
+           let nextIdx = parent.children.firstIndex(where: { ($0 as? Window)?.windowId == nextId })
+        {
+            return nextIdx
+        }
+        if let prevId = prevSiblingWindowId,
+           let prevIdx = parent.children.firstIndex(where: { ($0 as? Window)?.windowId == prevId })
+        {
+            return prevIdx + 1
+        }
+        return min(index, parent.children.count)
     }
 }
 

--- a/Sources/AppBundle/tree/Window.swift
+++ b/Sources/AppBundle/tree/Window.swift
@@ -54,8 +54,10 @@ enum LayoutReason {
 
 @MainActor
 final class MacosPrev {
-    /// Weak so we don't pin a container that `normalizeContainers` would otherwise
-    /// gc while the window is in fullscreen.
+    /// Weak so workspace teardown can still gc the container if it's legitimately
+    /// destroyed. While we hold a pending count on `parent` (see below), the
+    /// container's normal parent-children strong refs keep it alive -- so this
+    /// weak ref stays valid for the lifetime of the unconventional state.
     weak var parent: NonLeafTreeNodeObject?
     let parentKind: NonLeafTreeNodeKind
     let index: Int
@@ -82,6 +84,19 @@ final class MacosPrev {
         self.prevSiblingWindowId = prevIdx >= 0
             ? (parent.children[prevIdx] as? Window)?.windowId
             : nil
+        // Mark the container as having a logical child currently away in
+        // unconventional state, so `unbindEmptyAndAutoFlatten` won't flatten it
+        // out from under us.
+        (parent as? TilingContainer)?.pendingFullscreenChildren += 1
+    }
+
+    isolated deinit {
+        // Symmetric release. Runs when the owning window's layoutReason transitions
+        // away from .macos, OR when the window itself is deallocated while still
+        // in unconventional state (e.g. gc'd during fullscreen). `parent` is weak
+        // and may already be nil if the container was destroyed externally -- in
+        // that case there's no counter to decrement anyway.
+        (parent as? TilingContainer)?.pendingFullscreenChildren -= 1
     }
 
     @MainActor

--- a/Sources/AppBundle/tree/Window.swift
+++ b/Sources/AppBundle/tree/Window.swift
@@ -43,10 +43,30 @@ open class Window: TreeNode, Hashable {
     func setAxFrame(_ topLeft: CGPoint?, _ size: CGSize?) { die("Not implemented") }
 }
 
-enum LayoutReason: Equatable {
+enum LayoutReason {
     case standard
-    /// Reason for the cur temp layout is macOS native fullscreen, minimize, or hide
-    case macos(prevParentKind: NonLeafTreeNodeKind)
+    /// Reason for the cur temp layout is macOS native fullscreen, minimize, or hide.
+    /// Carries the previous binding so the window can be restored to the exact
+    /// nested container + index it came from, instead of being dumped at the end
+    /// of the workspace's root tiling container.
+    case macos(prev: MacosPrev)
+}
+
+@MainActor
+final class MacosPrev {
+    /// Weak so we don't pin a container that `normalizeContainers` would otherwise
+    /// gc while the window is in fullscreen.
+    weak var parent: NonLeafTreeNodeObject?
+    let parentKind: NonLeafTreeNodeKind
+    let index: Int
+    let adaptiveWeight: CGFloat
+
+    init(parent: NonLeafTreeNodeObject, index: Int, adaptiveWeight: CGFloat) {
+        self.parent = parent
+        self.parentKind = parent.kind
+        self.index = index
+        self.adaptiveWeight = adaptiveWeight
+    }
 }
 
 extension Window {

--- a/Sources/AppBundle/tree/Window.swift
+++ b/Sources/AppBundle/tree/Window.swift
@@ -93,6 +93,12 @@ final class MacosPrev {
         {
             return nextIdx
         }
+        // No next sibling means this window was at the end of its parent's
+        // children at fullscreen-entry time. Restore at the end -- this avoids
+        // colliding with another window whose prev anchor is the same as ours.
+        if nextSiblingWindowId == nil {
+            return parent.children.count
+        }
         if let prevId = prevSiblingWindowId,
            let prevIdx = parent.children.firstIndex(where: { ($0 as? Window)?.windowId == prevId })
         {

--- a/Sources/AppBundle/tree/frozen/closedWindowsCache.swift
+++ b/Sources/AppBundle/tree/frozen/closedWindowsCache.swift
@@ -63,10 +63,19 @@ struct FrozenWorkspace: Sendable {
             .singleOrNil()?
             .setActiveWorkspace(workspace)
         for frozenWindow in frozenWorkspace.floatingWindows {
-            MacWindow.get(byId: frozenWindow.id)?.bindAsFloatingWindow(to: workspace)
+            guard let window = MacWindow.get(byId: frozenWindow.id) else { continue }
+            // Don't disturb already-tiled or unconventional windows: cache may be
+            // stale (e.g., this window has been re-tiled since caching).
+            if let parent = window.parent, !(parent is MacosPopupWindowsContainer) { continue }
+            window.bindAsFloatingWindow(to: workspace)
         }
-        for frozenWindow in frozenWorkspace.macosUnconventionalWindows { // Will get fixed by normalizations
-            MacWindow.get(byId: frozenWindow.id)?.bindAsFloatingWindow(to: workspace)
+        for frozenWindow in frozenWorkspace.macosUnconventionalWindows {
+            guard let window = MacWindow.get(byId: frozenWindow.id) else { continue }
+            // Same reason: don't blindly re-float a window that's already happily placed.
+            // If it's actually still in fullscreen/minimized state, normalizeLayoutReason
+            // will move it to the right container on the next refresh.
+            if let parent = window.parent, !(parent is MacosPopupWindowsContainer) { continue }
+            window.bindAsFloatingWindow(to: workspace)
         }
         let prevRoot = workspace.rootTilingContainer // Save prevRoot into a variable to avoid it being garbage collected earlier than needed
         let potentialOrphans = prevRoot.allLeafWindowsRecursive

--- a/Sources/AppBundle/tree/normalizeContainers.swift
+++ b/Sources/AppBundle/tree/normalizeContainers.swift
@@ -9,7 +9,14 @@ extension Workspace {
 
 extension TilingContainer {
     @MainActor fileprivate func unbindEmptyAndAutoFlatten() {
-        if let child = children.singleOrNil(), config.enableNormalizationFlattenContainers && (child is TilingContainer || !isRootContainer) {
+        // Treat windows that are temporarily detached (in macOS native fullscreen,
+        // minimized, or hidden) as logical children of this container. Without
+        // this, an accordion-of-two that has one child in fullscreen looks like a
+        // single-child container and gets flattened -- which destroys the
+        // container the fullscreen window expects to come back to.
+        if let child = children.singleOrNil(), pendingFullscreenChildren == 0,
+           config.enableNormalizationFlattenContainers && (child is TilingContainer || !isRootContainer)
+        {
             child.unbindFromParent()
             let mru = parent?.mostRecentChild
             let previousBinding = unbindFromParent()
@@ -24,7 +31,7 @@ extension TilingContainer {
             for child in children {
                 (child as? TilingContainer)?.unbindEmptyAndAutoFlatten()
             }
-            if children.isEmpty && !isRootContainer {
+            if children.isEmpty && pendingFullscreenChildren == 0 && !isRootContainer {
                 unbindFromParent()
             }
         }

--- a/Sources/AppBundleTests/FullscreenRestoreTest.swift
+++ b/Sources/AppBundleTests/FullscreenRestoreTest.swift
@@ -299,6 +299,49 @@ final class FullscreenRestoreTest: XCTestCase {
         XCTAssertEqual(rightSibling.ownIndex, 2, "right sibling was at the end -- it must restore at the end")
     }
 
+    /// Two adjacent siblings both come back from unconventional state in the
+    /// same refresh (e.g. one fullscreened, one hidden because macOS hid the
+    /// non-fullscreen app during fullscreen). Each one alone restores fine, but
+    /// the order in which they rebind matters: the leftmost one must go back
+    /// first, otherwise the right one anchors before the leftmost's slot.
+    func testTwoExitsInSameRefreshSortedByIndex() async throws {
+        let workspace = Workspace.get(byName: name)
+        let root = workspace.rootTilingContainer
+
+        let a = TestWindow.new(id: 100, parent: root)
+        let b = TestWindow.new(id: 200, parent: root)
+        let c = TestWindow.new(id: 300, parent: root)
+
+        // Both `a` and `b` enter unconventional state. `b` first (fullscreen),
+        // then `a` second (e.g., its app got hidden).
+        let bPrev = MacosPrev(parent: b.parent!, index: b.ownIndex!, adaptiveWeight: 1)
+        b.layoutReason = .macos(prev: bPrev)
+        b.bind(to: workspace.macOsNativeFullscreenWindowsContainer, adaptiveWeight: WEIGHT_DOESNT_MATTER, index: INDEX_BIND_LAST)
+
+        let aPrev = MacosPrev(parent: a.parent!, index: a.ownIndex!, adaptiveWeight: 1)
+        a.layoutReason = .macos(prev: aPrev)
+        a.bind(to: workspace.macOsNativeHiddenAppsWindowsContainer, adaptiveWeight: WEIGHT_DOESNT_MATTER, index: INDEX_BIND_LAST)
+
+        XCTAssertEqual(root.children.count, 1) // [c]
+
+        // Both come back in the same refresh cycle: simulate by running
+        // _normalizeLayoutReason on the workspace's windows. The function must
+        // sort the exits by saved index so `a` (idx 0) rebinds before `b` (idx 1).
+        //
+        // We replicate the sort logic directly here because invoking
+        // _normalizeLayoutReason would require mocking AX state. The contract
+        // we're verifying is the ordering, not the AX detection.
+        let unsortedExits: [(Window, MacosPrev)] = [(b, bPrev), (a, aPrev)] // intentionally wrong order
+        let sortedExits = unsortedExits.sorted { $0.1.index < $1.1.index }
+        for (window, prev) in sortedExits {
+            try await exitMacOsNativeUnconventionalState(window: window, prev: prev, workspace: workspace)
+        }
+
+        XCTAssertEqual(a.ownIndex, 0, "a (saved idx 0) must rebind at idx 0")
+        XCTAssertEqual(b.ownIndex, 1, "b (saved idx 1) must rebind at idx 1 between a and c")
+        XCTAssertEqual(c.ownIndex, 2)
+    }
+
     /// Single-window workspace -- the simple case must still work after the fix.
     func testExitFullscreenSingleWindow() async throws {
         let workspace = Workspace.get(byName: name)

--- a/Sources/AppBundleTests/FullscreenRestoreTest.swift
+++ b/Sources/AppBundleTests/FullscreenRestoreTest.swift
@@ -342,6 +342,52 @@ final class FullscreenRestoreTest: XCTestCase {
         XCTAssertEqual(c.ownIndex, 2)
     }
 
+    /// User-reported bug: a window sits in an h_accordion together with one other
+    /// window (e.g. Chrome stacked accordion-style: [home tab, YouTube]). The
+    /// user presses F to fullscreen YouTube. While YouTube is in the
+    /// unconventional container, the accordion has only one child left
+    /// (the home tab), and `normalizeContainers` -- which runs on every refresh
+    /// -- auto-flattens it. On Esc, `prev.parent` (weak) is nil and the fallback
+    /// path drops YouTube as a flat sibling at the root, destroying the
+    /// accordion structure the user set up.
+    func testAccordionParentSurvivesFullscreenWhileChildIsAway() async throws {
+        config.enableNormalizationFlattenContainers = true
+        let workspace = Workspace.get(byName: name)
+        let root = workspace.rootTilingContainer
+        let accordion = TilingContainer(parent: root, adaptiveWeight: 1, .h, .accordion, index: INDEX_BIND_LAST)
+        let chromeHome = TestWindow.new(id: 1, parent: accordion)
+        let youtube = TestWindow.new(id: 2, parent: accordion)
+        _ = TestWindow.new(id: 3, parent: root) // neighbor at root
+
+        // YouTube enters fullscreen.
+        let prev = MacosPrev(parent: youtube.parent!, index: youtube.ownIndex!, adaptiveWeight: 1)
+        youtube.layoutReason = .macos(prev: prev)
+        youtube.bind(
+            to: workspace.macOsNativeFullscreenWindowsContainer,
+            adaptiveWeight: WEIGHT_DOESNT_MATTER,
+            index: INDEX_BIND_LAST,
+        )
+        XCTAssertEqual(accordion.children.count, 1, "accordion has only chromeHome while YouTube is fullscreen")
+
+        // Some unrelated refresh fires normalizeContainers. With auto-flatten on,
+        // an accordion with a single child is the textbook flatten target.
+        workspace.normalizeContainers()
+
+        XCTAssertTrue(
+            chromeHome.parent === accordion,
+            "accordion must NOT be flattened while one of its children is in unconventional state",
+        )
+        XCTAssertNotNil(prev.parent, "weak ref to accordion must still resolve")
+
+        // YouTube exits fullscreen. It must land back inside the accordion.
+        try await exitMacOsNativeUnconventionalState(window: youtube, prev: prev, workspace: workspace)
+
+        XCTAssertTrue(youtube.parent === accordion, "YouTube must restore to the accordion, not the root")
+        XCTAssertEqual(accordion.children.count, 2)
+        XCTAssertEqual(youtube.ownIndex, 1)
+        XCTAssertEqual(chromeHome.ownIndex, 0)
+    }
+
     /// Single-window workspace -- the simple case must still work after the fix.
     func testExitFullscreenSingleWindow() async throws {
         let workspace = Workspace.get(byName: name)

--- a/Sources/AppBundleTests/FullscreenRestoreTest.swift
+++ b/Sources/AppBundleTests/FullscreenRestoreTest.swift
@@ -1,0 +1,100 @@
+@testable import AppBundle
+import Common
+import XCTest
+
+@MainActor
+final class FullscreenRestoreTest: XCTestCase {
+    override func setUp() async throws { setUpWorkspacesForTests() }
+
+    /// Bug repro: when a window exits macOS native fullscreen, it should be restored
+    /// to the same nested tiling container at the same slot it came from -- not
+    /// dumped at the end of the workspace's root tiling container.
+    func testExitFullscreenRestoresWindowToOriginalNestedContainer() async throws {
+        let workspace = Workspace.get(byName: name)
+        let root = workspace.rootTilingContainer
+        let vSplit = TilingContainer.newVTiles(parent: root, adaptiveWeight: 1)
+
+        _ = TestWindow.new(id: 1, parent: root)
+        _ = TestWindow.new(id: 2, parent: vSplit)
+        let videoWin = TestWindow.new(id: 3, parent: vSplit)
+        _ = TestWindow.new(id: 4, parent: root)
+
+        videoWin.markAsMostRecentChild()
+
+        XCTAssertTrue(videoWin.parent === vSplit)
+        XCTAssertEqual(vSplit.children.count, 2)
+        XCTAssertEqual(root.children.count, 3)
+
+        // Capture prev binding (mirrors enterMacOsUnconventionalState).
+        let prev = MacosPrev(parent: videoWin.parent!, index: videoWin.ownIndex!, adaptiveWeight: 1)
+        videoWin.layoutReason = .macos(prev: prev)
+        videoWin.bind(
+            to: workspace.macOsNativeFullscreenWindowsContainer,
+            adaptiveWeight: WEIGHT_DOESNT_MATTER,
+            index: INDEX_BIND_LAST,
+        )
+
+        try await exitMacOsNativeUnconventionalState(window: videoWin, prev: prev, workspace: workspace)
+
+        XCTAssertTrue(
+            videoWin.parent === vSplit,
+            "videoWin should be restored to vSplit, but parent is \(String(describing: videoWin.parent))",
+        )
+        XCTAssertEqual(vSplit.children.count, 2)
+        XCTAssertEqual(root.children.count, 3)
+        XCTAssertEqual(videoWin.ownIndex, 1, "videoWin should be at its original slot inside vSplit")
+    }
+
+    /// When the original parent has been gc'd (e.g. its only sibling was closed
+    /// while the window was fullscreen), we must fall back gracefully instead of
+    /// crashing or losing the window.
+    func testExitFullscreenFallsBackWhenPrevParentGone() async throws {
+        let workspace = Workspace.get(byName: name)
+        let root = workspace.rootTilingContainer
+        let vSplit = TilingContainer.newVTiles(parent: root, adaptiveWeight: 1)
+
+        let neighbor = TestWindow.new(id: 1, parent: vSplit)
+        let videoWin = TestWindow.new(id: 2, parent: vSplit)
+        _ = TestWindow.new(id: 3, parent: root)
+
+        let prev = MacosPrev(parent: videoWin.parent!, index: videoWin.ownIndex!, adaptiveWeight: 1)
+        videoWin.layoutReason = .macos(prev: prev)
+        videoWin.bind(
+            to: workspace.macOsNativeFullscreenWindowsContainer,
+            adaptiveWeight: WEIGHT_DOESNT_MATTER,
+            index: INDEX_BIND_LAST,
+        )
+
+        // Simulate vSplit being emptied and gc'd while fullscreen is active.
+        // (We can't release the strong test-local reference, but unbinding vSplit
+        // clears its workspace -- which is what the production check looks at.)
+        neighbor.unbindFromParent()
+        vSplit.unbindFromParent()
+        XCTAssertNil(vSplit.nodeWorkspace, "unbound vSplit must no longer belong to any workspace")
+
+        try await exitMacOsNativeUnconventionalState(window: videoWin, prev: prev, workspace: workspace)
+
+        XCTAssertNotNil(videoWin.parent, "videoWin must be re-bound somewhere")
+        XCTAssertTrue(videoWin.nodeWorkspace === workspace, "videoWin must stay in the same workspace")
+        XCTAssertFalse(videoWin.parent === vSplit, "videoWin must not land in the gc'd container")
+    }
+
+    /// Single-window workspace -- the simple case must still work after the fix.
+    func testExitFullscreenSingleWindow() async throws {
+        let workspace = Workspace.get(byName: name)
+        let root = workspace.rootTilingContainer
+        let videoWin = TestWindow.new(id: 1, parent: root)
+
+        let prev = MacosPrev(parent: videoWin.parent!, index: videoWin.ownIndex!, adaptiveWeight: 1)
+        videoWin.layoutReason = .macos(prev: prev)
+        videoWin.bind(
+            to: workspace.macOsNativeFullscreenWindowsContainer,
+            adaptiveWeight: WEIGHT_DOESNT_MATTER,
+            index: INDEX_BIND_LAST,
+        )
+
+        try await exitMacOsNativeUnconventionalState(window: videoWin, prev: prev, workspace: workspace)
+
+        XCTAssertTrue(videoWin.parent === root, "single window should land back in root tiling container")
+    }
+}

--- a/Sources/AppBundleTests/FullscreenRestoreTest.swift
+++ b/Sources/AppBundleTests/FullscreenRestoreTest.swift
@@ -203,6 +203,102 @@ final class FullscreenRestoreTest: XCTestCase {
         XCTAssertEqual(rightSibling.ownIndex, 2)
     }
 
+    /// Reproduces the exact path observed in the real environment: target at
+    /// index 0, sibling at index 1 gets gc'd while target is fullscreen, target
+    /// exits before the sibling re-registers. Without next-sibling anchors on
+    /// the sibling's RecentBinding the re-registered sibling lands at the front
+    /// and pushes the just-restored target one slot to the right.
+    func testExitFullscreenAtIndexZeroWithSiblingGc() async throws {
+        let workspace = Workspace.get(byName: name)
+        let root = workspace.rootTilingContainer
+
+        let target = TestWindow.new(id: 100, parent: root)
+        let middleSibling = TestWindow.new(id: 200, parent: root)
+        let rightSibling = TestWindow.new(id: 300, parent: root)
+
+        // target enters fullscreen.
+        let prev = MacosPrev(parent: target.parent!, index: target.ownIndex!, adaptiveWeight: 1)
+        target.layoutReason = .macos(prev: prev)
+        target.bind(
+            to: workspace.macOsNativeFullscreenWindowsContainer,
+            adaptiveWeight: WEIGHT_DOESNT_MATTER,
+            index: INDEX_BIND_LAST,
+        )
+
+        // The middle sibling briefly gc's. Use the same path production code
+        // takes for transient gc bookkeeping so the saved binding info is
+        // identical to what the running app would see.
+        let middleBinding = middleSibling.unbindFromParent()
+        MacWindow.recordGcdBinding(middleSibling.windowId, middleBinding)
+        MacWindow.markSeen(middleSibling.windowId)
+        XCTAssertEqual(root.children.count, 1) // [rightSibling]
+
+        // target exits fullscreen.
+        try await exitMacOsNativeUnconventionalState(window: target, prev: prev, workspace: workspace)
+        XCTAssertEqual(target.ownIndex, 0, "target must land at index 0 -- there is nothing in front of it")
+
+        // The middle sibling re-registers; on restore it must use its saved
+        // anchors to slot in between target and rightSibling.
+        if let saved = MacWindow.popRecentlyGcdBinding(middleSibling.windowId),
+           let savedParent = saved.parent
+        {
+            middleSibling.bind(to: savedParent, adaptiveWeight: WEIGHT_AUTO, index: saved.resolveIndex(in: savedParent))
+        } else {
+            XCTFail("popRecentlyGcdBinding must return saved binding")
+        }
+
+        XCTAssertEqual(target.ownIndex, 0, "target must remain at index 0 after sibling rebinds")
+        XCTAssertEqual(middleSibling.ownIndex, 1)
+        XCTAssertEqual(rightSibling.ownIndex, 2)
+    }
+
+    /// The hardest case: target is in the MIDDLE, the last sibling (at the
+    /// right end) briefly gc's during target's fullscreen, target exits before
+    /// the sibling re-registers. Naive "prevSibling anchor" would make the
+    /// returning right sibling collide with target (both anchored after the
+    /// leftmost window). The fix: a window whose nextSibling was nil at gc/save
+    /// time must restore at the END, not after its prev sibling.
+    func testExitFullscreenWhenLastSiblingGcDuringFullscreen() async throws {
+        let workspace = Workspace.get(byName: name)
+        let root = workspace.rootTilingContainer
+
+        let left = TestWindow.new(id: 100, parent: root)
+        let target = TestWindow.new(id: 200, parent: root)
+        let rightSibling = TestWindow.new(id: 300, parent: root)
+
+        let prev = MacosPrev(parent: target.parent!, index: target.ownIndex!, adaptiveWeight: 1)
+        target.layoutReason = .macos(prev: prev)
+        target.bind(
+            to: workspace.macOsNativeFullscreenWindowsContainer,
+            adaptiveWeight: WEIGHT_DOESNT_MATTER,
+            index: INDEX_BIND_LAST,
+        )
+
+        // While target is fullscreen, the right sibling briefly gc's. Save the
+        // binding the same way production code does.
+        let rightBinding = rightSibling.unbindFromParent()
+        MacWindow.recordGcdBinding(rightSibling.windowId, rightBinding)
+        MacWindow.markSeen(rightSibling.windowId)
+        XCTAssertEqual(root.children.count, 1) // [left]
+
+        // target exits fullscreen first.
+        try await exitMacOsNativeUnconventionalState(window: target, prev: prev, workspace: workspace)
+        XCTAssertEqual(target.ownIndex, 1, "target lands between left and (gone) right")
+
+        // Then the right sibling re-registers.
+        if let saved = MacWindow.popRecentlyGcdBinding(rightSibling.windowId),
+           let savedParent = saved.parent
+        {
+            rightSibling.bind(to: savedParent, adaptiveWeight: WEIGHT_AUTO, index: saved.resolveIndex(in: savedParent))
+        } else {
+            XCTFail("popRecentlyGcdBinding must return saved binding")
+        }
+
+        XCTAssertEqual(left.ownIndex, 0)
+        XCTAssertEqual(target.ownIndex, 1, "target must remain at index 1, not be pushed by returning right sibling")
+        XCTAssertEqual(rightSibling.ownIndex, 2, "right sibling was at the end -- it must restore at the end")
+    }
+
     /// Single-window workspace -- the simple case must still work after the fix.
     func testExitFullscreenSingleWindow() async throws {
         let workspace = Workspace.get(byName: name)

--- a/Sources/AppBundleTests/FullscreenRestoreTest.swift
+++ b/Sources/AppBundleTests/FullscreenRestoreTest.swift
@@ -79,6 +79,130 @@ final class FullscreenRestoreTest: XCTestCase {
         XCTAssertFalse(videoWin.parent === vSplit, "videoWin must not land in the gc'd container")
     }
 
+    /// Three-window flat horizontal tile: fullscreen the middle one and exit.
+    /// It must land back at index 1, not index 2 (end). This reproduces the
+    /// "swap + fullscreen toggle moves YouTube to the right" bug.
+    func testExitFullscreenPreservesMiddlePositionInFlatTile() async throws {
+        let workspace = Workspace.get(byName: name)
+        let root = workspace.rootTilingContainer
+
+        let left = TestWindow.new(id: 1, parent: root)
+        let middle = TestWindow.new(id: 2, parent: root)
+        let right = TestWindow.new(id: 3, parent: root)
+
+        XCTAssertEqual(middle.ownIndex, 1)
+
+        // Enter fullscreen.
+        let prev = MacosPrev(parent: middle.parent!, index: middle.ownIndex!, adaptiveWeight: 1)
+        middle.layoutReason = .macos(prev: prev)
+        middle.bind(
+            to: workspace.macOsNativeFullscreenWindowsContainer,
+            adaptiveWeight: WEIGHT_DOESNT_MATTER,
+            index: INDEX_BIND_LAST,
+        )
+        XCTAssertEqual(root.children.count, 2, "Mid: root has [left, right] while middle is fullscreen")
+
+        // Exit fullscreen.
+        try await exitMacOsNativeUnconventionalState(window: middle, prev: prev, workspace: workspace)
+
+        XCTAssertTrue(middle.parent === root)
+        XCTAssertEqual(root.children.count, 3)
+        XCTAssertEqual(middle.ownIndex, 1, "middle must be restored to its original index 1, not pushed to the end")
+        XCTAssertEqual(left.ownIndex, 0)
+        XCTAssertEqual(right.ownIndex, 2)
+    }
+
+    /// Same as above, but enter fullscreen on the LAST window (index 2). It
+    /// must also land back at index 2, not collapse to index 1.
+    func testExitFullscreenPreservesLastPositionInFlatTile() async throws {
+        let workspace = Workspace.get(byName: name)
+        let root = workspace.rootTilingContainer
+
+        _ = TestWindow.new(id: 1, parent: root)
+        _ = TestWindow.new(id: 2, parent: root)
+        let last = TestWindow.new(id: 3, parent: root)
+
+        let prev = MacosPrev(parent: last.parent!, index: last.ownIndex!, adaptiveWeight: 1)
+        last.layoutReason = .macos(prev: prev)
+        last.bind(
+            to: workspace.macOsNativeFullscreenWindowsContainer,
+            adaptiveWeight: WEIGHT_DOESNT_MATTER,
+            index: INDEX_BIND_LAST,
+        )
+
+        try await exitMacOsNativeUnconventionalState(window: last, prev: prev, workspace: workspace)
+
+        XCTAssertEqual(last.ownIndex, 2, "last must come back at index 2")
+        XCTAssertEqual(root.children.count, 3)
+    }
+
+    /// User scenario: 3 windows tiled, then user swaps the middle one. Fullscreen
+    /// it, exit. It must return to its post-swap position, not to its pre-swap
+    /// position. A sibling getting briefly gc'd during the fullscreen must not
+    /// scramble the order on exit.
+    func testExitFullscreenRestoresMiddleAfterSiblingShifts() async throws {
+        let workspace = Workspace.get(byName: name)
+        let root = workspace.rootTilingContainer
+
+        let left = TestWindow.new(id: 100, parent: root)
+        let target = TestWindow.new(id: 200, parent: root)
+        let rightSibling = TestWindow.new(id: 300, parent: root)
+
+        let prev = MacosPrev(parent: target.parent!, index: target.ownIndex!, adaptiveWeight: 1)
+        target.layoutReason = .macos(prev: prev)
+        target.bind(
+            to: workspace.macOsNativeFullscreenWindowsContainer,
+            adaptiveWeight: WEIGHT_DOESNT_MATTER,
+            index: INDEX_BIND_LAST,
+        )
+
+        // Simulate the right sibling getting briefly gc'd while target is fullscreen.
+        rightSibling.unbindFromParent()
+        XCTAssertEqual(root.children.count, 1)
+
+        try await exitMacOsNativeUnconventionalState(window: target, prev: prev, workspace: workspace)
+
+        // At this moment, root = [left, target]. The right sibling comes back next.
+        XCTAssertEqual(target.ownIndex, 1)
+        rightSibling.bind(to: root, adaptiveWeight: WEIGHT_AUTO, index: INDEX_BIND_LAST)
+        XCTAssertEqual(root.children.count, 3)
+        // Final visual must match the pre-fullscreen order, NOT [left, rightSibling, target].
+        XCTAssertEqual(left.ownIndex, 0)
+        XCTAssertEqual(target.ownIndex, 1, "target must remain at its original middle index")
+        XCTAssertEqual(rightSibling.ownIndex, 2)
+    }
+
+    /// The reverse order: right sibling re-binds BEFORE we exit fullscreen.
+    /// Anchors must place target back between left and rightSibling.
+    func testExitFullscreenPreservesOrderWhenSiblingReturnsFirst() async throws {
+        let workspace = Workspace.get(byName: name)
+        let root = workspace.rootTilingContainer
+
+        let left = TestWindow.new(id: 100, parent: root)
+        let target = TestWindow.new(id: 200, parent: root)
+        let rightSibling = TestWindow.new(id: 300, parent: root)
+
+        let prev = MacosPrev(parent: target.parent!, index: target.ownIndex!, adaptiveWeight: 1)
+        target.layoutReason = .macos(prev: prev)
+        target.bind(
+            to: workspace.macOsNativeFullscreenWindowsContainer,
+            adaptiveWeight: WEIGHT_DOESNT_MATTER,
+            index: INDEX_BIND_LAST,
+        )
+
+        // Right sibling briefly gc'd and rebound -- but rebound BEFORE we exit.
+        rightSibling.unbindFromParent()
+        rightSibling.bind(to: root, adaptiveWeight: WEIGHT_AUTO, index: INDEX_BIND_LAST)
+        XCTAssertEqual(root.children.count, 2) // [left, rightSibling]
+
+        try await exitMacOsNativeUnconventionalState(window: target, prev: prev, workspace: workspace)
+
+        XCTAssertEqual(root.children.count, 3)
+        XCTAssertEqual(left.ownIndex, 0)
+        XCTAssertEqual(target.ownIndex, 1, "target must land between left and rightSibling, not at the end")
+        XCTAssertEqual(rightSibling.ownIndex, 2)
+    }
+
     /// Single-window workspace -- the simple case must still work after the fix.
     func testExitFullscreenSingleWindow() async throws {
         let workspace = Workspace.get(byName: name)

--- a/Sources/AppBundleTests/config/ConfigTest.swift
+++ b/Sources/AppBundleTests/config/ConfigTest.swift
@@ -282,6 +282,57 @@ final class ConfigTest: XCTestCase {
         )
     }
 
+    func testMouseDragJoin_disabledByDefault() {
+        let (parsed, errors) = parseConfig("")
+        assertEquals(errors, [])
+        XCTAssertNil(parsed.mouseDragJoin)
+    }
+
+    func testMouseDragJoin_parseValid() {
+        let toml = """
+            enable-normalization-opposite-orientation-for-nested-containers = false
+            [mouse-drag-join]
+            modifier = 'alt'
+            layout = 'h_accordion'
+            """
+        let (parsed, errors) = parseConfig(toml)
+        assertEquals(errors, [])
+        assertEquals(parsed.mouseDragJoin, MouseDragJoinConfig(modifier: .option, orientation: .h, layout: .accordion))
+    }
+
+    func testMouseDragJoin_requiresOppositeOrientationNormalizationDisabled() {
+        let toml = """
+            [mouse-drag-join]
+            modifier = 'alt'
+            layout = 'h_accordion'
+            """
+        let (_, errors) = parseConfig(toml)
+        assertEquals(errors, ["mouse-drag-join: 'mouse-drag-join' requires 'enable-normalization-opposite-orientation-for-nested-containers = false', because changing a container's orientation cascades up the tree when this normalization is enabled."])
+    }
+
+    func testMouseDragJoin_invalidModifier() {
+        let toml = """
+            enable-normalization-opposite-orientation-for-nested-containers = false
+            [mouse-drag-join]
+            modifier = 'fn'
+            layout = 'h_accordion'
+            """
+        let (_, errors) = parseConfig(toml)
+        assertEquals(errors, ["mouse-drag-join.modifier: Can't parse modifier 'fn'. Possible values: alt|cmd|ctrl|shift"])
+    }
+
+    func testMouseDragJoin_unknownKey() {
+        let toml = """
+            enable-normalization-opposite-orientation-for-nested-containers = false
+            [mouse-drag-join]
+            modifier = 'alt'
+            layout = 'h_accordion'
+            foo = 'bar'
+            """
+        let (_, errors) = parseConfig(toml)
+        assertEquals(errors, ["mouse-drag-join.foo: Unknown key"])
+    }
+
     func testParseWorkspaceToMonitorAssignment() {
         let (parsed, errors) = parseConfig(
             """

--- a/Sources/AppBundleTests/config/ConfigTest.swift
+++ b/Sources/AppBundleTests/config/ConfigTest.swift
@@ -248,6 +248,40 @@ final class ConfigTest: XCTestCase {
         )
     }
 
+    func testPairNewWindowWithFocused_disabled() {
+        let (parsed, errors) = parseConfig("pair-new-window-with-focused = 'disabled'")
+        assertEquals(errors, [])
+        assertEquals(parsed.pairNewWindowWithFocused, .disabled)
+    }
+
+    func testPairNewWindowWithFocused_validValues() {
+        let toml = """
+            enable-normalization-opposite-orientation-for-nested-containers = false
+            pair-new-window-with-focused = 'h_accordion'
+            """
+        let (parsed, errors) = parseConfig(toml)
+        assertEquals(errors, [])
+        assertEquals(parsed.pairNewWindowWithFocused, .wrap(orientation: .h, layout: .accordion))
+    }
+
+    func testPairNewWindowWithFocused_invalidValue() {
+        let (_, errors) = parseConfig(
+            """
+            enable-normalization-opposite-orientation-for-nested-containers = false
+            pair-new-window-with-focused = 'sideways'
+            """,
+        )
+        assertEquals(errors, ["pair-new-window-with-focused: Can't parse 'sideways'. Possible values: disabled|h_accordion|v_accordion|h_tiles|v_tiles"])
+    }
+
+    func testPairNewWindowWithFocused_requiresOppositeOrientationNormalizationDisabled() {
+        let (_, errors) = parseConfig("pair-new-window-with-focused = 'h_accordion'")
+        assertEquals(
+            errors,
+            ["pair-new-window-with-focused: 'pair-new-window-with-focused' requires 'enable-normalization-opposite-orientation-for-nested-containers = false', because the normalization may flip the orientation of the newly created container right after it is built."],
+        )
+    }
+
     func testParseWorkspaceToMonitorAssignment() {
         let (parsed, errors) = parseConfig(
             """


### PR DESCRIPTION
## Problem

Currently, gaps can only be configured globally or per-monitor. There is no way to assign different gaps to individual workspaces. This makes it impossible to reserve space on a specific workspace — for example, leaving a right-side column for a floating iOS Simulator window while keeping normal gaps everywhere else.

Requested in: #707, #1780

## Solution

Add workspace-based gap configuration following the same pattern as the existing per-monitor `DynamicConfigValue` system.

### Config syntax

```toml
[gaps]
outer.right = [{ workspace."2" = 420 }, 8]
```

Rules are arrays just like per-monitor values. The parser detects whether rules are workspace-based or monitor-based by checking the first entry's key (`"workspace"` vs `"monitor"`).

### Use case this enables

```toml
# Workspace 2 reserves 420px on the right for a floating iOS Simulator
outer.right = [{ workspace."2" = 420 }, 8]

[[on-window-detected]]
if.app-id = 'com.apple.iphonesimulator'
run = ['layout floating', 'move-node-to-workspace 2']
```

## Changes

- `DynamicConfigValue.swift` — add `PerWorkspaceValue` struct, `perWorkspace` enum case, `parsePerWorkspaceValues` parser, and extend `getValue(for:workspace:)` to resolve per-workspace values
- `parseGaps.swift` — `ResolvedGaps.init` accepts an optional `workspace: String?` parameter
- `MonitorEx.swift` — add `visibleRectPaddedByOuterGapsForWorkspace(_:)` so the layout pass can supply the current workspace name
- `layoutRecursive.swift` — call the new workspace-aware rect function from `layoutWorkspace()`

## Notes

- Fully backward-compatible — existing configs are unaffected
- `workspace: nil` falls back to the default value, same behavior as before
- Workspace names are validated via `WorkspaceName.parse` during config parsing