### PR TITLE
feat: cycle window size when moving against the edge

### DIFF
--- a/Sources/AppBundle/command/impl/MoveCommand.swift
+++ b/Sources/AppBundle/command/impl/MoveCommand.swift
@@ -26,6 +26,14 @@ struct MoveCommand: Command {
                             return .succ
                     }
                 } else {
+                    // Only hijack the edge `move` for a size toggle when there is actually a
+                    // same-orientation split to resize. Otherwise fall through to the normal
+                    // moveOut (e.g. move-up in an all-horizontal layout must still move/reorganize).
+                    if config.moveResizeToggleAtEdge, isAtExtremeEdge(currentWindow, direction),
+                       let exit = resizeToggleAtEdge(window: currentWindow, direction: direction)
+                    {
+                        return exit
+                    }
                     return moveOut(window: currentWindow, direction: direction, io, args, env)
                 }
             case .workspace: // floating window
@@ -148,6 +156,70 @@ private let moveOutMacosUnconventionalWindow = "moving macOS fullscreen, minimiz
                 index: deepTarget.ownIndex.orDie() + 1,
             )
     }
+    return .succ
+}
+
+/// Fractions of the parent the window cycles through, derived from the configurable
+/// `move-resize-toggle-ratios` (percentages). Defaults to 50/60/70 (1/2 -> 3/5 -> 7/10), which keep
+/// the neighbour usable on smaller/native screens. Always sorted ascending and clamped to (0, 1).
+@MainActor private var resizeToggleRatios: [CGFloat] {
+    let ratios = config.moveResizeToggleRatios
+        .map { CGFloat($0) / 100 }
+        .filter { $0 > 0 && $0 < 1 }
+        .sorted()
+    return ratios.isEmpty ? [0.5] : ratios
+}
+
+/// True when `window` cannot be moved/swapped any further in `direction`: there is no ancestor
+/// tiling container (oriented along `direction`) holding a sibling beyond the window in that
+/// direction. This is exactly the case where a plain `move` would be a no-op against the edge.
+@MainActor private func isAtExtremeEdge(_ window: Window, _ direction: CardinalDirection) -> Bool {
+    for node in window.parentsWithSelf {
+        guard let parent = node.parent as? TilingContainer else { break }
+        if parent.orientation == direction.orientation {
+            let siblingIndex = node.ownIndex.orDie() + direction.focusOffset
+            if parent.children.indices.contains(siblingIndex) {
+                return false // there's a neighbour to move/swap into
+            }
+        }
+    }
+    return true
+}
+
+/// Cycle the window's size along `direction`'s axis through `resizeToggleRatios` by adjusting the
+/// adaptiveWeight of the window's slice within the relevant tiling container. Other siblings keep
+/// their weights, so the window simply claims a larger/smaller fraction of the shared axis.
+///
+/// Returns nil when there is no meaningful same-orientation split to resize, so the caller can fall
+/// back to the normal `moveOut` behavior. This guarantees the feature only ADDS a size toggle at
+/// real edges and never swallows a move that would otherwise do something.
+@MainActor private func resizeToggleAtEdge(window: Window, direction: CardinalDirection) -> BinaryExitCode? {
+    let orientation = direction.orientation
+    // The node to resize is the window's ancestor (or itself) whose parent is a tiles container
+    // oriented along the move axis — the same selection ResizeCommand uses for an explicit axis.
+    let node = window.parentsWithSelf.first { node in
+        guard let parent = node.parent as? TilingContainer else { return false }
+        return parent.layout == .tiles && parent.orientation == orientation
+    }
+    guard let node, let parent = node.parent as? TilingContainer else { return nil }
+    guard parent.children.count > 1 else { return nil } // nothing to share the axis with
+
+    let totalWeight = CGFloat(parent.children.sumOfDouble { $0.getWeight(orientation) })
+    let nodeWeight = node.getWeight(orientation)
+    let otherWeight = totalWeight - nodeWeight
+    guard otherWeight > 0 else { return nil }
+
+    let currentRatio = nodeWeight / totalWeight
+    // Pick the next ratio strictly larger than the current one, wrapping back to the first.
+    // A small epsilon avoids getting stuck when the current ratio equals a cycle value.
+    let ratios = resizeToggleRatios
+    let epsilon: CGFloat = 0.01
+    let nextRatio = ratios.first { $0 > currentRatio + epsilon } ?? ratios[0]
+
+    // weight that makes node occupy `nextRatio` of the parent, with the other siblings unchanged:
+    // nextRatio = newWeight / (newWeight + otherWeight)  =>  newWeight = nextRatio/(1-nextRatio) * otherWeight
+    let newWeight = nextRatio / (1 - nextRatio) * otherWeight
+    node.setWeight(orientation, newWeight)
     return .succ
 }
 

--- a/Sources/AppBundle/config/Config.swift
+++ b/Sources/AppBundle/config/Config.swift
@@ -45,6 +45,8 @@ struct Config: ConvenienceCopyable {
     var autoReloadConfig: Bool = false
     var automaticallyUnhideMacosHiddenApps: Bool = false
     var accordionPadding: Int = 30
+    var moveResizeToggleAtEdge: Bool = false
+    var moveResizeToggleRatios: [Int] = [50, 60, 70] // percentages of the parent the window cycles through
     var enableNormalizationOppositeOrientationForNestedContainers: Bool = true
     var persistentWorkspaces: OrderedSet<String> = []
     var execOnWorkspaceChange: [String] = [] // todo deprecate

--- a/Sources/AppBundle/config/parseConfig.swift
+++ b/Sources/AppBundle/config/parseConfig.swift
@@ -114,6 +114,8 @@ private let configParser: [String: any ParserProtocol<Config>] = [
     "auto-reload-config": Parser(\.autoReloadConfig, parseBool),
     "automatically-unhide-macos-hidden-apps": Parser(\.automaticallyUnhideMacosHiddenApps, parseBool),
     "accordion-padding": Parser(\.accordionPadding, parseInt),
+    "move-resize-toggle-at-edge": Parser(\.moveResizeToggleAtEdge, parseBool),
+    "move-resize-toggle-ratios": Parser(\.moveResizeToggleRatios, parseMoveResizeToggleRatios),
     persistentWorkspacesKey: Parser(\.persistentWorkspaces, parsePersistentWorkspaces),
     "exec-on-workspace-change": Parser(\.execOnWorkspaceChange, parseArrayOfStrings),
     "exec": Parser(\.execConfig, parseExecConfig),
@@ -350,6 +352,25 @@ private func parsePersistentWorkspaces(_ raw: Json, _ backtrace: ConfigBacktrace
         .flatMap { arr in
             let set = arr.toOrderedSet()
             return set.count == arr.count ? .success(set) : .failure(.semantic(backtrace, "Contains duplicated workspace names"))
+        }
+}
+
+private func parseMoveResizeToggleRatios(_ raw: Json, _ backtrace: ConfigBacktrace) -> ParsedConfig<[Int]> {
+    parseTomlArray(raw, backtrace)
+        .flatMap { arr in
+            arr.enumerated().mapAllOrFailure { (index, elem) in
+                parseInt(elem, backtrace + .index(index))
+            }
+        }
+        .flatMap { ints in
+            // Percentages of the parent the window occupies. Must be in (0, 100), at least one value.
+            if ints.isEmpty {
+                return .failure(.semantic(backtrace, "move-resize-toggle-ratios must contain at least one value"))
+            }
+            if let bad = ints.first(where: { $0 <= 0 || $0 >= 100 }) {
+                return .failure(.semantic(backtrace, "move-resize-toggle-ratios values must be between 1 and 99 (got \(bad))"))
+            }
+            return .success(ints.sorted())
         }
 }
 

--- a/docs/config-examples/default-config.toml
+++ b/docs/config-examples/default-config.toml
@@ -25,6 +25,20 @@ enable-normalization-opposite-orientation-for-nested-containers = true
 # You can set 0 to disable the padding feature
 accordion-padding = 30
 
+# Opt-in: when a 'move <direction>' command would hit the edge of a same-orientation split, cycle the
+# focused window's size along that axis instead, through `move-resize-toggle-ratios`. Works on all
+# four edges. This intentionally repurposes the default `move` behavior at an edge, so it is OFF by
+# default; enable it explicitly. (When there is no same-orientation split to resize, `move` always
+# behaves normally regardless of this setting.)
+# Fallback value (if you omit the key): move-resize-toggle-at-edge = false
+move-resize-toggle-at-edge = false
+# The sizes (as percentages of the parent the focused window occupies) the toggle cycles through.
+# Each 'move' against the edge steps to the next larger percentage, wrapping back to the first.
+# Values must be 1-99; they're sorted automatically. Default 50/60/70 keeps the neighbour usable on
+# native/smaller screens (raise e.g. to [50, 67, 75] if you want bigger steps on large monitors).
+# Fallback value (if you omit the key): move-resize-toggle-ratios = [50, 60, 70]
+move-resize-toggle-ratios = [50, 60, 70]
+
 # Possible values: tiles|accordion
 default-root-container-layout = 'tiles'
 


### PR DESCRIPTION
## What

Opt-in: when a `move <direction>` command would hit the edge of a same-orientation split, cycle the focused window's **size** along that axis instead — 50% → 60% → 70% of the parent (configurable), wrapping back. Works on all four edges (left/right adjust the horizontal split, up/down the vertical split).

## Use case

With `move` bound to `alt-cmd-<arrow>`, pushing a window against a wall it already sits on can grow it in clean steps, without a separate resize binding.

## Off by default (opt-in)

This intentionally repurposes the `move`-at-edge behavior (and its `--boundaries-action`), so it would change established semantics if always on. It is therefore **off by default** and must be enabled explicitly. When there is no same-orientation split to resize, `resizeToggleAtEdge` returns `nil` and `move` falls through to its normal behavior regardless of the setting — so enabling it never breaks a move that would otherwise reorganize/relocate a window.

## Config

```toml
move-resize-toggle-at-edge = false          # opt-in
# Sizes (percentages of the parent the focused window occupies) the cycle steps through.
# Values 1-99, sorted automatically. The config model has no float type, hence integer percentages.
move-resize-toggle-ratios = [50, 60, 70]     # 1/2 -> 3/5 -> 7/10
```

## How it works

- `isAtExtremeEdge` walks the window's ancestors; it's at the edge when no same-orientation tiling container has a neighbour in that direction.
- `resizeToggleAtEdge` selects the window's slice in the nearest same-orientation tiles container and sets its `adaptiveWeight` to the next percentage strictly greater than the current ratio (wrapping), leaving siblings untouched; the layout pass re-normalizes.
