### PR TITLE
Single Window and Accordions Aspect Ratio

### DIFF
--- a/Sources/AppBundle/config/Config.swift
+++ b/Sources/AppBundle/config/Config.swift
@@ -57,6 +57,7 @@ struct Config: ConvenienceCopyable {
 
     var gaps: Gaps = .zero
     var singleWindowAspectRatio: AspectRatio? = nil
+    var applyAspectToAccordion: ApplyAspectOrientation = .all
     var workspaceToMonitorForceAssignment: [String: [MonitorDescription]] = [:]
     var modes: [String: Mode] = [:]
     var onWindowDetected: [WindowDetectedCallback] = []
@@ -70,4 +71,17 @@ enum DefaultContainerOrientation: String {
 struct AspectRatio: Equatable, Sendable {
     let width: CGFloat
     let height: CGFloat
+}
+
+enum ApplyAspectOrientation: String {
+    case vertical, horizontal, all, none
+
+    func matches(_ orientation: Orientation) -> Bool {
+        switch self {
+            case .all: return true
+            case .horizontal: return orientation == .h
+            case .vertical: return orientation == .v
+            case .none: return false
+        }
+    }
 }

--- a/Sources/AppBundle/config/Config.swift
+++ b/Sources/AppBundle/config/Config.swift
@@ -56,6 +56,7 @@ struct Config: ConvenienceCopyable {
     var onFocusedMonitorChanged: [any Command] = []
 
     var gaps: Gaps = .zero
+    var singleWindowAspectRatio: AspectRatio? = nil
     var workspaceToMonitorForceAssignment: [String: [MonitorDescription]] = [:]
     var modes: [String: Mode] = [:]
     var onWindowDetected: [WindowDetectedCallback] = []
@@ -64,4 +65,9 @@ struct Config: ConvenienceCopyable {
 
 enum DefaultContainerOrientation: String {
     case horizontal, vertical, auto
+}
+
+struct AspectRatio: Equatable, Sendable {
+    let width: CGFloat
+    let height: CGFloat
 }

--- a/Sources/AppBundle/config/parseConfig.swift
+++ b/Sources/AppBundle/config/parseConfig.swift
@@ -122,6 +122,7 @@ private let configParser: [String: any ParserProtocol<Config>] = [
     modeConfigRootKey: Parser(\.modes, skipParsing(Config().modes)), // Parsed manually
 
     "gaps": Parser(\.gaps, parseGaps),
+    "single-window-aspect-ratio": Parser(\.singleWindowAspectRatio, parseSingleWindowAspectRatio),
     "workspace-to-monitor-force-assignment": Parser(\.workspaceToMonitorForceAssignment, parseWorkspaceToMonitorAssignment),
     "on-window-detected": Parser(\.onWindowDetected, parseOnWindowDetectedArray),
 
@@ -360,6 +361,16 @@ private func parseArrayOfStrings(_ raw: Json, _ backtrace: ConfigBacktrace) -> P
                 parseString(elem, backtrace + .index(index))
             }
         }
+}
+
+private func parseSingleWindowAspectRatio(_ raw: Json, _ backtrace: ConfigBacktrace) -> ParsedConfig<AspectRatio?> {
+    parseString(raw, backtrace).flatMap { str in
+        let parts = str.split(whereSeparator: { $0 == ":" || $0 == " " }).compactMap { Double($0) }
+        guard parts.count == 2, parts[0] > 0, parts[1] > 0 else {
+            return .failure(.semantic(backtrace, "Expected format 'WIDTH:HEIGHT' (e.g. '16:9')"))
+        }
+        return .success(AspectRatio(width: CGFloat(parts[0]), height: CGFloat(parts[1])))
+    }
 }
 
 private func parseDefaultContainerOrientation(_ raw: Json, _ backtrace: ConfigBacktrace) -> ParsedConfig<DefaultContainerOrientation> {

--- a/Sources/AppBundle/config/parseConfig.swift
+++ b/Sources/AppBundle/config/parseConfig.swift
@@ -123,6 +123,7 @@ private let configParser: [String: any ParserProtocol<Config>] = [
 
     "gaps": Parser(\.gaps, parseGaps),
     "single-window-aspect-ratio": Parser(\.singleWindowAspectRatio, parseSingleWindowAspectRatio),
+    "apply-aspect-to-accordion": Parser(\.applyAspectToAccordion, parseApplyAspectOrientation),
     "workspace-to-monitor-force-assignment": Parser(\.workspaceToMonitorForceAssignment, parseWorkspaceToMonitorAssignment),
     "on-window-detected": Parser(\.onWindowDetected, parseOnWindowDetectedArray),
 
@@ -370,6 +371,13 @@ private func parseSingleWindowAspectRatio(_ raw: Json, _ backtrace: ConfigBacktr
             return .failure(.semantic(backtrace, "Expected format 'WIDTH:HEIGHT' (e.g. '16:9')"))
         }
         return .success(AspectRatio(width: CGFloat(parts[0]), height: CGFloat(parts[1])))
+    }
+}
+
+private func parseApplyAspectOrientation(_ raw: Json, _ backtrace: ConfigBacktrace) -> ParsedConfig<ApplyAspectOrientation> {
+    parseString(raw, backtrace).flatMap {
+        ApplyAspectOrientation(rawValue: $0)
+            .orFailure(.semantic(backtrace, "Expected 'vertical', 'horizontal', 'all', or 'none'"))
     }
 }
 

--- a/Sources/AppBundle/layout/layoutRecursive.swift
+++ b/Sources/AppBundle/layout/layoutRecursive.swift
@@ -8,7 +8,21 @@ extension Workspace {
         // If monitors are aligned vertically and the monitor below has smaller width, then macOS may not allow the
         // window on the upper monitor to take full width. rect.height - 1 resolves this problem
         // But I also faced this problem in monitors horizontal configuration. ¯\_(ツ)_/¯
-        try await layoutRecursive(rect.topLeftCorner, width: rect.width, height: rect.height - 1, virtual: rect, LayoutContext(self))
+        var point = rect.topLeftCorner
+        var width = rect.width
+        let height = rect.height - 1
+        var virtual = rect
+        if let ratio = config.singleWindowAspectRatio,
+           rootTilingContainer.hasSingleLeafWindowRecursive {
+            let constrainedWidth = height * ratio.width / ratio.height
+            if constrainedWidth < width {
+                let xOffset = (width - constrainedWidth) / 2
+                point = CGPoint(x: rect.topLeftX + xOffset, y: rect.topLeftY)
+                virtual = Rect(topLeftX: rect.topLeftX + xOffset, topLeftY: rect.topLeftY, width: constrainedWidth, height: rect.height)
+                width = constrainedWidth
+            }
+        }
+        try await layoutRecursive(point, width: width, height: height, virtual: virtual, LayoutContext(self))
     }
 }
 

--- a/Sources/AppBundle/layout/layoutRecursive.swift
+++ b/Sources/AppBundle/layout/layoutRecursive.swift
@@ -13,7 +13,8 @@ extension Workspace {
         let height = rect.height - 1
         var virtual = rect
         if let ratio = config.singleWindowAspectRatio,
-           rootTilingContainer.hasSingleLeafWindowRecursive {
+           rootTilingContainer.hasSingleLeafWindowRecursive
+        {
             let constrainedWidth = height * ratio.width / ratio.height
             if constrainedWidth < width {
                 let xOffset = (width - constrainedWidth) / 2

--- a/Sources/AppBundle/layout/layoutRecursive.swift
+++ b/Sources/AppBundle/layout/layoutRecursive.swift
@@ -12,9 +12,7 @@ extension Workspace {
         var width = rect.width
         let height = rect.height - 1
         var virtual = rect
-        if let ratio = config.singleWindowAspectRatio,
-           rootTilingContainer.hasSingleLeafWindowRecursive
-        {
+        if let ratio = config.singleWindowAspectRatio, shouldApplyAspectRatio(to: rootTilingContainer) {
             let constrainedWidth = height * ratio.width / ratio.height
             if constrainedWidth < width {
                 let xOffset = (width - constrainedWidth) / 2
@@ -25,6 +23,24 @@ extension Workspace {
         }
         try await layoutRecursive(point, width: width, height: height, virtual: virtual, LayoutContext(self))
     }
+}
+
+@MainActor
+private func shouldApplyAspectRatio(to root: TilingContainer) -> Bool {
+    if root.hasSingleLeafWindowRecursive { return true }
+    let accordion: TilingContainer
+    if root.layout == .accordion {
+        accordion = root
+    } else if root.children.count == 1,
+              let child = root.children.first as? TilingContainer,
+              child.layout == .accordion
+    {
+        accordion = child
+    } else {
+        return false
+    }
+    return accordion.children.allSatisfy { $0 is Window }
+        && config.applyAspectToAccordion.matches(accordion.orientation)
 }
 
 extension TreeNode {

--- a/Sources/AppBundle/tree/TreeNodeEx.swift
+++ b/Sources/AppBundle/tree/TreeNodeEx.swift
@@ -66,6 +66,19 @@ extension TreeNode {
         anyLeafWindowRecursive == nil
     }
 
+    var hasSingleLeafWindowRecursive: Bool {
+        var found = false
+        func visit(_ node: TreeNode) -> Bool {
+            if node is Window {
+                if found { return false }
+                found = true
+                return true
+            }
+            return node.children.allSatisfy { visit($0) }
+        }
+        return visit(self) && found
+    }
+
     @MainActor
     var hWeight: CGFloat {
         get { getWeight(.h) }


### PR DESCRIPTION
## PR checklist

- [x] Explain your changes in the relevant commit messages rather than in the PR description. The PR description must not contain more information than the commit messages (except for images and other media).
- [x] Each commit must explain what/why/how and motivation in its description. https://cbea.ms/git-commit/
- [x] Don't forget to link the appropriate issues/discussions in commit messages (if applicable).
- [x] Each commit must be an atomic change (a PR may contain several commits). Don't introduce new functional changes together with refactorings in the same commit.
- [x] `./test.sh` exits with non-zero exit code.
- [x] Avoid merge commits, always rebase and force push.

Failure to follow the checklist with no apparent reasons will result in silent PR rejection.

## Problem
Tiling window managers on ultrawide displays stretch single windows across the full screen width, making them uncomfortable to use. This is a common pain point for ultrawide users who currently have to rely on external scripts that manipulate outer gaps as a workaround.

Closes #60

## Solution
Adds two new configuration options:

```toml
single-window-aspect-ratio = '16 9'
apply-aspect-to-accordion = 'all'  # all | vertical | horizontal | none
```

When a workspace contains only a single window, **or** a single accordion tile matching the configured orientation, AeroSpace will:
- **Center** the window/tile
- **Constrain its width** to match the given aspect ratio
- **Maximize its height**

This gives ultrawide users a native, config-driven solution without any external scripts or gap workarounds.

