### PR TITLE
Fix workspace stubs and window swap edge cases

### DIFF
--- a/Sources/AppBundle/command/format.swift
+++ b/Sources/AppBundle/command/format.swift
@@ -24,8 +24,8 @@ struct WindowWithPrefetchedTitle {
     }
 
     private static func resolveWindow(_ window: Window, needsTitle: Bool) async throws -> Self {
-        let title: String = try await window.title
-        return .init(window: window, title: needsTitle ? title : nil)
+        let title = needsTitle ? try await window.title : nil
+        return .init(window: window, title: title)
     }
 
     static func forTest(window: Window, title: String?) -> Self {
@@ -162,7 +162,7 @@ extension FormatVar {
                 return switch f {
                     case .windowId: .success(.int(w.window.windowId))
                     case .windowIsFullscreen: .success(.bool(w.window.isFullscreen))
-                    case .windowTitle: .success(.string(w.title.orDie("Title wasn't prefeched")))
+                    case .windowTitle: .success(.string(w.title.orDie("Title wasn't prefetched")))
                     case .windowLayout, .windowParentContainerLayout: toLayoutResult(w: w.window)
                 }
             case (.workspace(let w), .workspace(let f)):

--- a/Sources/AppBundle/command/impl/MoveWorkspaceToMonitorCommand.swift
+++ b/Sources/AppBundle/command/impl/MoveWorkspaceToMonitorCommand.swift
@@ -15,8 +15,13 @@ struct MoveWorkspaceToMonitorCommand: Command {
                 if targetMonitor.monitorId_oneBased == prevMonitor.monitorId_oneBased {
                     return .succ
                 }
+                guard focusedWorkspace.canBeAssigned(to: targetMonitor) else {
+                    return .fail(io.err(
+                        "Can't move workspace '\(focusedWorkspace.name)' to monitor '\(targetMonitor.name)'. workspace-to-monitor-force-assignment doesn't allow it",
+                    ))
+                }
+                let stubWorkspace = getStubWorkspace(for: prevMonitor)
                 if targetMonitor.setActiveWorkspace(focusedWorkspace) {
-                    let stubWorkspace = getStubWorkspace(for: prevMonitor)
                     check(
                         prevMonitor.setActiveWorkspace(stubWorkspace),
                         "getStubWorkspace generated incompatible stub workspace (\(stubWorkspace)) for the monitor (\(prevMonitor)",

--- a/Sources/AppBundle/command/impl/SummonWorkspaceCommand.swift
+++ b/Sources/AppBundle/command/impl/SummonWorkspaceCommand.swift
@@ -16,9 +16,12 @@ struct SummonWorkspaceCommand: Command {
             }
         }
         let prevMonitor = workspace.isVisible ? workspace.workspaceMonitor : nil
+        guard workspace.canBeAssigned(to: monitor) else {
+            return .fail(io.err("Can't move workspace '\(workspace.name)' to monitor '\(monitor.name)'. workspace-to-monitor-force-assignment doesn't allow it"))
+        }
+        let stubWorkspace = prevMonitor.map { getStubWorkspace(for: $0) }
         if monitor.setActiveWorkspace(workspace) {
-            if let prevMonitor {
-                let stubWorkspace = getStubWorkspace(for: prevMonitor)
+            if let prevMonitor, let stubWorkspace {
                 check(
                     prevMonitor.setActiveWorkspace(stubWorkspace),
                     "getStubWorkspace generated incompatible stub workspace (\(stubWorkspace)) for the monitor (\(prevMonitor)",

--- a/Sources/AppBundle/model/Monitor.swift
+++ b/Sources/AppBundle/model/Monitor.swift
@@ -93,9 +93,23 @@ private let testMonitor = MonitorImpl(
     visibleRect: testMonitorRect,
     isMain: true,
 )
+private let testMonitorsThreadDictionaryKey = "aerospace.testMonitors"
+
+var testMonitors: [Monitor]? {
+    get {
+        Thread.current.threadDictionary[testMonitorsThreadDictionaryKey] as? [Monitor]
+    }
+    set {
+        if let newValue {
+            Thread.current.threadDictionary[testMonitorsThreadDictionaryKey] = newValue
+        } else {
+            Thread.current.threadDictionary.removeObject(forKey: testMonitorsThreadDictionaryKey)
+        }
+    }
+}
 
 var mainMonitor: Monitor {
-    if isUnitTest { return testMonitor }
+    if isUnitTest { return testMonitors?.first(where: \.isMain) ?? testMonitors?.first ?? testMonitor }
     let screens = NSScreen.screens
     // Fallback: If main screen can't be found (e.g., during display reconfiguration),
     // return screens.first or testMonitor to avoid crash
@@ -106,7 +120,7 @@ var mainMonitor: Monitor {
 
 var monitors: [Monitor] {
     isUnitTest
-        ? [testMonitor]
+        ? (testMonitors ?? [testMonitor])
         : NSScreen.screens.enumerated().map { $0.element.toMonitor(monitorAppKitNsScreenScreensId: $0.offset + 1) }
 }
 

--- a/Sources/AppBundle/mouse/moveWithMouse.swift
+++ b/Sources/AppBundle/mouse/moveWithMouse.swift
@@ -76,7 +76,7 @@ private func moveTilingWindow(_ window: Window) {
 func swapWindows(_ window1: Window, _ window2: Window) {
     if window1 == window2 { return }
     guard let index1 = window1.ownIndex else { return }
-    guard let index2 = window1.ownIndex else { return }
+    guard let index2 = window2.ownIndex else { return }
 
     if index1 < index2 {
         let binding2 = window2.unbindFromParent()

--- a/Sources/AppBundle/tree/Workspace.swift
+++ b/Sources/AppBundle/tree/Workspace.swift
@@ -7,6 +7,16 @@ import Common
 @MainActor private var screenPointToVisibleWorkspace: [CGPoint: Workspace] = [:]
 @MainActor private var visibleWorkspaceToScreenPoint: [Workspace: CGPoint] = [:]
 
+@MainActor func resetWorkspaceMonitorStateForTests() {
+    check(isUnitTest)
+    screenPointToPrevVisibleWorkspace = [:]
+    screenPointToVisibleWorkspace = [:]
+    visibleWorkspaceToScreenPoint = [:]
+    for workspace in Workspace.all {
+        workspace.assignedMonitorPoint = nil
+    }
+}
+
 // The returned workspace must be invisible and it must belong to the requested monitor
 @MainActor func getStubWorkspace(for monitor: Monitor) -> Workspace {
     getStubWorkspace(forPoint: monitor.rect.topLeftCorner)

--- a/Sources/AppBundle/tree/WorkspaceEx.swift
+++ b/Sources/AppBundle/tree/WorkspaceEx.swift
@@ -47,4 +47,8 @@ extension Workspace {
             .compactMap { $0.resolveMonitor(sortedMonitors: sortedMonitors) }
             .first
     }
+
+    @MainActor func canBeAssigned(to monitor: Monitor) -> Bool {
+        forceAssignedMonitor.map { $0.rect.topLeftCorner == monitor.rect.topLeftCorner } ?? true
+    }
 }

--- a/Sources/AppBundleTests/command/ListWindowsTest.swift
+++ b/Sources/AppBundleTests/command/ListWindowsTest.swift
@@ -1,4 +1,5 @@
 @testable import AppBundle
+import AppKit
 import Common
 import XCTest
 
@@ -71,6 +72,44 @@ final class ListWindowsTest: XCTestCase {
                 AeroObj.window(.forTest(window: TestWindow.new(id: 10, parent: $0), title: "title2")),
             ]
             assertEquals(windows.format([.interVar("window-id"), .interVar("right-padding"), .literal(" | "), .interVar("window-title")]), .success(["2  | title1", "10 | title2"]))
+        }
+    }
+
+    func testResolveWindowFetchesTitleOnlyWhenFormatNeedsIt() async throws {
+        let window = TitleFetchCountingWindow.new(
+            id: 1,
+            parent: Workspace.get(byName: name).rootTilingContainer,
+        )
+
+        _ = try await WindowWithPrefetchedTitle.resolveWindow(window, for: [.interVar("window-id")])
+        assertEquals(window.titleReadCount, 0)
+
+        let resolved = try await WindowWithPrefetchedTitle.resolveWindow(window, for: [.interVar("window-title")])
+        assertEquals(window.titleReadCount, 1)
+        assertEquals([AeroObj.window(resolved)].format([.interVar("window-title")]), .success(["counted"]))
+    }
+}
+
+private final class TitleFetchCountingWindow: Window {
+    private(set) var titleReadCount = 0
+
+    @MainActor
+    private init(_ id: UInt32, _ parent: NonLeafTreeNodeObject) {
+        super.init(id: id, TestApp.shared, lastFloatingSize: nil, parent: parent, adaptiveWeight: 1, index: INDEX_BIND_LAST)
+    }
+
+    @discardableResult
+    @MainActor
+    static func new(id: UInt32, parent: NonLeafTreeNodeObject) -> TitleFetchCountingWindow {
+        let window = TitleFetchCountingWindow(id, parent)
+        TestApp.shared._windows.append(window)
+        return window
+    }
+
+    override var title: String {
+        get async {
+            titleReadCount += 1
+            return "counted"
         }
     }
 }

--- a/Sources/AppBundleTests/command/MoveCommandTest.swift
+++ b/Sources/AppBundleTests/command/MoveCommandTest.swift
@@ -85,6 +85,17 @@ final class MoveCommandTest: XCTestCase {
         assertEquals(window1.hWeight, 1)
     }
 
+    func testSwapWindows_swapsWhenLeftIndexIsGreater() {
+        let root = Workspace.get(byName: name).rootTilingContainer
+        let window1 = TestWindow.new(id: 1, parent: root)
+        TestWindow.new(id: 2, parent: root)
+        let window3 = TestWindow.new(id: 3, parent: root)
+
+        swapWindows(window3, window1)
+
+        assertEquals(root.layoutDescription, .h_tiles([.window(3), .window(2), .window(1)]))
+    }
+
     func testMoveIn_newWeight() async throws {
         var window1: Window!
         var window2: Window!

--- a/Sources/AppBundleTests/command/MoveWorkspaceToMonitorCommandTest.swift
+++ b/Sources/AppBundleTests/command/MoveWorkspaceToMonitorCommandTest.swift
@@ -1,0 +1,33 @@
+@testable import AppBundle
+import Common
+import XCTest
+
+@MainActor
+final class MoveWorkspaceToMonitorCommandTest: XCTestCase {
+    override func setUp() async throws {
+        setUpWorkspacesForTests()
+        setUpTwoTestMonitors()
+    }
+
+    func testMoveWorkspaceToMonitorUsesPreviousWorkspaceAsStub() async throws {
+        check(Workspace.get(byName: "a").focusWorkspace())
+        check(Workspace.get(byName: "z").focusWorkspace())
+        check(Workspace.get(byName: "m").focusWorkspace())
+
+        let result = try await parseCommand("move-workspace-to-monitor next").cmdOrDie.run(.defaultEnv, .emptyStdin)
+
+        assertEquals(result.exitCode.rawValue, 0)
+        assertEquals(mainMonitor.activeWorkspace.name, "z")
+        assertEquals(monitors[1].activeWorkspace.name, "m")
+    }
+
+    func testMoveWorkspaceToMonitorRejectsForceAssignedWorkspace() async throws {
+        check(Workspace.get(byName: "m").focusWorkspace())
+        config.workspaceToMonitorForceAssignment["m"] = [.main]
+
+        let result = try await parseCommand("move-workspace-to-monitor next").cmdOrDie.run(.defaultEnv, .emptyStdin)
+
+        assertEquals(result.exitCode.rawValue, 2)
+        assertEquals(mainMonitor.activeWorkspace.name, "m")
+    }
+}

--- a/Sources/AppBundleTests/command/SummonWorkspaceCommandTest.swift
+++ b/Sources/AppBundleTests/command/SummonWorkspaceCommandTest.swift
@@ -9,4 +9,32 @@ final class SummonWorkspaceCommandTest: XCTestCase {
     func testParse() {
         assertEquals(parseCommand("summon-workspace").errorOrNil, "ERROR: Argument '<workspace>' is mandatory")
     }
+
+    func testSummonVisibleWorkspaceUsesPreviousWorkspaceAsStub() async throws {
+        setUpTwoTestMonitors()
+        let secondaryMonitor = monitors[1]
+        check(secondaryMonitor.setActiveWorkspace(Workspace.get(byName: "a")))
+        check(secondaryMonitor.setActiveWorkspace(Workspace.get(byName: "z")))
+        check(secondaryMonitor.setActiveWorkspace(Workspace.get(byName: "m")))
+
+        let result = try await parseCommand("summon-workspace m").cmdOrDie.run(.defaultEnv, .emptyStdin)
+
+        assertEquals(result.exitCode.rawValue, 0)
+        assertEquals(mainMonitor.activeWorkspace.name, "m")
+        assertEquals(secondaryMonitor.activeWorkspace.name, "z")
+    }
+
+    func testSummonWorkspaceRejectsForceAssignedWorkspace() async throws {
+        setUpTwoTestMonitors()
+        let secondaryMonitor = monitors[1]
+        check(secondaryMonitor.setActiveWorkspace(Workspace.get(byName: "m")))
+        config.workspaceToMonitorForceAssignment["m"] = [.secondary]
+        let mainWorkspaceBefore = mainMonitor.activeWorkspace.name
+
+        let result = try await parseCommand("summon-workspace m").cmdOrDie.run(.defaultEnv, .emptyStdin)
+
+        assertEquals(result.exitCode.rawValue, 2)
+        assertEquals(mainMonitor.activeWorkspace.name, mainWorkspaceBefore)
+        assertEquals(secondaryMonitor.activeWorkspace.name, "m")
+    }
 }

--- a/Sources/AppBundleTests/testUtil.swift
+++ b/Sources/AppBundleTests/testUtil.swift
@@ -1,4 +1,5 @@
 @testable import AppBundle
+import AppKit
 import Common
 import Foundation
 import HotKey
@@ -15,6 +16,8 @@ let projectRoot: URL = {
 
 @MainActor
 func setUpWorkspacesForTests() {
+    resetWorkspaceMonitorStateForTests()
+    testMonitors = nil
     config = defaultConfig
     configUrl = defaultConfigUrl
     config.enableNormalizationFlattenContainers = false // Make layout tests more predictable
@@ -24,6 +27,11 @@ func setUpWorkspacesForTests() {
     // Don't create any bindings and workspaces for tests
     config.modes = [mainModeId: Mode(bindings: [:])]
     config.persistentWorkspaces = []
+    config.onFocusChanged = []
+    config.onFocusedMonitorChanged = []
+    config.execOnWorkspaceChange = []
+    config.onWindowDetected = []
+    config.onModeChanged = []
 
     for workspace in Workspace.all {
         for child in workspace.children {
@@ -38,6 +46,28 @@ func setUpWorkspacesForTests() {
 
     TestApp.shared.focusedWindow = nil
     TestApp.shared.windows = []
+}
+
+private struct TestMonitor: Monitor {
+    let monitorAppKitNsScreenScreensId: Int
+    let name: String
+    let rect: Rect
+    let visibleRect: Rect
+    let isMain: Bool
+    var width: CGFloat { rect.width }
+    var height: CGFloat { rect.height }
+}
+
+@MainActor
+@discardableResult
+func setUpTwoTestMonitors() -> (main: Monitor, secondary: Monitor) {
+    let mainRect = Rect(topLeftX: 0, topLeftY: 0, width: 1920, height: 1080)
+    let secondaryRect = Rect(topLeftX: 1920, topLeftY: 0, width: 1920, height: 1080)
+    let main = TestMonitor(monitorAppKitNsScreenScreensId: 1, name: "Main Test Monitor", rect: mainRect, visibleRect: mainRect, isMain: true)
+    let secondary = TestMonitor(monitorAppKitNsScreenScreensId: 2, name: "Secondary Test Monitor", rect: secondaryRect, visibleRect: secondaryRect, isMain: false)
+    testMonitors = [main, secondary]
+    gcMonitors()
+    return (main, secondary)
 }
 
 extension ParsedCmd {


### PR DESCRIPTION
## Summary
- avoid fetching window titles unless a format expansion actually needs them
- fix `swapWindows` to read the second window index from the second window
- preserve the previous workspace as the stub when moving or summoning visible workspaces across monitors
- add two-monitor command tests and reset test-only monitor/focus callback state for isolation

## Why
This pulls forward and tightens fixes I had been carrying locally. The lazy title path still resolved `window.title` unconditionally, so list-window formatting could pay AX title cost even when unused. `swapWindows` also reused `window1.ownIndex` for both operands, breaking reverse-order swaps. For workspace moves between monitors, selecting the stub after mutating the visible workspace maps could choose the wrong empty workspace and leave monitor/workspace state unstable.

## Validation
- `swift test`
- `swift build --product aerospace -Xswiftc -warnings-as-errors`
- `swift build --product AeroSpaceApp -Xswiftc -warnings-as-errors`
- `swift build --target AppBundleTests -Xswiftc -warnings-as-errors`
- `git diff --check`