### PR TITLE
Fix: don't track hidden tabs of Fork/Ghostty as separate windows

### DIFF
--- a/Sources/AppBundle/model/KnownBundleId.swift
+++ b/Sources/AppBundle/model/KnownBundleId.swift
@@ -8,6 +8,7 @@ enum KnownBundleId: String, Equatable {
     case cleanshotx = "pl.maketheweb.cleanshotx"
     case emacs = "org.gnu.Emacs"
     case finder = "com.apple.finder"
+    case fork = "com.DanPristupov.Fork"
     case ghostty = "com.mitchellh.ghostty"
     case gimp = "org.gimp.gimp-2.10"
     case iphonesimulator = "com.apple.iphonesimulator"
@@ -39,5 +40,13 @@ enum KnownBundleId: String, Equatable {
 
     var isVscode: Bool {
         self == .vscode || self == .vscodium
+    }
+
+    /// True for apps that expose each native macOS tab as a separate AXWindow whose
+    /// AX object stays valid after the tab is hidden. AeroSpace must trust the app's
+    /// `AXWindows` (rather than the per-element `containingWindowId()`) to know which
+    /// tabs are actually visible right now.
+    var hasTabsAsWindows: Bool {
+        self == .fork || self == .ghostty
     }
 }

--- a/Sources/AppBundle/tree/MacApp.swift
+++ b/Sources/AppBundle/tree/MacApp.swift
@@ -102,13 +102,43 @@ final class MacApp: AbstractApp {
 
     // todo merge together with detectNewWindows
     func getFocusedWindow() async throws -> Window? {
-        let windowId = try await thread?.runInLoop { [nsApp, axApp, windows] job in
-            try axApp.threadGuarded.get(Ax.focusedWindowAttr)
-                .flatMap { try windows.threadGuarded.getOrRegisterAxWindow(windowId: $0.windowId, $0.ax.cast, nsApp, job) }?
-                .windowId
+        let result: (UInt32, [UInt32])? = try await thread?.runInLoop { [nsApp, axApp, windows, appId] job in
+            guard let focused = try axApp.threadGuarded.get(Ax.focusedWindowAttr) else { return nil }
+            // Register the focused window first. If it can't be registered (e.g.
+            // `isLeftMouseButtonDown` makes `getOrRegisterAxWindow` skip new
+            // registrations), bail out without touching anything else.
+            guard try windows.threadGuarded.getOrRegisterAxWindow(windowId: focused.windowId, focused.ax.cast, nsApp, job) != nil else {
+                return nil
+            }
+            // For tab-based apps (e.g. Fork): only after the new focused tab is in
+            // the dict, prune stale tab AX windows. Doing this in the opposite order
+            // would empty the dict during a click (mouse-down skips registration)
+            // and the next refresh would GC the only Fork MacWindow, briefly
+            // collapsing its tile -- which the user sees as a layout flicker.
+            var staleIds: [UInt32] = []
+            if appId?.hasTabsAsWindows == true {
+                let valid = Set((axApp.threadGuarded.get(Ax.windowsAttr) ?? []).map(\.windowId))
+                staleIds = windows.threadGuarded.keys.filter { !valid.contains($0) && $0 != focused.windowId }
+                for id in staleIds {
+                    windows.threadGuarded.removeValue(forKey: id)
+                }
+            }
+            return (focused.windowId, staleIds)
         }
-        guard let windowId else { return nil }
-        return try await MacWindow.getOrRegister(windowId: windowId, macApp: self)
+        guard let (windowId, staleIds) = result else { return nil }
+        // Capture the binding location of the stale MacWindow so the new tab can
+        // inherit the same tile slot. Without this, GCing the old tab and creating
+        // the new one through MRU placement can put the replacement in a different
+        // slot, which the user sees as a layout flicker.
+        var inheritedBinding: BindingData? = nil
+        for id in staleIds {
+            guard let stale = MacWindow.allWindowsMap.removeValue(forKey: id) else { continue }
+            let bindingData = stale.unbindFromParent()
+            if inheritedBinding == nil, bindingData.parent is TilingContainer {
+                inheritedBinding = bindingData
+            }
+        }
+        return try await MacWindow.getOrRegister(windowId: windowId, macApp: self, inheritedBinding: inheritedBinding)
     }
 
     @MainActor func nativeFocus(_ windowId: UInt32) {
@@ -272,19 +302,33 @@ final class MacApp: AbstractApp {
             return []
         }
         guard let thread else { return [] }
-        let (alive, dead) = try await thread.runInLoop { [nsApp, windows, axApp] (job) -> ([UInt32], [UInt32]) in
+        let (alive, dead) = try await thread.runInLoop { [nsApp, windows, axApp, appId] (job) -> ([UInt32], [UInt32]) in
             var alive: [UInt32: AxWindow] = windows.threadGuarded
             var dead = [UInt32: AxWindow]()
+            let axWindowsList = axApp.threadGuarded.get(Ax.windowsAttr) ?? []
+            // Some apps (e.g. Fork) expose each tab as a separate AXWindow whose AX
+            // object stays valid after the tab is hidden, so containingWindowId() alone
+            // keeps stale tabs alive. Opt-in: AXWindows excludes windows on inactive Spaces.
+            // For tab-based apps, intersect the alive set with `AXWindows`. Skip
+            // this filter while the left mouse button is down: in that state
+            // `getOrRegisterAxWindow` refuses to add new windows, so applying
+            // the filter would drop the old tab without being able to add the
+            // new one and would briefly leave the app with zero tracked windows.
+            let trustAxWindowsAsAliveSet: Set<UInt32>? = (appId?.hasTabsAsWindows == true && !isLeftMouseButtonDown)
+                ? Set(axWindowsList.map(\.windowId))
+                : nil
             // Second line of defence against lock screen. See the first line of defence: closedWindowsCache
             // Second and third lines of defence are technically needed only to avoid potential flickering
             if frontmostAppBundleId != lockScreenAppBundleId {
-                (alive, dead) = try alive.partition {
+                (alive, dead) = try alive.partition { (id, window) in
                     try job.checkCancellation()
-                    return $0.value.ax.containingWindowId() != nil
+                    if window.ax.containingWindowId() == nil { return false }
+                    if let trustAxWindowsAsAliveSet, !trustAxWindowsAsAliveSet.contains(id) { return false }
+                    return true
                 }
             }
 
-            for (id, window) in axApp.threadGuarded.get(Ax.windowsAttr) ?? [] {
+            for (id, window) in axWindowsList {
                 try job.checkCancellation()
                 try alive.getOrRegisterAxWindow(windowId: id, window, nsApp, job)
             }

--- a/Sources/AppBundle/tree/MacWindow.swift
+++ b/Sources/AppBundle/tree/MacWindow.swift
@@ -16,17 +16,21 @@ final class MacWindow: Window {
 
     @MainActor
     @discardableResult
-    static func getOrRegister(windowId: UInt32, macApp: MacApp) async throws -> MacWindow {
+    static func getOrRegister(windowId: UInt32, macApp: MacApp, inheritedBinding: BindingData? = nil) async throws -> MacWindow {
         if let existing = allWindowsMap[windowId] { return existing }
         let rect = try await macApp.getAxRect(windowId)
-        let data = try await unbindAndGetBindingDataForNewWindow(
-            windowId,
-            macApp,
-            isStartup
-                ? (rect?.center.monitorApproximation ?? mainMonitor).activeWorkspace
-                : focus.workspace,
-            window: nil,
-        )
+        let data: BindingData = if let inheritedBinding {
+            inheritedBinding
+        } else {
+            try await unbindAndGetBindingDataForNewWindow(
+                windowId,
+                macApp,
+                isStartup
+                    ? (rect?.center.monitorApproximation ?? mainMonitor).activeWorkspace
+                    : focus.workspace,
+                window: nil,
+            )
+        }
 
         // atomic synchronous section
         if let existing = allWindowsMap[windowId] { return existing }


### PR DESCRIPTION
> Replaces #2088 (couldn't be reopened after the branch was force-pushed with the additional fix).

## Problem

For apps that expose every macOS-native tab as its own `AXWindow`
(Fork — `com.DanPristupov.Fork`, Ghostty — `com.mitchellh.ghostty`),
AeroSpace tracks each tab as a separate window. The result is two
user-visible bugs:

1. **Inflated window count.** With N tabs in one Fork/Ghostty window
   AeroSpace tiles the workspace into N slots while only one tab is on
   screen, leaving the other tiles empty (or covered by the visible
   tab).
2. **Layout flicker on tab switch.** Switching tabs caused the tile
   layout to recompute — sometimes briefly placing the new tab in a
   different slot, sometimes briefly collapsing the Fork tile entirely
   while sibling tiles expanded.

Reproduction: open Fork, open multiple repositories so they appear as
tabs, then `aerospace list-windows --all` — Fork shows up N times
even though `count windows` via System Events returns 1. Click between
tabs rapidly and the layout flickers.

## Root cause

`MacApp.refreshAndGetAliveWindowIds` decides whether a tracked window
is still alive purely by `_AXUIElementGetWindow` returning a non-nil
id (`containingWindowId() != nil`). For tab-based apps the AX object
of an inactive tab stays valid even though the tab is hidden, so the
private API keeps reporting the same id and AeroSpace never GCs it.

Tab switching also has two non-atomic moments:

- In `MacApp.getFocusedWindow`, the new tab's AX entry is added to the
  app's `windows` dict before any cleanup runs, so two `MacWindow`s
  briefly point into the same workspace. When the next refresh GCs
  the old one, `MacWindow.getOrRegister` rebinds the new tab via MRU
  rather than into the slot the old tab occupied — visible flicker.
- The `getOrRegisterAxWindow` fast path bails out while the left
  mouse button is down (existing logic, used to defer new-window
  detection during drags). On a real tab click — mouse-down → click
  registered → mouse-up — that early-out fires while the focus has
  already moved, so the new tab can't be added during the click. If
  we naively pruned the old tab first, the app's `windows` dict went
  empty until mouse-up, the only Fork `MacWindow` was GC'd, the tile
  collapsed, and sibling tiles expanded. Mouse-up ran another refresh
  that put everything back. End result: one or two frames of "tile
  gone".

## Fix

Opt-in per app to keep risk small.

- `KnownBundleId.hasTabsAsWindows` — predicate, currently true for
  Fork and Ghostty. `AXWindows` cannot replace `containingWindowId()`
  globally because it does not include windows on inactive macOS
  Spaces (existing comment in `accessibility.swift`).
- `refreshAndGetAliveWindowIds` — for these apps, intersect the alive
  set with the application's `AXWindows`. Skip this filter while the
  left mouse button is down, so the in-flight click does not strip
  the old tab when the new one cannot yet be registered.
- `getFocusedWindow` — register the focused tab first; only after it
  succeeds do we prune stale tab AX entries. Capture the stale
  `MacWindow`'s `BindingData` (parent/index/weight) and pass it to
  `MacWindow.getOrRegister` via a new `inheritedBinding` parameter.
  The replacement tab takes the previous tab's exact tile slot, so
  there is no two-tile intermediate state and no visible flicker.

The change adds zero new behavior for apps not in the predicate.

## Verification

- `swift test` — 122 tests pass.
- Manual: Fork with 5 tabs shifted from `aerospace list-windows --all`
  reporting 5 entries to 1, matching `count windows` via
  AppleScript/System Events. Rapid tab switching (mouse and
  AppleScript-driven menu) keeps the count at 1 and produces no
  visible flicker. Same verified for Ghostty with two tabs.
- Other multi-window apps in the existing dump suite (Chrome,
  Firefox, Slack, etc.) are untouched because `hasTabsAsWindows` is
  false for them.

## Notes

CONTRIBUTING.md asks for a prior discussion for non-trivial,
user-visible changes. I went ahead and opened the PR because the fix
is narrowly scoped (opt-in by bundle id, three files), but happy to
move the discussion to an issue first if you'd prefer — feel free to
close and I'll reopen with a discussion link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)