### PR TITLE
feat: add fullscreen fail flags

### DIFF
--- a/Sources/AppBundle/command/fullscreenFailure.swift
+++ b/Sources/AppBundle/command/fullscreenFailure.swift
@@ -1,0 +1,16 @@
+@MainActor
+func shouldFailBecauseFullscreen(
+    window: Window,
+    failIfFullscreen: Bool,
+    failIfMacosNativeFullscreen: Bool,
+) async throws -> Bool {
+    if failIfFullscreen && window.isFullscreen {
+        return true
+    }
+    if failIfMacosNativeFullscreen {
+        if try await window.isMacosFullscreen {
+            return true
+        }
+    }
+    return false
+}

--- a/Sources/AppBundle/command/impl/FocusCommand.swift
+++ b/Sources/AppBundle/command/impl/FocusCommand.swift
@@ -7,6 +7,13 @@ struct FocusCommand: Command {
 
     func run(_ env: CmdEnv, _ io: CmdIo) async throws -> BinaryExitCode {
         guard let target = args.resolveTargetOrReportError(env, io) else { return .fail }
+        if let window = target.windowOrNil, try await shouldFailBecauseFullscreen(
+            window: window,
+            failIfFullscreen: args.failIfFullscreen,
+            failIfMacosNativeFullscreen: args.failIfMacosNativeFullscreen,
+        ) {
+            return .fail
+        }
         // todo bug: floating windows break mru
         let floatingWindows = args.floatingAsTiling ? try await makeFloatingWindowsSeenAsTiling(workspace: target.workspace) : []
         defer {

--- a/Sources/AppBundle/command/impl/MoveCommand.swift
+++ b/Sources/AppBundle/command/impl/MoveCommand.swift
@@ -5,11 +5,18 @@ struct MoveCommand: Command {
     let args: MoveCmdArgs
     /*conforms*/ let shouldResetClosedWindowsCache = true
 
-    func run(_ env: CmdEnv, _ io: CmdIo) -> BinaryExitCode {
+    func run(_ env: CmdEnv, _ io: CmdIo) async throws -> BinaryExitCode {
         let direction = args.direction.val
         guard let target = args.resolveTargetOrReportError(env, io) else { return .fail }
         guard let currentWindow = target.windowOrNil else {
             return .fail(io.err(noWindowIsFocused))
+        }
+        if try await shouldFailBecauseFullscreen(
+            window: currentWindow,
+            failIfFullscreen: args.failIfFullscreen,
+            failIfMacosNativeFullscreen: args.failIfMacosNativeFullscreen,
+        ) {
+            return .fail
         }
         guard let parent = currentWindow.parent else { return .fail }
         switch parent.cases {

--- a/Sources/AppBundleTests/command/FocusCommandTest.swift
+++ b/Sources/AppBundleTests/command/FocusCommandTest.swift
@@ -50,6 +50,52 @@ final class FocusCommandTest: XCTestCase {
             parseCommand("focus left --boundaries-action wrap-around-the-workspace --wrap-around").errorOrNil,
             "ERROR: Conflicting options: --boundaries-action, --wrap-around",
         )
+        assertEquals(
+            parseCommand("focus dfs-next --fail-if-fullscreen").errorOrNil,
+            "--fail-if-fullscreen/--fail-if-macos-native-fullscreen require using (left|down|up|right) argument",
+        )
+        assertEquals(
+            parseCommand("focus --fail-if-macos-native-fullscreen --window-id 42").errorOrNil,
+            "--window-id is incompatible with other options",
+        )
+        assertNil(parseCommand("focus --fail-if-fullscreen --fail-if-macos-native-fullscreen left").errorOrNil)
+    }
+
+    func testFailIfFullscreen() async throws {
+        Workspace.get(byName: name).rootTilingContainer.apply {
+            let window = TestWindow.new(id: 1, parent: $0)
+            assertEquals(window.focusWindow(), true)
+            TestWindow.new(id: 2, parent: $0)
+            window.isFullscreen = true
+        }
+
+        let result = try await parseCommand("focus --fail-if-fullscreen right").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode.rawValue, 2)
+        assertEquals(focus.windowOrNil?.windowId, 1)
+    }
+
+    func testFailIfMacosNativeFullscreen() async throws {
+        Workspace.get(byName: name).rootTilingContainer.apply {
+            let window = TestWindow.new(id: 1, parent: $0)
+            assertEquals(window.focusWindow(), true)
+            TestWindow.new(id: 2, parent: $0)
+            window.isMacosFullscreenForTest = true
+        }
+
+        let result = try await parseCommand("focus --fail-if-macos-native-fullscreen right").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode.rawValue, 2)
+        assertEquals(focus.windowOrNil?.windowId, 1)
+    }
+
+    func testFailIfFullscreenAllowsRegularWindows() async throws {
+        Workspace.get(byName: name).rootTilingContainer.apply {
+            assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)
+            TestWindow.new(id: 2, parent: $0)
+        }
+
+        let result = try await parseCommand("focus --fail-if-fullscreen --fail-if-macos-native-fullscreen right").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode.rawValue, 0)
+        assertEquals(focus.windowOrNil?.windowId, 2)
     }
 
     func testFocus() {

--- a/Sources/AppBundleTests/command/MoveCommandTest.swift
+++ b/Sources/AppBundleTests/command/MoveCommandTest.swift
@@ -6,6 +6,48 @@ import XCTest
 final class MoveCommandTest: XCTestCase {
     override func setUp() async throws { setUpWorkspacesForTests() }
 
+    func testParse() {
+        assertNil(parseCommand("move --fail-if-fullscreen left").errorOrNil)
+        assertNil(parseCommand("move --fail-if-macos-native-fullscreen --window-id 1 right").errorOrNil)
+    }
+
+    func testFailIfFullscreen() async throws {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            let window = TestWindow.new(id: 1, parent: $0)
+            assertEquals(window.focusWindow(), true)
+            TestWindow.new(id: 2, parent: $0)
+            window.isFullscreen = true
+        }
+
+        let result = try await parseCommand("move --fail-if-fullscreen right").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode.rawValue, 2)
+        assertEquals(root.layoutDescription, .h_tiles([.window(1), .window(2)]))
+    }
+
+    func testFailIfMacosNativeFullscreen() async throws {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            let window = TestWindow.new(id: 1, parent: $0)
+            assertEquals(window.focusWindow(), true)
+            TestWindow.new(id: 2, parent: $0)
+            window.isMacosFullscreenForTest = true
+        }
+
+        let result = try await parseCommand("move --fail-if-macos-native-fullscreen right").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode.rawValue, 2)
+        assertEquals(root.layoutDescription, .h_tiles([.window(1), .window(2)]))
+    }
+
+    func testFailIfFullscreenAllowsRegularWindows() async throws {
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)
+            TestWindow.new(id: 2, parent: $0)
+        }
+
+        let result = try await parseCommand("move --fail-if-fullscreen --fail-if-macos-native-fullscreen right").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode.rawValue, 0)
+        assertEquals(root.layoutDescription, .h_tiles([.window(2), .window(1)]))
+    }
+
     func testMove_swapWindows() async throws {
         let root = Workspace.get(byName: name).rootTilingContainer.apply {
             assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)

--- a/Sources/AppBundleTests/tree/TestWindow.swift
+++ b/Sources/AppBundleTests/tree/TestWindow.swift
@@ -3,6 +3,7 @@ import AppKit
 
 final class TestWindow: Window, CustomStringConvertible {
     private var _rect: Rect?
+    var isMacosFullscreenForTest = false
 
     @MainActor
     private init(_ id: UInt32, _ parent: NonLeafTreeNodeObject, _ adaptiveWeight: CGFloat, _ rect: Rect?) {
@@ -38,5 +39,11 @@ final class TestWindow: Window, CustomStringConvertible {
 
     @MainActor override func getAxRect() async throws -> Rect? { // todo change to not Optional
         _rect
+    }
+
+    override var isMacosFullscreen: Bool {
+        get async {
+            isMacosFullscreenForTest
+        }
     }
 }

--- a/Sources/Common/cmdArgs/impl/FocusCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/FocusCmdArgs.swift
@@ -12,6 +12,8 @@ public struct FocusCmdArgs: CmdArgs {
 
             "--boundaries": ArgParser(\.rawBoundaries, upcastArgParserFun(parseBoundaries)),
             "--boundaries-action": ArgParser(\.rawBoundariesAction, upcastArgParserFun(parseBoundariesAction)),
+            "--fail-if-fullscreen": trueBoolFlag(\.failIfFullscreen),
+            "--fail-if-macos-native-fullscreen": trueBoolFlag(\.failIfMacosNativeFullscreen),
             "--wrap-around": trueBoolFlag(\.wrapAroundAlias),
         ],
         posArgs: [ArgParser(\.cardinalOrDfsDirection, upcastArgParserFun(parseCardinalOrDfsDirection))],
@@ -23,6 +25,8 @@ public struct FocusCmdArgs: CmdArgs {
 
     public var rawBoundaries: Boundaries? = nil // todo cover boundaries wrapping with tests
     public var rawBoundariesAction: WhenBoundariesCrossed? = nil
+    public var failIfFullscreen: Bool = false
+    public var failIfMacosNativeFullscreen: Bool = false
     fileprivate var wrapAroundAlias: Bool = false
     public var dfsIndex: UInt32? = nil
     public var cardinalOrDfsDirection: CardinalOrDfsDirection? = nil
@@ -107,6 +111,15 @@ func parseFocusCmdArgs(_ args: StrArrSlice) -> ParsedCmd<FocusCmdArgs> {
         }
         .filter("--dfs-index is incompatible with other options") {
             $0.dfsIndex == nil || $0 == FocusCmdArgs(rawArgs: args, dfsIndex: $0.dfsIndex.orDie())
+        }
+        .filter("--fail-if-fullscreen/--fail-if-macos-native-fullscreen require using (left|down|up|right) argument") {
+            if !$0.failIfFullscreen && !$0.failIfMacosNativeFullscreen {
+                return true
+            }
+            if case .direction? = $0.cardinalOrDfsDirection {
+                return true
+            }
+            return false
         }
         .filter("(dfs-next|dfs-prev) only supports --boundaries workspace") {
             $0.target.isDfsRelative.implies($0.boundaries == .workspace)

--- a/Sources/Common/cmdArgs/impl/MoveCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/MoveCmdArgs.swift
@@ -9,6 +9,8 @@ public struct MoveCmdArgs: CmdArgs {
             "--window-id": windowIdSubArgParser(),
             "--boundaries": ArgParser(\.rawBoundaries, upcastArgParserFun(parseBoundaries)),
             "--boundaries-action": ArgParser(\.rawBoundariesAction, upcastArgParserFun(parseBoundariesAction)),
+            "--fail-if-fullscreen": trueBoolFlag(\.failIfFullscreen),
+            "--fail-if-macos-native-fullscreen": trueBoolFlag(\.failIfMacosNativeFullscreen),
         ],
         posArgs: [newMandatoryPosArgParser(\.direction, parseCardinalDirectionArg, placeholder: CardinalDirection.unionLiteral)],
     )
@@ -16,6 +18,8 @@ public struct MoveCmdArgs: CmdArgs {
     public var direction: Lateinit<CardinalDirection> = .uninitialized
     public var rawBoundaries: Boundaries? = nil
     public var rawBoundariesAction: WhenBoundariesCrossed? = nil
+    public var failIfFullscreen: Bool = false
+    public var failIfMacosNativeFullscreen: Bool = false
 
     public init(rawArgs: [String], _ direction: CardinalDirection) {
         self.commonState = .init(rawArgs.slice)

--- a/Sources/Common/cmdHelpGenerated.swift
+++ b/Sources/Common/cmdHelpGenerated.swift
@@ -44,6 +44,7 @@ let focus_monitor_help_generated = """
 let focus_help_generated = """
     USAGE: focus [-h|--help] [--ignore-floating] [--wrap-around]
                  [--boundaries <boundary>] [--boundaries-action <action>]
+                 [--fail-if-fullscreen] [--fail-if-macos-native-fullscreen]
                  (left|down|up|right)
        OR: focus [-h|--help] [--ignore-floating] [--wrap-around]
                  [--boundaries <boundary>] [--boundaries-action <action>]
@@ -121,7 +122,9 @@ let move_workspace_to_monitor_help_generated = """
        OR: move-workspace-to-monitor [-h|--help] [--workspace <workspace>] <monitor-pattern>...
     """
 let move_help_generated = """
-    USAGE: move [-h|--help] [--window-id <window-id>] [--boundaries <boundary>] [--boundaries-action <boundary-action>] (left|down|up|right)
+    USAGE: move [-h|--help] [--window-id <window-id>] [--boundaries <boundary>]
+                [--boundaries-action <boundary-action>] [--fail-if-fullscreen]
+                [--fail-if-macos-native-fullscreen] (left|down|up|right)
     """
 let reload_config_help_generated = """
     USAGE: reload-config [-h|--help] [--no-gui] [--dry-run]

--- a/docs/aerospace-focus.adoc
+++ b/docs/aerospace-focus.adoc
@@ -11,6 +11,7 @@ include::util/man-attributes.adoc[]
 // tag::synopsis[]
 aerospace focus [-h|--help] [--ignore-floating] [--wrap-around]
                 [--boundaries <boundary>] [--boundaries-action <action>]
+                [--fail-if-fullscreen] [--fail-if-macos-native-fullscreen]
                 (left|down|up|right)
 aerospace focus [-h|--help] [--ignore-floating] [--wrap-around]
                 [--boundaries <boundary>] [--boundaries-action <action>]
@@ -64,6 +65,14 @@ Index is 0-based.
 --ignore-floating::
 Don't perceive floating windows as part of the tree.
 It may be useful for more reliable scripting.
+
+--fail-if-fullscreen::
+Exit with non-zero code if the current target window is fullscreen by the `fullscreen` command.
+Only compatible with `(left|down|up|right)`.
+
+--fail-if-macos-native-fullscreen::
+Exit with non-zero code if the current target window is in macOS native fullscreen.
+Only compatible with `(left|down|up|right)`.
 
 // =========================================================== Arguments
 include::./util/conditional-arguments-header.adoc[]

--- a/docs/aerospace-move.adoc
+++ b/docs/aerospace-move.adoc
@@ -9,7 +9,9 @@ include::util/man-attributes.adoc[]
 == Synopsis
 [verse]
 // tag::synopsis[]
-aerospace move [-h|--help] [--window-id <window-id>] [--boundaries <boundary>] [--boundaries-action <boundary-action>] (left|down|up|right)
+aerospace move [-h|--help] [--window-id <window-id>] [--boundaries <boundary>]
+               [--boundaries-action <boundary-action>] [--fail-if-fullscreen]
+               [--fail-if-macos-native-fullscreen] (left|down|up|right)
 
 // end::synopsis[]
 
@@ -38,6 +40,12 @@ The default is: `workspace`
 Defines the behavior when requested to move across the `<boundary>`. +
 `<boundary-action>` possible values: `(stop|fail|create-implicit-container)`. +
 The default is: `create-implicit-container`
+
+--fail-if-fullscreen::
+Exit with non-zero code if the target window is fullscreen by the `fullscreen` command.
+
+--fail-if-macos-native-fullscreen::
+Exit with non-zero code if the target window is in macOS native fullscreen.
 
 // =========================================================== Examples
 include::util/conditional-examples-header.adoc[]

--- a/grammar/commands-bnf-grammar.txt
+++ b/grammar/commands-bnf-grammar.txt
@@ -119,13 +119,15 @@ aerospace -h;
 
 <list_workspaces1_flag> ::= --visible [no] | --empty [no] | --format <output_format> | --format <output_format> | --count | --json;
 
-<move_command_flag> ::= --window-id <window_id> | --boundaries <boundary> | --boundaries-action <move_boundaries_action>;
+<move_command_flag> ::= --window-id <window_id> | --boundaries <boundary> | --boundaries-action <move_boundaries_action>
+    | --fail-if-fullscreen | --fail-if-macos-native-fullscreen;
 <move_boundaries_action> ::= stop|fail|create-implicit-container;
 
 <move_node_to_monitor1_flag> ::= --window-id <window_id>|--focus-follows-window|--fail-if-noop|--wrap-around;
 <move_node_to_monitor2_flag> ::= --window-id <window_id>|--focus-follows-window|--fail-if-noop;
 
-<focus_direction_flag> ::= --boundaries <boundary>|--boundaries-action <boundaries_action>|--ignore-floating|--wrap-around;
+<focus_direction_flag> ::= --boundaries <boundary>|--boundaries-action <boundaries_action>|--ignore-floating|--wrap-around
+    | --fail-if-fullscreen | --fail-if-macos-native-fullscreen;
 <focus_dfs_relative_flag> ::= --boundaries-action <boundaries_action>|--ignore-floating|--wrap-around;
 <boundaries_action> ::= stop|fail|wrap-around-the-workspace|wrap-around-all-monitors;
 <boundary> ::= workspace|all-monitors-outer-frame;


### PR DESCRIPTION
## Summary

Add `--fail-if-fullscreen` and `--fail-if-macos-native-fullscreen` to directional `focus` and `move` commands so users can compose window movement bindings with fallback commands without disturbing fullscreen windows.

Fixes #1480.

## Test plan

- `swift build --target AppBundle` -- production target compiled successfully.
- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./swift-test.sh` -- Swift test suite passed.
- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./format.sh` -- formatter/linter script completed successfully.
- `git diff --check` -- no whitespace errors.
