### PR TITLE
Fix infinite AX prompt loop on macOS 26 Tahoe

### DIFF
--- a/.github/workflows/publish-castrozan-release.yml
+++ b/.github/workflows/publish-castrozan-release.yml
@@ -1,0 +1,55 @@
+name: publish-castrozan-release
+
+on:
+  push:
+    branches:
+      - "fix/**"
+      - "feat/**"
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-publish:
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: ./.github/gh-actions-runner-xcode-select.sh
+
+      - run: brew install bash fish xcbeautify swiftly
+
+      - run: swiftly init --skip-install --assume-yes --verbose && swiftly install
+
+      - name: build release
+        run: |
+          ./build-release.sh --codesign-identity - --build-version "${GITHUB_SHA::7}-castrozan"
+
+      - name: package zip
+        id: package
+        run: |
+          mkdir -p .release-out
+          (cd .release && zip -r ../.release-out/AeroSpace.app.zip AeroSpace.app aerospace)
+          echo "zip_path=.release-out/AeroSpace.app.zip" >> "$GITHUB_OUTPUT"
+          sha=$(/usr/bin/shasum -a 256 .release-out/AeroSpace.app.zip | awk '{print $1}')
+          echo "sha256=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: derive release tag from branch
+        id: tag
+        run: |
+          branch="${GITHUB_REF#refs/heads/}"
+          tag="castrozan-${branch//\//-}"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: publish or refresh release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${{ steps.tag.outputs.tag }}"
+          gh release delete "$tag" --yes --cleanup-tag 2>/dev/null || true
+          gh release create "$tag" \
+            --target "$GITHUB_SHA" \
+            --title "Castrozan fork build for $tag" \
+            --notes "Automated build from commit $GITHUB_SHA on branch ${GITHUB_REF#refs/heads/}. SHA256: ${{ steps.package.outputs.sha256 }}" \
+            --prerelease \
+            "${{ steps.package.outputs.zip_path }}"

--- a/Sources/AppBundle/command/impl/DebugWindowsCommand.swift
+++ b/Sources/AppBundle/command/impl/DebugWindowsCommand.swift
@@ -78,9 +78,8 @@ private func dumpWindowDebugInfo(_ window: Window) async throws -> String {
     var result: [String: Json] = try await window.dumpAxInfo()
 
     let windowLevel = getWindowLevel(for: window.windowId)
-    let windowLevelJson = (try? JSONEncoder().encode(windowLevel))
-        .flatMap { String(data: $0, encoding: .utf8) }
-    result["Aero.windowLevel"] = .stringOrNull(windowLevelJson)
+    let windowLevelJson = windowLevel?.toJson() ?? .null
+    result["Aero.windowLevel"] = windowLevelJson
     result["Aero.axWindowId"] = .uint32(window.windowId)
     result["Aero.workspace"] = .stringOrNull(window.nodeWorkspace?.name)
     result["Aero.treeNodeParent"] = .string(String(describing: window.parent))

--- a/Sources/AppBundle/command/impl/EnableCommand.swift
+++ b/Sources/AppBundle/command/impl/EnableCommand.swift
@@ -13,8 +13,10 @@ struct EnableCommand: Command {
             case .toggle: !TrayMenuModel.shared.isEnabled
         }
         if newState == prevState {
-            io.out((newState ? "Already enabled" : "Already disabled") +
-                "Tip: use --fail-if-noop to exit with non-zero code")
+            if !args.failIfNoop {
+                io.out((newState ? "Already enabled" : "Already disabled") +
+                    "Tip: use --fail-if-noop to exit with non-zero code")
+            }
             return !args.failIfNoop
         }
 

--- a/Sources/AppBundle/command/impl/MacosNativeFullscreenCommand.swift
+++ b/Sources/AppBundle/command/impl/MacosNativeFullscreenCommand.swift
@@ -22,8 +22,10 @@ struct MacosNativeFullscreenCommand: Command {
             case .toggle: !prevState
         }
         if newState == prevState {
-            io.err((newState ? "Already fullscreen. " : "Already not fullscreen. ") +
-                "Tip: use --fail-if-noop to exit with non-zero exit code")
+            if !args.failIfNoop {
+                io.err((newState ? "Already fullscreen. " : "Already not fullscreen. ") +
+                    "Tip: use --fail-if-noop to exit with non-zero exit code")
+            }
             return !args.failIfNoop
         }
         window.asMacWindow().setNativeFullscreen(newState)

--- a/Sources/AppBundle/command/impl/MoveMouseCommand.swift
+++ b/Sources/AppBundle/command/impl/MoveMouseCommand.swift
@@ -12,7 +12,9 @@ struct MoveMouseCommand: Command {
             case .windowLazyCenter:
                 guard let rect = try await windowSubjectRectOrReportError(target, io) else { return false }
                 if rect.contains(mouse) {
-                    io.err("The mouse already belongs to the window. Tip: use --fail-if-noop to exit with non-zero code")
+                    if !args.failIfNoop {
+                        io.err("The mouse already belongs to the window. Tip: use --fail-if-noop to exit with non-zero code")
+                    }
                     return !args.failIfNoop
                 }
                 return moveMouse(io, rect.center)
@@ -22,7 +24,9 @@ struct MoveMouseCommand: Command {
             case .monitorLazyCenter:
                 let rect = target.workspace.workspaceMonitor.rect
                 if rect.contains(mouse) {
-                    io.err("The mouse already belongs to the monitor. Tip: use --fail-if-noop to exit with non-zero code")
+                    if !args.failIfNoop {
+                        io.err("The mouse already belongs to the monitor. Tip: use --fail-if-noop to exit with non-zero code")
+                    }
                     return !args.failIfNoop
                 }
                 return moveMouse(io, rect.center)

--- a/Sources/AppBundle/command/impl/MoveNodeToWorkspaceCommand.swift
+++ b/Sources/AppBundle/command/impl/MoveNodeToWorkspaceCommand.swift
@@ -31,7 +31,9 @@ struct MoveNodeToWorkspaceCommand: Command {
 @MainActor
 func moveWindowToWorkspace(_ window: Window, _ targetWorkspace: Workspace, _ io: CmdIo, focusFollowsWindow: Bool, failIfNoop: Bool, index: Int = INDEX_BIND_LAST) -> Bool {
     if window.nodeWorkspace == targetWorkspace {
-        io.err("Window '\(window.windowId)' already belongs to workspace '\(targetWorkspace.name)'. Tip: use --fail-if-noop to exit with non-zero code")
+        if !failIfNoop {
+            io.err("Window '\(window.windowId)' already belongs to workspace '\(targetWorkspace.name)'. Tip: use --fail-if-noop to exit with non-zero code")
+        }
         return !failIfNoop
     }
     let targetContainer: NonLeafTreeNodeObject = window.isFloating ? targetWorkspace : targetWorkspace.rootTilingContainer

--- a/Sources/AppBundle/command/impl/SummonWorkspaceCommand.swift
+++ b/Sources/AppBundle/command/impl/SummonWorkspaceCommand.swift
@@ -9,7 +9,9 @@ struct SummonWorkspaceCommand: Command {
         let workspace = Workspace.get(byName: args.target.val.raw)
         let monitor = focus.workspace.workspaceMonitor
         if monitor.activeWorkspace == workspace {
-            io.err("Workspace '\(workspace.name)' is already visible on the focused monitor. Tip: use --fail-if-noop to exit with non-zero code")
+            if !args.failIfNoop {
+                io.err("Workspace '\(workspace.name)' is already visible on the focused monitor. Tip: use --fail-if-noop to exit with non-zero code")
+            }
             return !args.failIfNoop
         }
         if monitor.setActiveWorkspace(workspace) {

--- a/Sources/AppBundle/command/impl/WorkspaceCommand.swift
+++ b/Sources/AppBundle/command/impl/WorkspaceCommand.swift
@@ -28,7 +28,9 @@ struct WorkspaceCommand: Command {
                 }
         }
         if focusedWs.name == workspaceName {
-            io.err("Workspace '\(workspaceName)' is already focused. Tip: use --fail-if-noop to exit with non-zero code")
+            if !args.failIfNoop {
+                io.err("Workspace '\(workspaceName)' is already focused. Tip: use --fail-if-noop to exit with non-zero code")
+            }
             return !args.failIfNoop
         } else {
             return Workspace.get(byName: workspaceName).focusWorkspace()

--- a/Sources/AppBundle/config/HotkeyBinding.swift
+++ b/Sources/AppBundle/config/HotkeyBinding.swift
@@ -33,7 +33,7 @@ extension HotKey {
         hotkeys[binding.descriptionWithKeyCode] = HotKey(key: binding.keyCode, modifiers: binding.modifiers, keyDownHandler: {
             Task {
                 if let activeMode {
-                    try await runLightSession(.hotkeyBinding, .checkServerIsEnabledOrDie) { () throws in
+                    try await runLightSession(.hotkeyBinding, .checkServerIsEnabledOrDie()) { () throws in
                         _ = try await config.modes[activeMode]?.bindings[binding.descriptionWithKeyCode]?.commands
                             .runCmdSeq(.defaultEnv, .emptyStdin)
                     }

--- a/Sources/AppBundle/config/parseConfig.swift
+++ b/Sources/AppBundle/config/parseConfig.swift
@@ -6,18 +6,21 @@ import OrderedCollections
 
 @MainActor
 func readConfig(forceConfigUrl: URL? = nil) -> Result<(Config, URL), String> {
-    let customConfigUrl: URL
-    switch findCustomConfigUrl() {
-        case .file(let url): customConfigUrl = url
-        case .noCustomConfigExists: customConfigUrl = defaultConfigUrl
-        case .ambiguousConfigError(let candidates):
-            let msg = """
-                Ambiguous config error. Several configs found:
-                \(candidates.map(\.path).joined(separator: "\n"))
-                """
-            return .failure(msg)
+    let configUrl: URL
+    if let forceConfigUrl {
+        configUrl = forceConfigUrl
+    } else {
+        switch findCustomConfigUrl() {
+            case .file(let url): configUrl = url
+            case .noCustomConfigExists: configUrl = defaultConfigUrl
+            case .ambiguousConfigError(let candidates):
+                let msg = """
+                    Ambiguous config error. Several configs found:
+                    \(candidates.map(\.path).joined(separator: "\n"))
+                    """
+                return .failure(msg)
+        }
     }
-    let configUrl: URL = forceConfigUrl ?? customConfigUrl
     let (parsedConfig, errors) = (try? String(contentsOf: configUrl)).map { parseConfig($0) } ?? (defaultConfig, [])
 
     if errors.isEmpty {

--- a/Sources/AppBundle/initAppBundle.swift
+++ b/Sources/AppBundle/initAppBundle.swift
@@ -15,7 +15,7 @@ import Foundation
         if try await !reloadConfig() {
             var out = ""
             check(
-                try await !reloadConfig(forceConfigUrl: defaultConfigUrl, stdout: &out),
+                try await reloadConfig(forceConfigUrl: defaultConfigUrl, stdout: &out),
                 """
                 Can't load default config. Your installation is probably corrupted.
                 Please don't change default-config.toml

--- a/Sources/AppBundle/initAppBundle.swift
+++ b/Sources/AppBundle/initAppBundle.swift
@@ -18,7 +18,7 @@ import Foundation
                 try await reloadConfig(forceConfigUrl: defaultConfigUrl, stdout: &out),
                 """
                 Can't load default config. Your installation is probably corrupted.
-                Please don't change default-config.toml
+                Please don't modify '\(defaultConfigUrl)'
 
                 \(out)
                 """,

--- a/Sources/AppBundle/initAppBundle.swift
+++ b/Sources/AppBundle/initAppBundle.swift
@@ -31,7 +31,7 @@ import Foundation
         Workspace.garbageCollectUnusedWorkspaces() // init workspaces
         _ = Workspace.all.first?.focusWorkspace()
         try await runRefreshSessionBlocking(.startup, layoutWorkspaces: false)
-        try await runLightSession(.startup, .checkServerIsEnabledOrDie) {
+        try await runLightSession(.startup, .checkServerIsEnabledOrDie()) {
             smartLayoutAtStartup()
             _ = try await config.afterStartupCommand.runCmdSeq(.defaultEnv, .emptyStdin)
         }

--- a/Sources/AppBundle/initAppBundle.swift
+++ b/Sources/AppBundle/initAppBundle.swift
@@ -31,7 +31,7 @@ import Foundation
         Workspace.garbageCollectUnusedWorkspaces() // init workspaces
         _ = Workspace.all.first?.focusWorkspace()
         try await runRefreshSessionBlocking(.startup, layoutWorkspaces: false)
-        try await runLightSession(.startup, .checkServerIsEnabledOrDie()) {
+        try await runLightSession(.startup, .forceRun) {
             smartLayoutAtStartup()
             _ = try await config.afterStartupCommand.runCmdSeq(.defaultEnv, .emptyStdin)
         }

--- a/Sources/AppBundle/layout/layoutRecursive.swift
+++ b/Sources/AppBundle/layout/layoutRecursive.swift
@@ -69,16 +69,23 @@ extension Window {
     @MainActor
     fileprivate func layoutFloatingWindow(_ context: LayoutContext) async throws {
         let workspace = context.workspace
-        let currentMonitor = try await getCenter()?.monitorApproximation // Probably not idempotent
-        if let currentMonitor, let windowTopLeftCorner = try await getAxTopLeftCorner(), workspace != currentMonitor.activeWorkspace {
+        let windowRect = try await getAxRect() // Probably not idempotent
+        let currentMonitor = windowRect?.center.monitorApproximation
+        if let currentMonitor, let windowRect, workspace != currentMonitor.activeWorkspace {
+            let windowTopLeftCorner = windowRect.topLeftCorner
             let xProportion = (windowTopLeftCorner.x - currentMonitor.visibleRect.topLeftX) / currentMonitor.visibleRect.width
             let yProportion = (windowTopLeftCorner.y - currentMonitor.visibleRect.topLeftY) / currentMonitor.visibleRect.height
 
-            let moveTo = workspace.workspaceMonitor
-            setAxFrame(CGPoint(
-                x: moveTo.visibleRect.topLeftX + xProportion * moveTo.visibleRect.width,
-                y: moveTo.visibleRect.topLeftY + yProportion * moveTo.visibleRect.height,
-            ), nil)
+            let workspaceRect = workspace.workspaceMonitor.visibleRect
+            var newX = workspaceRect.topLeftX + xProportion * workspaceRect.width
+            var newY = workspaceRect.topLeftY + yProportion * workspaceRect.height
+
+            let windowWidth = windowRect.width
+            let windowHeight = windowRect.height
+            newX = newX.coerceIn(workspaceRect.minX ... max(workspaceRect.minX, workspaceRect.maxX - windowWidth))
+            newY = newY.coerceIn(workspaceRect.minY ... max(workspaceRect.minY, workspaceRect.maxY - windowHeight))
+
+            setAxFrame(CGPoint(x: newX, y: newY), nil)
         }
         if isFullscreen {
             layoutFullscreen(context)

--- a/Sources/AppBundle/layout/refresh.swift
+++ b/Sources/AppBundle/layout/refresh.swift
@@ -88,7 +88,14 @@ struct RunSessionGuard: Sendable {
         command is EnableCommand ? .forceRun : .isServerEnabled
     }
     @MainActor
-    static var checkServerIsEnabledOrDie: RunSessionGuard { .isServerEnabled ?? dieT("server is disabled") }
+    static func checkServerIsEnabledOrDie(
+        file: String = #fileID,
+        line: Int = #line,
+        column: Int = #column,
+        function: String = #function,
+    ) -> RunSessionGuard {
+        .isServerEnabled ?? dieT("server is disabled", file: file, line: line, column: column, function: function)
+    }
     static let forceRun = RunSessionGuard()
     private init() {}
 }

--- a/Sources/AppBundle/layout/refresh.swift
+++ b/Sources/AppBundle/layout/refresh.swift
@@ -104,7 +104,7 @@ func refreshModel() {
 private func refresh() async throws {
     // Garbage collect terminated apps and windows before working with all windows
     let mapping = try await MacApp.refreshAllAndGetAliveWindowIds(frontmostAppBundleId: NSWorkspace.shared.frontmostApplication?.bundleIdentifier)
-    let aliveWindowIds = mapping.values.flatMap { $0 }
+    let aliveWindowIds = mapping.values.flatMap { $0 }.toSet()
 
     for window in MacWindow.allWindows {
         if !aliveWindowIds.contains(window.windowId) {

--- a/Sources/AppBundle/tree/MacWindow.swift
+++ b/Sources/AppBundle/tree/MacWindow.swift
@@ -163,11 +163,16 @@ final class MacWindow: Window {
             // Tiling windows should be unhidden with layoutRecursive anyway
             case .floatingWindow:
                 let workspaceRect = nodeWorkspace.workspaceMonitor.rect
-                let pointInsideWorkspace = CGPoint(
-                    x: workspaceRect.width * prevUnhiddenProportionalPositionInsideWorkspaceRect.x,
-                    y: workspaceRect.height * prevUnhiddenProportionalPositionInsideWorkspaceRect.y,
-                )
-                setAxFrame(workspaceRect.topLeftCorner + pointInsideWorkspace, nil)
+                var newX = workspaceRect.topLeftX + workspaceRect.width * prevUnhiddenProportionalPositionInsideWorkspaceRect.x
+                var newY = workspaceRect.topLeftY + workspaceRect.height * prevUnhiddenProportionalPositionInsideWorkspaceRect.y
+                // todo we probably should replace lastFloatingSize with proper floating window sizing
+                // https://github.com/nikitabobko/AeroSpace/issues/1519
+                let windowWidth = lastFloatingSize?.width ?? 0
+                let windowHeight = lastFloatingSize?.height ?? 0
+                newX = newX.coerceIn(workspaceRect.minX ... max(workspaceRect.minX, workspaceRect.maxX - windowWidth))
+                newY = newY.coerceIn(workspaceRect.minY ... max(workspaceRect.minY, workspaceRect.maxY - windowHeight))
+
+                setAxFrame(CGPoint(x: newX, y: newY), nil)
             case .macosNativeFullscreenWindow, .macosNativeHiddenAppWindow, .macosNativeMinimizedWindow,
                  .macosPopupWindow, .tiling, .rootTilingContainer, .shimContainerRelation: break
         }

--- a/Sources/AppBundle/tree/MacWindow.swift
+++ b/Sources/AppBundle/tree/MacWindow.swift
@@ -125,15 +125,17 @@ final class MacWindow: Window {
     @MainActor
     func hideInCorner(_ corner: OptimalHideCorner) async throws {
         guard let nodeMonitor else { return }
-        // Don't accidentally override prevUnhiddenEmulationPosition in case of subsequent
-        // `hideEmulation` calls
+        // Don't accidentally override prevUnhiddenEmulationPosition in case of subsequent `hideInCorner` calls
         if !isHiddenInCorner {
             guard let windowRect = try await getAxRect() else { return }
-            let topLeftCorner = windowRect.topLeftCorner
-            let monitorRect = windowRect.center.monitorApproximation.rect // Similar to layoutFloatingWindow. Non idempotent
-            let absolutePoint = topLeftCorner - monitorRect.topLeftCorner
-            prevUnhiddenProportionalPositionInsideWorkspaceRect =
-                CGPoint(x: absolutePoint.x / monitorRect.width, y: absolutePoint.y / monitorRect.height)
+            // Check for isHiddenInCorner for the second time because of the suspension point above
+            if !isHiddenInCorner {
+                let topLeftCorner = windowRect.topLeftCorner
+                let monitorRect = windowRect.center.monitorApproximation.rect // Similar to layoutFloatingWindow. Non idempotent
+                let absolutePoint = topLeftCorner - monitorRect.topLeftCorner
+                prevUnhiddenProportionalPositionInsideWorkspaceRect =
+                    CGPoint(x: absolutePoint.x / monitorRect.width, y: absolutePoint.y / monitorRect.height)
+            }
         }
         let p: CGPoint
         switch corner {

--- a/Sources/AppBundle/ui/SecureInputView.swift
+++ b/Sources/AppBundle/ui/SecureInputView.swift
@@ -15,23 +15,20 @@ public final class SecureInputPanel: NSPanelHud {
 
     @MainActor
     public func refresh() {
-        lazy var isSecureInputEnabled = IsSecureEventInputEnabled()
-        switch true {
-            case isVisible && !TrayMenuModel.shared.isEnabled:
-                close()
-            case isSecureInputEnabled == isVisible:
-                break
-            case isSecureInputEnabled:
-                self.contentView?.subviews.removeAll()
-                hostingView = NSHostingView(rootView: SecureInputView())
-                hostingView.frame = NSRect(x: 0, y: 0, width: iconSize.width, height: iconSize.height)
-                self.contentView?.addSubview(hostingView)
-                let x = mainMonitor.width - iconSize.width - 20
-                let panelFrame = NSRect(x: x, y: 20, width: iconSize.width, height: iconSize.width)
-                self.setFrame(panelFrame, display: true)
-                self.orderFrontRegardless()
-            default:
-                close()
+        if let activeMode, TrayMenuModel.shared.isEnabled &&
+            config.modes[activeMode]?.bindings.isEmpty == false && IsSecureEventInputEnabled()
+        {
+            if isVisible { return }
+            self.contentView?.subviews.removeAll()
+            hostingView = NSHostingView(rootView: SecureInputView())
+            hostingView.frame = NSRect(x: 0, y: 0, width: iconSize.width, height: iconSize.height)
+            self.contentView?.addSubview(hostingView)
+            let x = mainMonitor.width - iconSize.width - 20
+            let panelFrame = NSRect(x: x, y: 20, width: iconSize.width, height: iconSize.width)
+            self.setFrame(panelFrame, display: true)
+            self.orderFrontRegardless()
+        } else {
+            close()
         }
     }
 

--- a/Sources/AppBundle/util/accessibility.swift
+++ b/Sources/AppBundle/util/accessibility.swift
@@ -5,14 +5,20 @@ import PrivateApi
 @MainActor
 func checkAccessibilityPermissions() {
     let options = [axTrustedCheckOptionPrompt: true]
-    if !AXIsProcessTrustedWithOptions(options as CFDictionary) {
-        resetAccessibility() // Because macOS doesn't reset it for us when the app signature changes...
-        terminateApp()
-    }
-}
-
-private func resetAccessibility() {
-    _ = try? Process.run(URL(filePath: "/usr/bin/tccutil"), arguments: ["reset", "Accessibility", aeroSpaceAppId])
+    _ = AXIsProcessTrustedWithOptions(options as CFDictionary)
+    // On macOS 26 (Tahoe), AXIsProcessTrustedWithOptions returns false for
+    // ad-hoc-signed binaries even after the user grants accessibility,
+    // because Tahoe added a strict "anchor apple" platform-requirement check
+    // to TCC that ad-hoc signatures cannot satisfy. The previous behaviour
+    // (calling tccutil reset + terminateApp on a false return) caused an
+    // infinite re-prompt loop under launchd KeepAlive: every launch failed
+    // the trust check, reset its own TCC entry, exited, and got respawned,
+    // re-prompting the user each time.
+    //
+    // We now fire the prompt once (no-op when AX is already trusted) and
+    // continue. If AX is genuinely not granted, the AX calls themselves
+    // will fail later and the user can grant via System Settings without
+    // AeroSpace fighting its own TCC state.
 }
 
 protocol ReadableAttr: Sendable {

--- a/Sources/AppBundle/windowLevelCache.swift
+++ b/Sources/AppBundle/windowLevelCache.swift
@@ -20,29 +20,39 @@ func getWindowLevel(for windowId: UInt32) -> MacOsWindowLevel? {
         guard let _windowId = dict[kCGWindowNumber] else { continue }
         let windowId = ((_windowId as! CFNumber) as NSNumber).uint32Value
 
-        result[windowId] = .new(layerNumber: windowLayer)
+        result[windowId] = .new(windowLevel: windowLayer)
     }
     cache = result
     return result[windowId]
 }
 
-enum MacOsWindowLevel: Sendable, Codable, Equatable {
+enum MacOsWindowLevel: Sendable, Equatable {
     case normalWindow
     case alwaysOnTopWindow
-    case unknown(layerNumber: Int)
+    case unknown(windowLevel: Int)
 
-    static func new(layerNumber: Int) -> MacOsWindowLevel {
-        switch layerNumber {
+    static func new(windowLevel: Int) -> MacOsWindowLevel {
+        switch windowLevel {
             case 0: .normalWindow
             case 3: .alwaysOnTopWindow
-            default: .unknown(layerNumber: layerNumber)
+            default: .unknown(windowLevel: windowLevel)
         }
     }
 
-    var normalize: MacOsWindowLevel {
+    static func fromJson(_ json: Json) -> MacOsWindowLevel? {
+        switch json {
+            case .string(let str) where str == "normalWindow": .normalWindow
+            case .string(let str) where str == "alwaysOnTopWindow": .alwaysOnTopWindow
+            case .int(let int): .new(windowLevel: int)
+            default: nil
+        }
+    }
+
+    func toJson() -> Json {
         switch self {
-            case .unknown(let layerNumber): .new(layerNumber: layerNumber)
-            default: self
+            case .normalWindow: .string("normalWindow")
+            case .alwaysOnTopWindow: .string("alwaysOnTopWindow")
+            case .unknown(let layerNumber): .int(layerNumber)
         }
     }
 }

--- a/Sources/AppBundleTests/AxUiElementWindowTypeTest.swift
+++ b/Sources/AppBundleTests/AxUiElementWindowTypeTest.swift
@@ -20,9 +20,7 @@ func checkAxDumpsRecursive(_ dir: URL) throws {
         let json = Json.newOrDie(rawJson).asDictOrDie
         let app = json["Aero.AXApp"]!.asDictOrDie
         let appBundleId = (rawJson["Aero.App.appBundleId"] as? String).flatMap { KnownBundleId.init(rawValue: $0) }
-        let windowLevel = (rawJson["Aero.windowLevel"] as? String)?.data(using: .utf8)
-            .map { (try? JSONDecoder().decode(MacOsWindowLevel.self, from: $0)) ?? dieT() }?
-            .normalize
+        let windowLevel = json["Aero.windowLevel"].map { MacOsWindowLevel.fromJson($0) ?? dieT() }
         let activationPolicy: NSApplication.ActivationPolicy = .from(string: rawJson["Aero.App.nsApp.activationPolicy"] as! String)
         assertEquals(
             json.getWindowType(axApp: app, appBundleId, activationPolicy, windowLevel),

--- a/axDumps/1password.json5
+++ b/axDumps/1password.json5
@@ -100,6 +100,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.TilingContainer)",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "Random"
 }

--- a/axDumps/1password_large_type_window.json5
+++ b/axDumps/1password_large_type_window.json5
@@ -101,6 +101,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.TilingContainer)",
-  "Aero.windowLevel" : "{\"alwaysOnTopWindow\":{}}",
+  "Aero.windowLevel" : "alwaysOnTopWindow",
   "Aero.workspace" : "Random"
 }

--- a/axDumps/1password_mini_window.json5
+++ b/axDumps/1password_mini_window.json5
@@ -104,6 +104,6 @@
     }
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.Workspace)",
-  "Aero.windowLevel" : "{\"alwaysOnTopWindow\":{}}",
+  "Aero.windowLevel" : "alwaysOnTopWindow",
   "Aero.workspace" : "Random"
 }

--- a/axDumps/alacritty_decorations_buttonless.json5
+++ b/axDumps/alacritty_decorations_buttonless.json5
@@ -94,6 +94,6 @@
   "Aero.AxUiElementWindowType_isDialogHeuristic" : false,
   "Aero.AxUiElementWindowType" : "window",
   "Aero.treeNodeParent" : "AppBundle.TilingContainer",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "M"
 }

--- a/axDumps/apple_mail.json5
+++ b/axDumps/apple_mail.json5
@@ -117,6 +117,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.TilingContainer)",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "M"
 }

--- a/axDumps/brave.json5
+++ b/axDumps/brave.json5
@@ -107,6 +107,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.TilingContainer)",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "F"
 }

--- a/axDumps/brave_pip.json5
+++ b/axDumps/brave_pip.json5
@@ -98,6 +98,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.Workspace)",
-  "Aero.windowLevel" : "{\"alwaysOnTopWindow\":{}}",
+  "Aero.windowLevel" : "alwaysOnTopWindow",
   "Aero.workspace" : "F"
 }

--- a/axDumps/calculator.json5
+++ b/axDumps/calculator.json5
@@ -89,6 +89,6 @@
 
   ],
   "Aero.treeNodeParent" : "AppBundle.Workspace",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "M"
 }

--- a/axDumps/chrome.json5
+++ b/axDumps/chrome.json5
@@ -99,6 +99,6 @@
     }
   ],
   "Aero.treeNodeParent" : "AppBundle.TilingContainer",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "F"
 }

--- a/axDumps/chrome_extensions_popup.json5
+++ b/axDumps/chrome_extensions_popup.json5
@@ -65,6 +65,6 @@
     }
   ],
   "Aero.treeNodeParent" : "AppBundle.MacosPopupWindowsContainer",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : null
 }

--- a/axDumps/chrome_find_in_page.json5
+++ b/axDumps/chrome_find_in_page.json5
@@ -65,6 +65,6 @@
     }
   ],
   "Aero.treeNodeParent" : "AppBundle.MacosPopupWindowsContainer",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : null
 }

--- a/axDumps/chrome_pip.json5
+++ b/axDumps/chrome_pip.json5
@@ -65,6 +65,6 @@
     }
   ],
   "Aero.treeNodeParent" : "AppBundle.Workspace",
-  "Aero.windowLevel" : "{\"alwaysOnTopWindow\":{}}",
+  "Aero.windowLevel" : "alwaysOnTopWindow",
   "Aero.workspace" : "F"
 }

--- a/axDumps/chrome_sharing_is_in_progress_popup.json5
+++ b/axDumps/chrome_sharing_is_in_progress_popup.json5
@@ -63,6 +63,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.MacosPopupWindowsContainer)",
-  "Aero.windowLevel" : "{\"unknown\":{\"layerNumber\":25}}",
+  "Aero.windowLevel" : 25,
   "Aero.workspace" : null
 }

--- a/axDumps/cleanshotx_monitor_1.json5
+++ b/axDumps/cleanshotx_monitor_1.json5
@@ -72,6 +72,6 @@
     }
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.MacosPopupWindowsContainer)",
-  "Aero.windowLevel" : "{\"unknown\":{\"layerNumber\":103}}",
+  "Aero.windowLevel" : 103,
   "Aero.workspace" : null
 }

--- a/axDumps/cleanshotx_monitor_2.json5
+++ b/axDumps/cleanshotx_monitor_2.json5
@@ -72,6 +72,6 @@
     }
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.MacosPopupWindowsContainer)",
-  "Aero.windowLevel" : "{\"unknown\":{\"layerNumber\":103}}",
+  "Aero.windowLevel" : 103,
   "Aero.workspace" : null
 }

--- a/axDumps/finder.json5
+++ b/axDumps/finder.json5
@@ -107,6 +107,6 @@
 
   ],
   "Aero.treeNodeParent" : "AppBundle.TilingContainer",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "F"
 }

--- a/axDumps/finder_quick_look.json5
+++ b/axDumps/finder_quick_look.json5
@@ -86,6 +86,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.Workspace)",
-  "Aero.windowLevel" : "{\"alwaysOnTopWindow\":{}}",
+  "Aero.windowLevel" : "alwaysOnTopWindow",
   "Aero.workspace" : "M"
 }

--- a/axDumps/firefox.json5
+++ b/axDumps/firefox.json5
@@ -96,6 +96,6 @@
 
   ],
   "Aero.treeNodeParent" : "AppBundle.TilingContainer",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "W"
 }

--- a/axDumps/firefox_extensions_popup.json5
+++ b/axDumps/firefox_extensions_popup.json5
@@ -68,6 +68,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.MacosPopupWindowsContainer)",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : null
 }

--- a/axDumps/firefox_mouse_hover_over_extensions_button.json5
+++ b/axDumps/firefox_mouse_hover_over_extensions_button.json5
@@ -60,6 +60,6 @@
 
   ],
   "Aero.treeNodeParent" : "AppBundle.MacosPopupWindowsContainer",
-  "Aero.windowLevel" : "{\"unknown\":{\"layerNumber\":101}}",
+  "Aero.windowLevel" : 101,
   "Aero.workspace" : null
 }

--- a/axDumps/firefox_mouse_hover_over_tab.json5
+++ b/axDumps/firefox_mouse_hover_over_tab.json5
@@ -60,6 +60,6 @@
 
   ],
   "Aero.treeNodeParent" : "AppBundle.MacosPopupWindowsContainer",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : null
 }

--- a/axDumps/firefox_non_native_fullscreen.json5
+++ b/axDumps/firefox_non_native_fullscreen.json5
@@ -61,6 +61,6 @@
 
   ],
   "Aero.treeNodeParent" : "AppBundle.Workspace",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "W"
 }

--- a/axDumps/firefox_normal_window_when_non_native_fullscreen_in_background.json5
+++ b/axDumps/firefox_normal_window_when_non_native_fullscreen_in_background.json5
@@ -96,6 +96,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.TilingContainer)",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "W"
 }

--- a/axDumps/firefox_pinterest_sign_in_with_google.json5
+++ b/axDumps/firefox_pinterest_sign_in_with_google.json5
@@ -98,6 +98,6 @@
 
   ],
   "Aero.treeNodeParent" : "AppBundle.Workspace",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "W"
 }

--- a/axDumps/firefox_pip.json5
+++ b/axDumps/firefox_pip.json5
@@ -98,6 +98,6 @@
 
   ],
   "Aero.treeNodeParent" : "AppBundle.Workspace",
-  "Aero.windowLevel" : "{\"alwaysOnTopWindow\":{}}",
+  "Aero.windowLevel" : "alwaysOnTopWindow",
   "Aero.workspace" : "F"
 }

--- a/axDumps/ghostty.json5
+++ b/axDumps/ghostty.json5
@@ -98,6 +98,6 @@
 
   ],
   "Aero.treeNodeParent" : "AppBundle.TilingContainer",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "M"
 }

--- a/axDumps/ghostty_about.json5
+++ b/axDumps/ghostty_about.json5
@@ -90,6 +90,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.TilingContainer)",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "G"
 }

--- a/axDumps/ghostty_check_for_updates_1_dialog.json5
+++ b/axDumps/ghostty_check_for_updates_1_dialog.json5
@@ -70,6 +70,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.TilingContainer)",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "G"
 }

--- a/axDumps/ghostty_check_for_updates_2_alert.json5
+++ b/axDumps/ghostty_check_for_updates_2_alert.json5
@@ -78,6 +78,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.Workspace)",
-  "Aero.windowLevel" : "{\"unknown\":{\"layerNumber\":8}}",
+  "Aero.windowLevel" : 8,
   "Aero.workspace" : "M"
 }

--- a/axDumps/ghostty_config_error.json5
+++ b/axDumps/ghostty_config_error.json5
@@ -89,6 +89,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.Workspace)",
-  "Aero.windowLevel" : "{\"unknown\":{\"layerNumber\":101}}",
+  "Aero.windowLevel" : 101,
   "Aero.workspace" : "G"
 }

--- a/axDumps/ghostty_quick_terminal.json5
+++ b/axDumps/ghostty_quick_terminal.json5
@@ -69,6 +69,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.MacosPopupWindowsContainer)",
-  "Aero.windowLevel" : "{\"alwaysOnTopWindow\":{}}",
+  "Aero.windowLevel" : "alwaysOnTopWindow",
   "Aero.workspace" : null
 }

--- a/axDumps/ghostty_window_decorations_false.json5
+++ b/axDumps/ghostty_window_decorations_false.json5
@@ -62,6 +62,6 @@
 
   ],
   "Aero.treeNodeParent" : "AppBundle.TilingContainer",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "M"
 }

--- a/axDumps/intellij.json5
+++ b/axDumps/intellij.json5
@@ -97,6 +97,6 @@
 
   ],
   "Aero.treeNodeParent" : "AppBundle.TilingContainer",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "I"
 }

--- a/axDumps/iterm2.json5
+++ b/axDumps/iterm2.json5
@@ -106,6 +106,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.TilingContainer)",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "F"
 }

--- a/axDumps/iterm2_hotkey_window.json5
+++ b/axDumps/iterm2_hotkey_window.json5
@@ -96,6 +96,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.Workspace)",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "F"
 }

--- a/axDumps/iterm2_no_title_bar.json5
+++ b/axDumps/iterm2_no_title_bar.json5
@@ -106,6 +106,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.TilingContainer)",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "1"
 }

--- a/axDumps/macos_join_network.json5
+++ b/axDumps/macos_join_network.json5
@@ -106,6 +106,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.Workspace)",
-  "Aero.windowLevel" : "{\"unknown\":{\"layerNumber\":8}}",
+  "Aero.windowLevel" : 8,
   "Aero.workspace" : "1"
 }

--- a/axDumps/marta.json5
+++ b/axDumps/marta.json5
@@ -98,6 +98,6 @@
 
   ],
   "Aero.treeNodeParent" : "AppBundle.TilingContainer",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "M"
 }

--- a/axDumps/raycast.json5
+++ b/axDumps/raycast.json5
@@ -66,6 +66,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.MacosPopupWindowsContainer)",
-  "Aero.windowLevel" : "{\"unknown\":{\"layerNumber\":8}}",
+  "Aero.windowLevel" : 8,
   "Aero.workspace" : null
 }

--- a/axDumps/raycast_settings.json5
+++ b/axDumps/raycast_settings.json5
@@ -96,6 +96,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.Workspace)",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "M"
 }

--- a/axDumps/safari.json5
+++ b/axDumps/safari.json5
@@ -99,6 +99,6 @@
 
   ],
   "Aero.treeNodeParent" : "AppBundle.TilingContainer",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "M"
 }

--- a/axDumps/slack.json5
+++ b/axDumps/slack.json5
@@ -108,6 +108,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.TilingContainer)",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "1"
 }

--- a/axDumps/slack_chat_in_a_separate_window.json5
+++ b/axDumps/slack_chat_in_a_separate_window.json5
@@ -109,6 +109,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.TilingContainer)",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "1"
 }

--- a/axDumps/slack_huddle_share_screen_draw_on_screen_fake_window.json5
+++ b/axDumps/slack_huddle_share_screen_draw_on_screen_fake_window.json5
@@ -101,6 +101,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.Workspace)",
-  "Aero.windowLevel" : "{\"unknown\":{\"layerNumber\":1000}}",
+  "Aero.windowLevel" : 1000,
   "Aero.workspace" : "1"
 }

--- a/axDumps/slack_huddle_share_screen_floating_popup.json5
+++ b/axDumps/slack_huddle_share_screen_floating_popup.json5
@@ -100,6 +100,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.Workspace)",
-  "Aero.windowLevel" : "{\"unknown\":{\"layerNumber\":1001}}",
+  "Aero.windowLevel" : 1001,
   "Aero.workspace" : "1"
 }

--- a/axDumps/slack_huddle_share_screen_target_picker.json5
+++ b/axDumps/slack_huddle_share_screen_target_picker.json5
@@ -69,6 +69,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.MacosPopupWindowsContainer)",
-  "Aero.windowLevel" : "{\"unknown\":{\"layerNumber\":1000}}",
+  "Aero.windowLevel" : 1000,
   "Aero.workspace" : null
 }

--- a/axDumps/spotify.json5
+++ b/axDumps/spotify.json5
@@ -96,6 +96,6 @@
 
   ],
   "Aero.treeNodeParent" : "AppBundle.TilingContainer",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "B"
 }

--- a/axDumps/sublime_text_4.json5
+++ b/axDumps/sublime_text_4.json5
@@ -95,6 +95,6 @@
 
   ],
   "Aero.treeNodeParent" : "AppBundle.TilingContainer",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "E"
 }

--- a/axDumps/telegram.json5
+++ b/axDumps/telegram.json5
@@ -95,6 +95,6 @@
 
   ],
   "Aero.treeNodeParent" : "AppBundle.TilingContainer",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "T"
 }

--- a/axDumps/telegram_image_viewer.json5
+++ b/axDumps/telegram_image_viewer.json5
@@ -61,6 +61,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.Workspace)",
-  "Aero.windowLevel" : "{\"unknown\":{\"layerNumber\":101}}",
+  "Aero.windowLevel" : 101,
   "Aero.workspace" : "T"
 }

--- a/axDumps/terminal_app.json5
+++ b/axDumps/terminal_app.json5
@@ -96,6 +96,6 @@
 
   ],
   "Aero.treeNodeParent" : "AppBundle.TilingContainer",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "M"
 }

--- a/axDumps/transmission.json5
+++ b/axDumps/transmission.json5
@@ -99,6 +99,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.TilingContainer)",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "B"
 }

--- a/axDumps/xcode_open_quickly.json5
+++ b/axDumps/xcode_open_quickly.json5
@@ -100,6 +100,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.Workspace)",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "X"
 }

--- a/axDumps/xcode_quick_actions.json5
+++ b/axDumps/xcode_quick_actions.json5
@@ -100,6 +100,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.Workspace)",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "X"
 }

--- a/axDumps/xcode_settings.json5
+++ b/axDumps/xcode_settings.json5
@@ -104,6 +104,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.Workspace)",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "X"
 }

--- a/axDumps/zebar.json5
+++ b/axDumps/zebar.json5
@@ -64,6 +64,6 @@
     }
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.TilingContainer)",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "1"
 }

--- a/axDumps/zed.json5
+++ b/axDumps/zed.json5
@@ -96,6 +96,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.TilingContainer)",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "E"
 }

--- a/axDumps/zen_browser.json5
+++ b/axDumps/zen_browser.json5
@@ -106,6 +106,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.TilingContainer)",
-  "Aero.windowLevel" : "{\"normalWindow\":{}}",
+  "Aero.windowLevel" : "normalWindow",
   "Aero.workspace" : "1"
 }

--- a/axDumps/zen_browser_pip.json5
+++ b/axDumps/zen_browser_pip.json5
@@ -108,6 +108,6 @@
 
   ],
   "Aero.treeNodeParent" : "Optional(AppBundle.MacosPopupWindowsContainer)",
-  "Aero.windowLevel" : "{\"alwaysOnTopWindow\":{}}",
+  "Aero.windowLevel" : "alwaysOnTopWindow",
   "Aero.workspace" : null
 }

--- a/docs/goodies.adoc
+++ b/docs/goodies.adoc
@@ -17,6 +17,22 @@ defaults write -g NSWindowShouldDragOnGesture -bool true
 
 Now, you can move windows by holding `ctrl + cmd` and dragging any part of the window (not necessarily the window title)
 
+[#non-native-fullscreen-in-firefox]
+== Non-native fullscreen in Firefox
+
+Change the following settings in `about:config`:
+
+----
+// Disable macOS native fullscreen in Firefox
+full-screen-api.macos-native-full-screen = false
+
+// Disable fullscreen transition animations
+full-screen-api.transition-duration.enter = 0 0
+full-screen-api.transition-duration.leave = 0 0
+----
+
+`full-screen-api.ignore-widgets` is also an interesting config knob that might be of your preference.
+
 [#highlight-focused-windows-with-colored-borders]
 == Highlight focused windows with colored borders
 

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
 
             src = pkgs.fetchurl {
               url = releaseZipUrl;
-              sha256 = pkgs.lib.fakeSha256;
+              sha256 = "sha256-kfPgLhyv4YMolyORtnGpqIR0qkiqc9znzj1VfKI9Ds8=";
             };
 
             nativeBuildInputs = [ pkgs.unzip ];

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,81 @@
+{
+  description = ''
+    Castrozan fork of AeroSpace exposing the prebuilt release zip as a flake
+    package. The zip is built by the publish-castrozan-release workflow on
+    every push to fix/** or feat/** branches and uploaded to a prerelease
+    tagged castrozan-<sanitised-branch>.
+
+    Consumers add this as a flake input and reference
+    inputs.aerospace.packages.<system>.aerospace from their overlays.
+  '';
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachSystem
+      [
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ]
+      (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          releaseTag = "castrozan-fix-tahoe-ax-prompt-loop";
+          releaseZipUrl = "https://github.com/Castrozan/AeroSpace/releases/download/${releaseTag}/AeroSpace.app.zip";
+
+          aerospace = pkgs.stdenv.mkDerivation {
+            pname = "aerospace";
+            version = releaseTag;
+
+            src = pkgs.fetchurl {
+              url = releaseZipUrl;
+              sha256 = pkgs.lib.fakeSha256;
+            };
+
+            nativeBuildInputs = [ pkgs.unzip ];
+
+            sourceRoot = ".";
+
+            unpackPhase = ''
+              runHook preUnpack
+              unzip "$src"
+              runHook postUnpack
+            '';
+
+            installPhase = ''
+              runHook preInstall
+              mkdir -p $out/Applications $out/bin
+              cp -R AeroSpace.app $out/Applications/
+              cp aerospace $out/bin/
+              runHook postInstall
+            '';
+
+            meta = {
+              description = "Castrozan fork of AeroSpace - patches the macOS 26 Tahoe AX-prompt loop";
+              homepage = "https://github.com/Castrozan/AeroSpace";
+              license = pkgs.lib.licenses.mit;
+              platforms = [
+                "aarch64-darwin"
+                "x86_64-darwin"
+              ];
+              mainProgram = "aerospace";
+            };
+          };
+        in
+        {
+          packages = {
+            aerospace = aerospace;
+            default = aerospace;
+          };
+        }
+      );
+}


### PR DESCRIPTION
## Problem

On macOS 26 (Tahoe), AeroSpace enters an infinite `AXIsProcessTrustedWithOptions` → `tccutil reset` → `terminateApp` → launchd respawn loop, prompting the user with the accessibility dialog continuously even after they grant accessibility in System Settings.

## Root cause

Tahoe added a strict `anchor apple` platform-requirement check to TCC's accessibility path. AeroSpace's release binaries are signed with a self-signed `aerospace-codesign-certificate` (no Apple Developer ID), so the check cannot be satisfied. `AXIsProcessTrustedWithOptions` returns false even when TCC's stored `auth_right` is `Allowed (System Set)`.

The defensive logic in `checkAccessibilityPermissions` then calls `tccutil reset Accessibility bobko.aerospace` and `terminateApp()`. Under launchd `KeepAlive` (the default when home-manager's `programs.aerospace.launchd.enable = true` ships the agent, and the same pattern used in most install methods), the process is respawned, the trust check fails again, the cycle repeats.

## Repro

1. Install AeroSpace v0.20.3-Beta on macOS 26.x via any method.
2. Grant accessibility in System Settings → Privacy & Security → Accessibility.
3. Observe the toggle stays ON but the system continuously re-prompts.
4. `log show --predicate 'process == "tccd"' --info --last 1m | grep aerospace` shows:
   ```
   For bobko.aerospace: matches platform requirements: No
   ReqResult(Auth Right: Allowed (System Set), promptType: 1, DB Action:None)
   ```
5. `/tmp/aerospace.log` shows repeating `Successfully reset Accessibility approval status for bobko.aerospace` lines.

## Fix

Drop the `resetAccessibility` + `terminateApp` branch. Keep the `AXIsProcessTrustedWithOptions` call with the prompt option so first-time users still get the system grant dialog, but don't terminate on a false return. Existing per-call AX error handling already covers the case where AX is genuinely not granted at runtime.

## Verification

Tested on macOS 26.1 (Darwin 25.1.0) with this branch:
- Replaced `/Applications/AeroSpace.app`'s binary with the patched build, re-signed ad-hoc.
- AeroSpace stays running stable.
- `/tmp/aerospace.log` stays empty (no more reset loop).
- `tccd` log shows zero `bobko.aerospace` auth requests in steady state.
- Window tiling and hotkeys continue to function.

## Tradeoff

On a fresh install where the user has not yet granted accessibility, AeroSpace now stays alive instead of terminating after the prompt. The prompt is still fired, so the user is asked to grant. Once they grant via System Settings, no relaunch is needed (matches the macOS convention for other Accessibility-using apps).

The original comment said: 'Because macOS doesn't reset it for us when the app signature changes'. With the cert rotation in 0.20.3-Beta plus Tahoe, this auto-reset behavior backfires. Users who hit a stale TCC entry after a real signature change can still resolve it manually via System Settings or `tccutil reset Accessibility bobko.aerospace`.