### PR TITLE
feat: workspace HUD overlay on workspace change

### DIFF
--- a/Sources/AppBundle/config/Config.swift
+++ b/Sources/AppBundle/config/Config.swift
@@ -44,6 +44,8 @@ struct Config: ConvenienceCopyable {
     var startAtLogin: Bool = false
     var autoReloadConfig: Bool = false
     var automaticallyUnhideMacosHiddenApps: Bool = false
+    var workspaceHud: Bool = true
+    var workspaceHudDurationMs: Int = 850
     var accordionPadding: Int = 30
     var enableNormalizationOppositeOrientationForNestedContainers: Bool = true
     var persistentWorkspaces: OrderedSet<String> = []

--- a/Sources/AppBundle/config/parseConfig.swift
+++ b/Sources/AppBundle/config/parseConfig.swift
@@ -113,6 +113,8 @@ private let configParser: [String: any ParserProtocol<Config>] = [
     "start-at-login": Parser(\.startAtLogin, parseBool),
     "auto-reload-config": Parser(\.autoReloadConfig, parseBool),
     "automatically-unhide-macos-hidden-apps": Parser(\.automaticallyUnhideMacosHiddenApps, parseBool),
+    "workspace-hud": Parser(\.workspaceHud, parseBool),
+    "workspace-hud-duration-ms": Parser(\.workspaceHudDurationMs, parseInt),
     "accordion-padding": Parser(\.accordionPadding, parseInt),
     persistentWorkspacesKey: Parser(\.persistentWorkspaces, parsePersistentWorkspaces),
     "exec-on-workspace-change": Parser(\.execOnWorkspaceChange, parseArrayOfStrings),

--- a/Sources/AppBundle/focus.swift
+++ b/Sources/AppBundle/focus.swift
@@ -188,6 +188,14 @@ extension Workspace {
         workspace: newWorkspace,
         prevWorkspace: oldWorkspace,
     ))
+    if config.workspaceHud {
+        let ws = Workspace.get(byName: newWorkspace)
+        WorkspaceHud.shared.show(
+            workspace: newWorkspace,
+            monitorScreenId: ws.workspaceMonitor.monitorAppKitNsScreenScreensId,
+            durationMs: config.workspaceHudDurationMs,
+        )
+    }
     if let exec = config.execOnWorkspaceChange.first {
         let process = Process()
         process.executableURL = URL(filePath: exec)

--- a/Sources/AppBundle/ui/WorkspaceHud.swift
+++ b/Sources/AppBundle/ui/WorkspaceHud.swift
@@ -1,0 +1,82 @@
+import AppKit
+import SwiftUI
+
+/// Apple-style transient overlay shown when the focused workspace changes.
+/// Modeled after `VolumePanel`: a borderless HUD panel hosting a SwiftUI view,
+/// auto-dismissed by a timer with a fade-out.
+public final class WorkspaceHud: NSPanelHud {
+    @MainActor public static var shared: WorkspaceHud = WorkspaceHud()
+    private var timer: Timer?
+    private let panelSize = NSSize(width: 200, height: 200)
+
+    override private init() {
+        super.init()
+    }
+
+    @MainActor public func show(workspace: String, monitorScreenId: Int, durationMs: Int) {
+        timer?.invalidate()
+        contentView?.subviews.removeAll()
+
+        let hostingView = NSHostingView(rootView: WorkspaceHudView(workspace: workspace))
+        hostingView.frame = NSRect(origin: .zero, size: panelSize)
+        contentView?.addSubview(hostingView)
+
+        // Center on the monitor the workspace lives on (Cocoa/bottom-left coords).
+        let screenFrame = NSScreen.screens.getOrNil(atIndex: monitorScreenId - 1)?.frame
+            ?? NSScreen.main?.frame
+            ?? NSRect(x: 0, y: 0, width: panelSize.width, height: panelSize.height)
+        let origin = NSPoint(
+            x: screenFrame.midX - panelSize.width / 2,
+            y: screenFrame.midY - panelSize.height / 2,
+        )
+        setFrame(NSRect(origin: origin, size: panelSize), display: true)
+
+        alphaValue = 0
+        orderFrontRegardless()
+        NSAnimationContext.runAnimationGroup { ctx in
+            ctx.duration = 0.12
+            self.animator().alphaValue = 1
+        }
+        startTimer(durationMs: durationMs)
+    }
+
+    private func startTimer(durationMs: Int) {
+        timer = .scheduledTimer(withTimeInterval: Double(durationMs) / 1000, repeats: false) { _ in
+            Task { @MainActor [weak self] in self?.fadeOut() }
+        }
+    }
+
+    @MainActor private func fadeOut() {
+        NSAnimationContext.runAnimationGroup { ctx in
+            ctx.duration = 0.25
+            self.animator().alphaValue = 0
+        } completionHandler: { [weak self] in
+            Task { @MainActor in self?.close() }
+        }
+    }
+}
+
+struct WorkspaceHudView: View {
+    let workspace: String
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Text(workspace)
+                .font(.system(size: 92, weight: .semibold, design: .rounded))
+                .minimumScaleFactor(0.35)
+                .lineLimit(1)
+                .foregroundStyle(.primary)
+                .frame(maxWidth: 150)
+            Text("WORKSPACE")
+                .font(.system(size: 11, weight: .bold, design: .rounded))
+                .tracking(3)
+                .foregroundStyle(.secondary)
+        }
+        .frame(width: 200, height: 200)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 30, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 30, style: .continuous)
+                .strokeBorder(.primary.opacity(0.08), lineWidth: 1),
+        )
+    }
+}

--- a/docs/config-examples/default-config.toml
+++ b/docs/config-examples/default-config.toml
@@ -45,6 +45,14 @@ on-focused-monitor-changed = ['move-mouse monitor-lazy-center']
 # Also see: https://nikitabobko.github.io/AeroSpace/goodies#disable-hide-app
 automatically-unhide-macos-hidden-apps = false
 
+# Show a transient Apple-style overlay with the workspace name when the focused workspace changes
+# Fallback value (if you omit the key): workspace-hud = true
+workspace-hud = true
+
+# How long (in milliseconds) the workspace overlay stays on screen before fading out
+# Fallback value (if you omit the key): workspace-hud-duration-ms = 850
+workspace-hud-duration-ms = 850
+
 # List of workspaces that should stay alive even when they contain no windows,
 # even when they are invisible.
 # This config option is only available since 'config-version = 2'


### PR DESCRIPTION
## What

Adds a transient, Apple-style **workspace HUD**: a frosted-glass panel showing the workspace name, centered on the focused monitor, shown briefly whenever the focused workspace changes.

![Workspace HUD](https://raw.githubusercontent.com/alcibiadesc/AeroSpace/pr-assets/workspace-hud.png)

## Use cases

- Quick `alt+number` switching with no always-visible workspace indicator (menu bar hidden, or eyes on the content rather than the bar) — you lose track of which workspace you landed on.
- A brief, non-intrusive confirmation of the switch, mirroring the native macOS volume/brightness overlay that users already have muscle memory for.
- Multi-monitor: the HUD appears on the monitor whose focused workspace changed.

## How it works

- Reuses the existing `NSPanelHud` + SwiftUI hosting infrastructure (same pattern as `VolumePanel`).
- A new `WorkspaceHud` panel is shown from `onWorkspaceChanged()` in `focus.swift`, which already fires on every focused-workspace change and is skipped during AeroSpace startup.
- The panel fades in (~0.12s), stays for a configurable duration, then fades out (~0.25s) and is auto-dismissed by a timer.

## Config

Two keys, both with sensible defaults so the feature is opt-out, not opt-in:

```toml
# Show the overlay when the focused workspace changes (default: true)
workspace-hud = true
# How long the overlay stays on screen, in milliseconds (default: 850)
workspace-hud-duration-ms = 850
```

## Notes

- Single, additive commit; no refactoring mixed in.
- No new dependencies.
- Happy to adjust the design (size, copy, position, default duration) or gate it behind a discussion first per CONTRIBUTING — opening this as a concrete proposal to look at.
