### PR TITLE
feat: optional new-window-prevent-flicker

### DIFF
--- a/Sources/AppBundle/config/Config.swift
+++ b/Sources/AppBundle/config/Config.swift
@@ -44,6 +44,7 @@ struct Config: ConvenienceCopyable {
     var startAtLogin: Bool = false
     var autoReloadConfig: Bool = false
     var automaticallyUnhideMacosHiddenApps: Bool = false
+    var newWindowPreventFlicker: Bool = false
     var accordionPadding: Int = 30
     var enableNormalizationOppositeOrientationForNestedContainers: Bool = true
     var persistentWorkspaces: OrderedSet<String> = []

--- a/Sources/AppBundle/config/parseConfig.swift
+++ b/Sources/AppBundle/config/parseConfig.swift
@@ -113,6 +113,7 @@ private let configParser: [String: any ParserProtocol<Config>] = [
     "start-at-login": Parser(\.startAtLogin, parseBool),
     "auto-reload-config": Parser(\.autoReloadConfig, parseBool),
     "automatically-unhide-macos-hidden-apps": Parser(\.automaticallyUnhideMacosHiddenApps, parseBool),
+    "new-window-prevent-flicker": Parser(\.newWindowPreventFlicker, parseBool),
     "accordion-padding": Parser(\.accordionPadding, parseInt),
     persistentWorkspacesKey: Parser(\.persistentWorkspaces, parsePersistentWorkspaces),
     "exec-on-workspace-change": Parser(\.execOnWorkspaceChange, parseArrayOfStrings),

--- a/Sources/AppBundle/tree/MacWindow.swift
+++ b/Sources/AppBundle/tree/MacWindow.swift
@@ -37,7 +37,29 @@ final class MacWindow: Window {
         if try await !restoreClosedWindowsCacheIfNeeded(newlyDetectedWindow: window) {
             try await tryOnWindowDetected(window)
         }
+        window.preventNewWindowFlickerIfNeeded()
         return window
+    }
+
+    // Move a freshly detected tiling window offscreen the instant it's registered, *before* macOS paints
+    // it at its native spawn position (usually screen center). The subsequent layoutWorkspaces() in the same
+    // refresh session unhides it straight into its final tiled slot, so the user never sees the center flash.
+    // Opt-in via `new-window-prevent-flicker` because moving windows via the AX API is app-dependent.
+    @MainActor
+    func preventNewWindowFlickerIfNeeded() {
+        guard config.newWindowPreventFlicker else { return }
+        guard !isStartup else { return } // On startup everything is laid out at once; no per-window flash to hide
+        guard let nodeMonitor, let workspace = nodeWorkspace, workspace.isVisible else { return }
+        // Only tiling windows flash at a wrong spot; floating windows keep their native position on purpose.
+        guard parent is TilingContainer else { return }
+        if isHiddenInCorner { return }
+        // Stash a sentinel so layoutWorkspaces()'s unhideFromCorner() treats this as a hidden tiling window
+        // (the value itself is unused for tiling windows - they're repositioned by layoutRecursive).
+        prevUnhiddenProportionalPositionInsideWorkspaceRect = .zero
+        // Single non-blocking AX move to the bottom-right corner, mirroring hideInCorner's offscreen target.
+        let s = lastFloatingSize ?? .zero
+        let corner = nodeMonitor.visibleRect.bottomRightCorner + CGPoint(x: 1, y: 1) - CGPoint(x: s.width, y: 0)
+        setAxFrame(corner, nil)
     }
 
     // var description: String {

--- a/docs/config-examples/default-config.toml
+++ b/docs/config-examples/default-config.toml
@@ -45,6 +45,13 @@ on-focused-monitor-changed = ['move-mouse monitor-lazy-center']
 # Also see: https://nikitabobko.github.io/AeroSpace/goodies#disable-hide-app
 automatically-unhide-macos-hidden-apps = false
 
+# When a new window opens, move it offscreen the instant it's detected so macOS never
+# paints it at its native spawn position (usually screen center) before AeroSpace tiles it.
+# Reduces the flash/jump you see when a window appears and the tiles rearrange.
+# Opt-in because moving windows via the Accessibility API is app-dependent.
+# Fallback value (if you omit the key): new-window-prevent-flicker = false
+new-window-prevent-flicker = false
+
 # List of workspaces that should stay alive even when they contain no windows,
 # even when they are invisible.
 # This config option is only available since 'config-version = 2'


### PR DESCRIPTION
## What

Adds an **opt-in** option to reduce the flash/jump when a new window opens: `new-window-prevent-flicker` (default `false`).

## Problem

When a new tiling window is detected it is bound to the tree but only positioned at the *end* of the refresh session. In the meantime macOS paints it at its native spawn position (usually screen center), and then everything snaps into place — a visible flash + reflow.

## How it works

When enabled, the instant a new tiling window on a visible workspace is registered (`getOrRegister`), it is moved offscreen to the monitor's bottom-right corner with a single non-blocking AX frame set, *before* macOS paints it at center. The same refresh session's `layoutWorkspaces()` then positions it directly into its tiled slot. Net: the window goes corner→slot instead of center→slot, suppressing the central flash. Reuses the existing corner-hide infrastructure.

## Honest scope / limitation

This does **not** animate or fully eliminate motion — Accessibility-based window management can't do smooth frame animation (each AX frame set is a blocking IPC round-trip, which is also why AeroSpace disables AX animations). It trades a center-flash for a smaller corner→slot motion. Whether that reads as "less flicker" is app/monitor-dependent, which is why it's **opt-in and default off**.

## Config

```toml
new-window-prevent-flicker = false  # set true to enable
```

## Notes
- Default off → zero impact unless enabled.
- Self-healing: the offscreen move is cancelled by the final placement; if a refresh is interrupted between them the window self-corrects on the next refresh.
