### PR TITLE
Fix: don't track hidden tabs of Fork/Ghostty as separate windows

### DIFF
--- a/Sources/AppBundle/model/KnownBundleId.swift
+++ b/Sources/AppBundle/model/KnownBundleId.swift
@@ -8,6 +8,7 @@ enum KnownBundleId: String, Equatable {
     case cleanshotx = "pl.maketheweb.cleanshotx"
     case emacs = "org.gnu.Emacs"
     case finder = "com.apple.finder"
+    case fork = "com.DanPristupov.Fork"
     case ghostty = "com.mitchellh.ghostty"
     case gimp = "org.gimp.gimp-2.10"
     case iphonesimulator = "com.apple.iphonesimulator"
@@ -39,5 +40,13 @@ enum KnownBundleId: String, Equatable {
 
     var isVscode: Bool {
         self == .vscode || self == .vscodium
+    }
+
+    /// True for apps that expose each native macOS tab as a separate AXWindow whose
+    /// AX object stays valid after the tab is hidden. AeroSpace must trust the app's
+    /// `AXWindows` (rather than the per-element `containingWindowId()`) to know which
+    /// tabs are actually visible right now.
+    var hasTabsAsWindows: Bool {
+        self == .fork || self == .ghostty
     }
 }

--- a/Sources/AppBundle/tree/MacApp.swift
+++ b/Sources/AppBundle/tree/MacApp.swift
@@ -102,12 +102,46 @@ final class MacApp: AbstractApp {
 
     // todo merge together with detectNewWindows
     func getFocusedWindow() async throws -> Window? {
-        let windowId = try await thread?.runInLoop { [nsApp, axApp, windows] job in
-            try axApp.threadGuarded.get(Ax.focusedWindowAttr)
-                .flatMap { try windows.threadGuarded.getOrRegisterAxWindow(windowId: $0.windowId, $0.ax.cast, nsApp, job) }?
-                .windowId
+        let result: (UInt32, [UInt32])? = try await thread?.runInLoop { [nsApp, axApp, windows, appId] job in
+            guard let focused = try axApp.threadGuarded.get(Ax.focusedWindowAttr) else { return nil }
+            // Register the focused window first. If it can't be registered (e.g.
+            // `isLeftMouseButtonDown` makes `getOrRegisterAxWindow` skip new
+            // registrations), bail out without touching anything else.
+            guard try windows.threadGuarded.getOrRegisterAxWindow(windowId: focused.windowId, focused.ax.cast, nsApp, job) != nil else {
+                return nil
+            }
+            // For tab-based apps (e.g. Fork): only after the new focused tab is in
+            // the dict, prune stale tab AX windows. Doing this in the opposite order
+            // would empty the dict during a click (mouse-down skips registration)
+            // and the next refresh would GC the only Fork MacWindow, briefly
+            // collapsing its tile -- which the user sees as a layout flicker.
+            var staleIds: [UInt32] = []
+            if appId?.hasTabsAsWindows == true {
+                let valid = Set((axApp.threadGuarded.get(Ax.windowsAttr) ?? []).map(\.windowId))
+                staleIds = windows.threadGuarded.keys.filter { !valid.contains($0) && $0 != focused.windowId }
+                for id in staleIds {
+                    windows.threadGuarded.removeValue(forKey: id)
+                }
+            }
+            return (focused.windowId, staleIds)
         }
-        guard let windowId else { return nil }
+        guard let (windowId, staleIds) = result else { return nil }
+        // Unbind stale MacWindows and capture one's BindingData so the new tab can
+        // inherit the same tile slot. The full unbind -> bind dance MUST be done
+        // without awaiting anything in between, otherwise the cancellable refresh
+        // task can be cancelled mid-await and leave the workspace tree with a gap
+        // that the user sees as a layout flicker.
+        var inheritedBinding: BindingData? = nil
+        for id in staleIds {
+            guard let stale = MacWindow.allWindowsMap.removeValue(forKey: id) else { continue }
+            let bindingData = stale.unbindFromParent()
+            if inheritedBinding == nil, bindingData.parent is TilingContainer {
+                inheritedBinding = bindingData
+            }
+        }
+        if let inheritedBinding {
+            return MacWindow.registerWithInheritedBinding(windowId: windowId, macApp: self, binding: inheritedBinding)
+        }
         return try await MacWindow.getOrRegister(windowId: windowId, macApp: self)
     }
 
@@ -272,19 +306,33 @@ final class MacApp: AbstractApp {
             return []
         }
         guard let thread else { return [] }
-        let (alive, dead) = try await thread.runInLoop { [nsApp, windows, axApp] (job) -> ([UInt32], [UInt32]) in
+        let (alive, dead) = try await thread.runInLoop { [nsApp, windows, axApp, appId] (job) -> ([UInt32], [UInt32]) in
             var alive: [UInt32: AxWindow] = windows.threadGuarded
             var dead = [UInt32: AxWindow]()
+            let axWindowsList = axApp.threadGuarded.get(Ax.windowsAttr) ?? []
+            // Some apps (e.g. Fork) expose each tab as a separate AXWindow whose AX
+            // object stays valid after the tab is hidden, so containingWindowId() alone
+            // keeps stale tabs alive. Opt-in: AXWindows excludes windows on inactive Spaces.
+            // For tab-based apps, intersect the alive set with `AXWindows`. Skip
+            // this filter while the left mouse button is down: in that state
+            // `getOrRegisterAxWindow` refuses to add new windows, so applying
+            // the filter would drop the old tab without being able to add the
+            // new one and would briefly leave the app with zero tracked windows.
+            let trustAxWindowsAsAliveSet: Set<UInt32>? = (appId?.hasTabsAsWindows == true && !isLeftMouseButtonDown)
+                ? Set(axWindowsList.map(\.windowId))
+                : nil
             // Second line of defence against lock screen. See the first line of defence: closedWindowsCache
             // Second and third lines of defence are technically needed only to avoid potential flickering
             if frontmostAppBundleId != lockScreenAppBundleId {
-                (alive, dead) = try alive.partition {
+                (alive, dead) = try alive.partition { (id, window) in
                     try job.checkCancellation()
-                    return $0.value.ax.containingWindowId() != nil
+                    if window.ax.containingWindowId() == nil { return false }
+                    if let trustAxWindowsAsAliveSet, !trustAxWindowsAsAliveSet.contains(id) { return false }
+                    return true
                 }
             }
 
-            for (id, window) in axApp.threadGuarded.get(Ax.windowsAttr) ?? [] {
+            for (id, window) in axWindowsList {
                 try job.checkCancellation()
                 try alive.getOrRegisterAxWindow(windowId: id, window, nsApp, job)
             }

--- a/Sources/AppBundle/tree/MacWindow.swift
+++ b/Sources/AppBundle/tree/MacWindow.swift
@@ -14,6 +14,19 @@ final class MacWindow: Window {
     @MainActor static var allWindowsMap: [UInt32: MacWindow] = [:]
     @MainActor static var allWindows: [MacWindow] { Array(allWindowsMap.values) }
 
+    /// Synchronous swap-registration used during a tab swap in tab-based apps.
+    /// Doing this without awaits ensures the workspace tree is never observed in a
+    /// "gap" state (between the stale tab being unbound and the new tab being bound),
+    /// which is critical because the refresh task can be cancelled mid-await and
+    /// leave the tree without a tile until the next refresh -- a visible flicker.
+    @MainActor
+    static func registerWithInheritedBinding(windowId: UInt32, macApp: MacApp, binding: BindingData) -> MacWindow {
+        if let existing = allWindowsMap[windowId] { return existing }
+        let window = MacWindow(windowId, macApp, lastFloatingSize: nil, parent: binding.parent, adaptiveWeight: binding.adaptiveWeight, index: binding.index)
+        allWindowsMap[windowId] = window
+        return window
+    }
+
     @MainActor
     @discardableResult
     static func getOrRegister(windowId: UInt32, macApp: MacApp) async throws -> MacWindow {


### PR DESCRIPTION
> Supersedes #2088 and #2089 (couldn't be reopened after the branch was force-pushed with the additional fix for the Ghostty cancellation race).

## Problem

For apps that expose every macOS-native tab as its own `AXWindow`
(Fork — `com.DanPristupov.Fork`, Ghostty — `com.mitchellh.ghostty`),
AeroSpace tracks each tab as a separate window. Two user-visible bugs:

1. **Inflated window count.** With N tabs in one Fork/Ghostty window
   AeroSpace tiles the workspace into N slots while only one tab is on
   screen, leaving the other tiles empty or covered by the visible tab.
2. **Layout flicker on tab switch.** Switching tabs caused the tile
   layout to recompute — sometimes briefly placing the new tab in a
   different slot, sometimes briefly collapsing the tile entirely
   while sibling tiles expanded.

Reproduction: open Fork, open multiple repositories so they appear as
tabs, then `aerospace list-windows --all` — Fork shows up N times
even though `count windows` via System Events returns 1. Click between
tabs rapidly and the layout flickers.

## Root cause

`MacApp.refreshAndGetAliveWindowIds` decides whether a tracked window
is still alive purely by `_AXUIElementGetWindow` returning a non-nil
id (`containingWindowId() != nil`). For tab-based apps the AX object
of an inactive tab stays valid even though the tab is hidden, so the
private API keeps reporting the same id and AeroSpace never GCs it.

Tab switching also has three non-atomic moments:

- In `MacApp.getFocusedWindow`, the new tab's AX entry is added to the
  app's `windows` dict before any cleanup runs, so two `MacWindow`s
  briefly point into the same workspace. When the next refresh GCs the
  old one, `MacWindow.getOrRegister` rebinds the new tab via MRU rather
  than into the slot the old tab occupied — visible flicker.
- The `getOrRegisterAxWindow` fast path bails out while the left mouse
  button is down (existing logic, used to defer new-window detection
  during drags). On a real tab click — mouse-down → click registered
  → mouse-up — pruning the old tab first while the new one cannot yet
  be registered emptied the app's `windows` dict, so the only Fork
  `MacWindow` was GC'd, the tile collapsed, and sibling tiles
  expanded. Mouse-up ran another refresh that put everything back.
- Splitting the swap across "unbind on main actor" and then "await
  `getOrRegister` to bind" let the cancellable refresh task get
  cancelled mid-await on the next notification, leaving the tree with
  a gap. The next refresh ran the regular MRU placement path and the
  replacement tab landed in a different slot — most visible in
  Ghostty where each click reshuffles which tabs `AXWindows` reports.

## Fix

Opt-in per app to keep risk small.

- `KnownBundleId.hasTabsAsWindows` — predicate, currently true for
  Fork and Ghostty. `AXWindows` cannot replace `containingWindowId()`
  globally because it does not include windows on inactive macOS
  Spaces (existing comment in `accessibility.swift`).
- `refreshAndGetAliveWindowIds` — for these apps, intersect the alive
  set with the application's `AXWindows`. Skip this filter while the
  left mouse button is down, so the in-flight click does not strip
  the old tab when the new one cannot yet be registered.
- `getFocusedWindow` — register the focused tab first; only after
  that succeeds do we prune stale tab AX entries. Then perform the
  stale-tab unbind and the new-tab bind in a single synchronous
  main-actor section via the new
  `MacWindow.registerWithInheritedBinding`. The tree is never
  observable in a "gap" state, and the cancellable refresh task
  cannot interleave the two halves.

The change adds zero new behavior for apps not in the predicate.

## Verification

- `swift test` — 122 tests pass.
- Manual: Fork with 5 tabs went from `aerospace list-windows --all`
  reporting 5 entries to 1, matching `count windows` via
  AppleScript/System Events. Rapid tab clicks keep the count at 1 and
  produce no visible flicker. Same for Ghostty with multiple tabbed
  windows — previous build flickered intermittently when clicking
  tabs in a Ghostty window; with this build the user reports no more
  flicker.
- Other multi-window apps in the existing dump suite (Chrome, Firefox,
  Slack, etc.) are untouched because `hasTabsAsWindows` is false for
  them.

## Notes

CONTRIBUTING.md asks for a prior discussion for non-trivial,
user-visible changes. Happy to move the discussion to an issue first
if you'd prefer — feel free to close and I'll reopen with a
discussion link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)