### PR TITLE
Add sticky window support

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ What stops us from 1.0 release:
   - [ ] https://github.com/nikitabobko/AeroSpace/issues/28 Maybe it will allow to distinguish left and right modifiers. Maybe not
 
 Big and important issues which will go after 1.0 release:
-- [ ] https://github.com/nikitabobko/AeroSpace/issues/2 sticky windows
+- [x] https://github.com/nikitabobko/AeroSpace/issues/2 sticky windows
 - [ ] https://github.com/nikitabobko/AeroSpace/issues/260 Dynamic TWM
 
 ## Development

--- a/Sources/AppBundle/command/cmdManifest.swift
+++ b/Sources/AppBundle/command/cmdManifest.swift
@@ -70,6 +70,8 @@ extension CmdArgs {
                 command = ResizeCommand(args: self as! ResizeCmdArgs)
             case .split:
                 command = SplitCommand(args: self as! SplitCmdArgs)
+            case .sticky:
+                command = StickyCommand(args: self as! StickyCmdArgs)
             case .subscribe:
                 die("subscribe is handled separately")
             case .summonWorkspace:

--- a/Sources/AppBundle/command/format.swift
+++ b/Sources/AppBundle/command/format.swift
@@ -162,6 +162,7 @@ extension FormatVar {
                 return switch f {
                     case .windowId: .success(.int(w.window.windowId))
                     case .windowIsFullscreen: .success(.bool(w.window.isFullscreen))
+                    case .windowIsSticky: .success(.bool(w.window.isSticky))
                     case .windowTitle: .success(.string(w.title.orDie("Title wasn't prefeched")))
                     case .windowLayout, .windowParentContainerLayout: toLayoutResult(w: w.window)
                 }

--- a/Sources/AppBundle/command/impl/FocusCommand.swift
+++ b/Sources/AppBundle/command/impl/FocusCommand.swift
@@ -141,6 +141,7 @@ struct FocusCommand: Command {
             tilingParent = workspace.rootTilingContainer
         }
 
+        guard window.parent === workspace else { continue }
         let data = window.unbindFromParent()
         let floatingWindowData = FloatingWindowData(
             window: window,

--- a/Sources/AppBundle/command/impl/ListWindowsCommand.swift
+++ b/Sources/AppBundle/command/impl/ListWindowsCommand.swift
@@ -31,7 +31,8 @@ struct ListWindowsCommand: Command {
                 if monitors.isEmpty { return .fail }
                 workspaces = workspaces.filter { monitors.contains($0.workspaceMonitor.rect.topLeftCorner) }
             }
-            windows = workspaces.flatMap(\.allLeafWindowsRecursive)
+            windows = workspaces.flatMap(windowsInOrVisuallyOnWorkspace)
+            windows = Array(windows.toOrderedSet())
             if let pid = args.filteringOptions.pidFilter {
                 windows = windows.filter { $0.app.pid == pid }
             }

--- a/Sources/AppBundle/command/impl/StickyCommand.swift
+++ b/Sources/AppBundle/command/impl/StickyCommand.swift
@@ -1,0 +1,30 @@
+import AppKit
+import Common
+
+struct StickyCommand: Command {
+    let args: StickyCmdArgs
+    /*conforms*/ let shouldResetClosedWindowsCache = false
+
+    func run(_ env: CmdEnv, _ io: CmdIo) -> BinaryExitCode {
+        guard let target = args.resolveTargetOrReportError(env, io) else { return .fail }
+        guard let window = target.windowOrNil else {
+            return .fail(io.err(noWindowIsFocused))
+        }
+        let newState: Bool = switch args.toggle {
+            case .on: true
+            case .off: false
+            case .toggle: !window.isSticky
+        }
+        if newState == window.isSticky {
+            return switch args.failIfNoop {
+                case true: .fail
+                case false:
+                    .succ(io.err((newState ? "Already sticky. " : "Already not sticky. ") +
+                            "Tip: use --fail-if-noop to exit with non-zero code"))
+            }
+        }
+        window.isSticky = newState
+        window.markAsMostRecentChild()
+        return .succ
+    }
+}

--- a/Sources/AppBundle/command/impl/StickyCommand.swift
+++ b/Sources/AppBundle/command/impl/StickyCommand.swift
@@ -5,7 +5,7 @@ struct StickyCommand: Command {
     let args: StickyCmdArgs
     /*conforms*/ let shouldResetClosedWindowsCache = false
 
-    func run(_ env: CmdEnv, _ io: CmdIo) -> BinaryExitCode {
+    func run(_ env: CmdEnv, _ io: CmdIo) async throws -> BinaryExitCode {
         guard let target = args.resolveTargetOrReportError(env, io) else { return .fail }
         guard let window = target.windowOrNil else {
             return .fail(io.err(noWindowIsFocused))
@@ -24,6 +24,12 @@ struct StickyCommand: Command {
             }
         }
         window.isSticky = newState
+        if newState && !window.isFloating, let workspace = window.nodeWorkspace {
+            if window.lastFloatingSize == nil {
+                window.lastFloatingSize = try await window.getAxSize()
+            }
+            window.bindAsFloatingWindow(to: workspace)
+        }
         window.markAsMostRecentChild()
         return .succ
     }

--- a/Sources/AppBundle/layout/layoutRecursive.swift
+++ b/Sources/AppBundle/layout/layoutRecursive.swift
@@ -26,6 +26,12 @@ extension TreeNode {
                     window.lastAppliedLayoutVirtualRect = nil
                     try await window.layoutFloatingWindow(context)
                 }
+                // Position sticky windows from hidden workspaces that are visually on this workspace
+                let stickyWindows = windowsVisuallyOnWorkspace(workspace)
+                    .filter { $0.isSticky && $0.nodeWorkspace != workspace }
+                for window in stickyWindows {
+                    try await window.layoutFloatingWindow(context)
+                }
             case .window(let window):
                 if window.windowId != currentlyManipulatedWithMouseWindowId {
                     lastAppliedLayoutVirtualRect = virtual

--- a/Sources/AppBundle/layout/refresh.swift
+++ b/Sources/AppBundle/layout/refresh.swift
@@ -196,7 +196,11 @@ private func layoutWorkspaces() async throws {
     for workspace in Workspace.all where !workspace.isVisible {
         let corner = monitorToOptimalHideCorner[workspace.workspaceMonitor.rect.topLeftCorner] ?? .bottomRightCorner
         for window in workspace.allLeafWindowsRecursive {
-            try await (window as! MacWindow).hideInCorner(corner) // todo as!
+            if window.shouldStayVisibleWhenOwningWorkspaceIsHidden {
+                (window as! MacWindow).unhideFromCorner() // todo as!
+            } else {
+                try await (window as! MacWindow).hideInCorner(corner) // todo as!
+            }
         }
     }
 }

--- a/Sources/AppBundle/tree/TreeNodeEx.swift
+++ b/Sources/AppBundle/tree/TreeNodeEx.swift
@@ -31,7 +31,12 @@ extension TreeNode {
 
     /// Also see: workspace
     @MainActor
-    var visualWorkspace: Workspace? { nodeWorkspace ?? nodeMonitor?.activeWorkspace }
+    var visualWorkspace: Workspace? {
+        if let window = self as? Window {
+            return window.visualWorkspaceForWindow
+        }
+        return nodeWorkspace ?? nodeMonitor?.activeWorkspace
+    }
 
     @MainActor
     var nodeMonitor: Monitor? {

--- a/Sources/AppBundle/tree/Window.swift
+++ b/Sources/AppBundle/tree/Window.swift
@@ -7,6 +7,7 @@ open class Window: TreeNode, Hashable {
     var lastFloatingSize: CGSize?
     var isFullscreen: Bool = false
     var noOuterGapsInFullscreen: Bool = false
+    var isSticky: Bool = false
     var layoutReason: LayoutReason = .standard
 
     @MainActor

--- a/Sources/AppBundle/tree/WindowVisibility.swift
+++ b/Sources/AppBundle/tree/WindowVisibility.swift
@@ -1,0 +1,51 @@
+import Common
+
+extension Window {
+    @MainActor
+    var visualWorkspaceForWindow: Workspace? {
+        stickyWorkspaceOnActiveMonitor ?? nodeWorkspace ?? nodeMonitor?.activeWorkspace
+    }
+
+    @MainActor
+    func isVisuallyOn(workspace: Workspace) -> Bool {
+        visualWorkspaceForWindow == workspace
+    }
+
+    @MainActor
+    var shouldStayVisibleWhenOwningWorkspaceIsHidden: Bool {
+        stickyWorkspaceOnActiveMonitor != nil
+    }
+
+    @MainActor
+    private var stickyWorkspaceOnActiveMonitor: Workspace? {
+        guard isSticky,
+              isManagedByAeroSpaceWorkspaceVisibility,
+              nodeWorkspace?.isVisible != true
+        else { return nil }
+        return nodeMonitor?.activeWorkspace
+    }
+
+    @MainActor
+    private var isManagedByAeroSpaceWorkspaceVisibility: Bool {
+        guard let parent else { return false }
+        return switch getChildParentRelation(child: self, parent: parent) {
+            case .floatingWindow, .tiling: true
+            case .rootTilingContainer, .shimContainerRelation,
+                 .macosNativeFullscreenWindow, .macosNativeHiddenAppWindow,
+                 .macosNativeMinimizedWindow, .macosPopupWindow:
+                false
+        }
+    }
+}
+
+@MainActor
+func windowsVisuallyOnWorkspace(_ workspace: Workspace) -> [Window] {
+    Workspace.all
+        .flatMap(\.allLeafWindowsRecursive)
+        .filter { $0.isVisuallyOn(workspace: workspace) }
+}
+
+@MainActor
+func windowsInOrVisuallyOnWorkspace(_ workspace: Workspace) -> [Window] {
+    Array((workspace.allLeafWindowsRecursive + windowsVisuallyOnWorkspace(workspace)).toOrderedSet())
+}

--- a/Sources/AppBundle/ui/MenuBarLabel.swift
+++ b/Sources/AppBundle/ui/MenuBarLabel.swift
@@ -13,6 +13,7 @@ struct MenuBarLabel: View {
     let itemSize = CGFloat(40)
     let itemBorderSize = CGFloat(3)
     let itemCornerRadius = CGFloat(6)
+    let focusedWindowBadgeSize = CGFloat(32)
 
     private var finalColor: Color {
         return color ?? (menuColorScheme == .dark ? Color.white : Color.black)
@@ -69,6 +70,7 @@ struct MenuBarLabel: View {
                             .opacity(item.isVisible ? 1 : 0.5)
                     }
             }
+            focusedWindowBadges
         }
     }
 
@@ -84,6 +86,17 @@ struct MenuBarLabel: View {
             if item.type == .mode {
                 modeSeparator(with: .monospaced)
             }
+        }
+    }
+
+    private var focusedWindowBadges: some View {
+        ForEach(viewModel.focusedWindowBadges) { badge in
+            Image(systemName: badge.systemImageName)
+                .font(.system(size: focusedWindowBadgeSize, weight: .semibold, design: .rounded))
+                .symbolRenderingMode(.monochrome)
+                .foregroundStyle(finalColor)
+                .frame(width: itemSize, height: itemSize)
+                .accessibilityLabel(Text(badge.accessibilityLabel))
         }
     }
 

--- a/Sources/AppBundle/ui/TrayMenuModel.swift
+++ b/Sources/AppBundle/ui/TrayMenuModel.swift
@@ -7,6 +7,7 @@ public final class TrayMenuModel: ObservableObject {
     private init() {}
 
     @Published var trayText: String = ""
+    @Published var focusedWindowBadges: [FocusedWindowBadge] = []
     @Published var trayItems: [TrayItem] = []
     /// Is "layouting" enabled
     @Published var isEnabled: Bool = true
@@ -26,6 +27,7 @@ public final class TrayMenuModel: ObservableObject {
             return ($0.activeWorkspace == focus.workspace && sortedMonitors.count > 1 ? "*" : "") + activeWorkspaceName
         }
         .joined(separator: " │ ")
+    TrayMenuModel.shared.focusedWindowBadges = menuBarFocusedWindowBadges(for: focus.windowOrNil)
     TrayMenuModel.shared.workspaces = Workspace.all.map {
         let apps = $0.allLeafWindowsRecursive.map { $0.app.name?.takeIf { !$0.isEmpty } }.filterNotNil().toSet()
         let dash = " - "
@@ -62,6 +64,15 @@ public final class TrayMenuModel: ObservableObject {
     TrayMenuModel.shared.trayItems = items
 }
 
+@MainActor
+func menuBarFocusedWindowBadges(for window: Window?) -> [FocusedWindowBadge] {
+    guard let window else { return [] }
+    return [
+        window.isFloating ? .floating : nil,
+        window.isSticky ? .sticky : nil,
+    ].filterNotNil()
+}
+
 struct WorkspaceViewModel: Hashable {
     let name: String
     let suffix: String
@@ -74,6 +85,27 @@ struct WorkspaceViewModel: Hashable {
 enum TrayItemType: String, Hashable {
     case mode
     case workspace
+}
+
+enum FocusedWindowBadge: Hashable, Identifiable {
+    case floating
+    case sticky
+
+    var id: Self { self }
+
+    var systemImageName: String {
+        switch self {
+            case .floating: "rectangle.fill.on.rectangle.angled.fill"
+            case .sticky: "pin.fill"
+        }
+    }
+
+    var accessibilityLabel: String {
+        switch self {
+            case .floating: "Floating window"
+            case .sticky: "Sticky window"
+        }
+    }
 }
 
 private let validLetters = "A" ... "Z"

--- a/Sources/AppBundle/util/AxUiElementMock.swift
+++ b/Sources/AppBundle/util/AxUiElementMock.swift
@@ -1,5 +1,4 @@
 import AppKit
-import Common
 
 /// Alternative name: AttrAddressibleStorage
 protocol AxUiElementMock {

--- a/Sources/AppBundleTests/command/FocusCommandTest.swift
+++ b/Sources/AppBundleTests/command/FocusCommandTest.swift
@@ -75,6 +75,24 @@ final class FocusCommandTest: XCTestCase {
         assertEquals(focus.windowOrNil?.windowId, 3)
     }
 
+    func testFocusSkipsFloatingWindowThatWasUnboundDuringAxRead() async throws {
+        let workspace = Workspace.get(byName: name)
+        workspace.rootTilingContainer.apply {
+            assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)
+            TestWindow.new(id: 2, parent: $0)
+        }
+        let floating = TestWindow.new(id: 3, parent: workspace, rect: Rect(topLeftX: 0, topLeftY: 0, width: 100, height: 100))
+        floating.beforeGetAxRect = {
+            floating.beforeGetAxRect = nil
+            floating.unbindFromParent()
+        }
+
+        try await FocusCommand.new(direction: .right).run(.defaultEnv, .emptyStdin)
+
+        assertEquals(focus.windowOrNil?.windowId, 2)
+        assertEquals(floating.isBound, false)
+    }
+
     func testFocusAlongTheContainerOrientation() async throws {
         Workspace.get(byName: name).rootTilingContainer.apply {
             assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)

--- a/Sources/AppBundleTests/command/StickyCommandTest.swift
+++ b/Sources/AppBundleTests/command/StickyCommandTest.swift
@@ -1,0 +1,167 @@
+@testable import AppBundle
+import Common
+import XCTest
+
+@MainActor
+final class StickyCommandTest: XCTestCase {
+    override func setUp() async throws { setUpWorkspacesForTests() }
+
+    func testParse() {
+        testParseCommandSucc("sticky", StickyCmdArgs(rawArgs: []))
+        testParseCommandSucc("sticky on", StickyCmdArgs(rawArgs: []).copy(\.toggle, .on))
+        testParseCommandSucc("sticky off", StickyCmdArgs(rawArgs: []).copy(\.toggle, .off))
+        testParseCommandSucc("sticky --window-id 42 off", StickyCmdArgs(rawArgs: []).copy(\.windowId, 42).copy(\.toggle, .off))
+        testParseCommandSucc("sticky --fail-if-noop on", StickyCmdArgs(rawArgs: []).copy(\.failIfNoop, true).copy(\.toggle, .on))
+        assertEquals(parseCommand("sticky --fail-if-noop").errorOrNil, "--fail-if-noop requires 'on' or 'off' argument")
+    }
+
+    func testToggleOnOffAndNoop() async throws {
+        var window: TestWindow!
+        Workspace.get(byName: "a").rootTilingContainer.apply {
+            window = TestWindow.new(id: 1, parent: $0)
+        }
+        _ = window.focusWindow()
+
+        try await StickyCommand(args: StickyCmdArgs(rawArgs: [])).run(.defaultEnv, .emptyStdin)
+        assertEquals(window.isSticky, true)
+
+        try await StickyCommand(args: StickyCmdArgs(rawArgs: [])).run(.defaultEnv, .emptyStdin)
+        assertEquals(window.isSticky, false)
+
+        try await parseCommand("sticky on").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(window.isSticky, true)
+
+        let alreadySticky = try await parseCommand("sticky on").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(alreadySticky.exitCode.rawValue, 0)
+        assertEquals(alreadySticky.stderr, ["Already sticky. Tip: use --fail-if-noop to exit with non-zero code"])
+
+        let failIfNoop = try await parseCommand("sticky --fail-if-noop on").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(failIfNoop.exitCode.rawValue, 2)
+
+        try await parseCommand("sticky off").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(window.isSticky, false)
+    }
+
+    func testWindowId() async throws {
+        var window1: TestWindow!
+        var window2: TestWindow!
+        Workspace.get(byName: "a").rootTilingContainer.apply {
+            window1 = TestWindow.new(id: 1, parent: $0)
+            window2 = TestWindow.new(id: 2, parent: $0)
+        }
+        _ = window1.focusWindow()
+
+        try await parseCommand("sticky --window-id 2 on").cmdOrDie.run(.defaultEnv, .emptyStdin)
+
+        assertEquals(window1.isSticky, false)
+        assertEquals(window2.isSticky, true)
+    }
+
+    func testStickyWindowUsesVisibleWorkspaceWhenHomeWorkspaceIsHidden() {
+        let workspaceA = Workspace.get(byName: "a")
+        let workspaceB = Workspace.get(byName: "b")
+        var window: TestWindow!
+        workspaceA.rootTilingContainer.apply {
+            window = TestWindow.new(id: 1, parent: $0)
+        }
+        window.isSticky = true
+
+        check(workspaceB.focusWorkspace())
+
+        assertEquals(window.nodeWorkspace, workspaceA)
+        assertEquals(window.visualWorkspace, workspaceB)
+        assertEquals(window.isVisuallyOn(workspace: workspaceB), true)
+        assertEquals(window.isVisuallyOn(workspace: workspaceA), false)
+        assertEquals(windowsVisuallyOnWorkspace(workspaceB), [window])
+    }
+
+    func testNonStickyWindowStaysVisuallyOnItsHomeWorkspaceWhenHidden() {
+        let workspaceA = Workspace.get(byName: "a")
+        let workspaceB = Workspace.get(byName: "b")
+        var window: TestWindow!
+        workspaceA.rootTilingContainer.apply {
+            window = TestWindow.new(id: 1, parent: $0)
+        }
+
+        check(workspaceB.focusWorkspace())
+
+        assertEquals(window.nodeWorkspace, workspaceA)
+        assertEquals(window.visualWorkspace, workspaceA)
+        assertEquals(window.shouldStayVisibleWhenOwningWorkspaceIsHidden, false)
+    }
+
+    func testListVisibleAndMonitorWindowsIncludeStickyWindowsWithoutDuplication() async throws {
+        let workspaceA = Workspace.get(byName: "a")
+        let workspaceB = Workspace.get(byName: "b")
+        workspaceA.rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0).isSticky = true
+        }
+        workspaceB.rootTilingContainer.apply {
+            TestWindow.new(id: 2, parent: $0)
+        }
+        check(workspaceB.focusWorkspace())
+
+        let result = try await parseCommand("list-windows --workspace visible --format '%{window-id}'").cmdOrDie.run(.defaultEnv, .emptyStdin)
+
+        assertEquals(result.stdout.toSet(), ["1", "2"])
+
+        let monitorResult = try await parseCommand("list-windows --monitor all --format '%{window-id}'").cmdOrDie.run(.defaultEnv, .emptyStdin)
+
+        assertEquals(monitorResult.stdout.toSet(), ["1", "2"])
+        assertEquals(monitorResult.stdout.count, 2)
+    }
+
+    func testStickyWindowInVisibleHomeWorkspaceIsNotDuplicatedInListWindows() async throws {
+        Workspace.get(byName: "a").rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0).isSticky = true
+        }
+
+        let result = try await parseCommand("list-windows --workspace visible --format '%{window-id}'").cmdOrDie.run(.defaultEnv, .emptyStdin)
+
+        assertEquals(result.stdout, ["1"])
+    }
+
+    func testWindowIsStickyFormatVar() async throws {
+        let workspaceA = Workspace.get(byName: "a")
+        workspaceA.rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0).isSticky = true
+            TestWindow.new(id: 2, parent: $0)
+        }
+        check(workspaceA.focusWorkspace())
+
+        let result = try await parseCommand("list-windows --workspace visible --format '%{window-id} %{window-is-sticky}'").cmdOrDie.run(.defaultEnv, .emptyStdin)
+
+        assertEquals(result.stdout.toSet(), ["1 true", "2 false"])
+    }
+
+    func testStickyDoesNotChangeWindowOwnershipOrLayout() async throws {
+        let workspaceA = Workspace.get(byName: "a")
+        var window: TestWindow!
+        workspaceA.rootTilingContainer.apply {
+            window = TestWindow.new(id: 1, parent: $0)
+        }
+        let parentBefore = window.parent
+        _ = window.focusWindow()
+
+        try await parseCommand("sticky on").cmdOrDie.run(.defaultEnv, .emptyStdin)
+
+        assertEquals(window.nodeWorkspace, workspaceA)
+        assertTrue(window.parent === parentBefore)
+    }
+
+    func testMoveNodeToWorkspacePreservesStickyState() async throws {
+        let workspaceA = Workspace.get(byName: "a")
+        let workspaceB = Workspace.get(byName: "b")
+        var window: TestWindow!
+        workspaceA.rootTilingContainer.apply {
+            window = TestWindow.new(id: 1, parent: $0)
+        }
+        window.isSticky = true
+        _ = window.focusWindow()
+
+        try await MoveNodeToWorkspaceCommand(args: MoveNodeToWorkspaceCmdArgs(workspace: "b")).run(.defaultEnv, .emptyStdin)
+
+        assertEquals(window.isSticky, true)
+        assertEquals(window.nodeWorkspace, workspaceB)
+    }
+}

--- a/Sources/AppBundleTests/command/StickyCommandTest.swift
+++ b/Sources/AppBundleTests/command/StickyCommandTest.swift
@@ -134,19 +134,72 @@ final class StickyCommandTest: XCTestCase {
         assertEquals(result.stdout.toSet(), ["1 true", "2 false"])
     }
 
-    func testStickyDoesNotChangeWindowOwnershipOrLayout() async throws {
+    func testStickyOnAutoFloatsTilingWindow() async throws {
         let workspaceA = Workspace.get(byName: "a")
         var window: TestWindow!
         workspaceA.rootTilingContainer.apply {
             window = TestWindow.new(id: 1, parent: $0)
         }
-        let parentBefore = window.parent
         _ = window.focusWindow()
+
+        assertTrue(window.isFloating == false)
 
         try await parseCommand("sticky on").cmdOrDie.run(.defaultEnv, .emptyStdin)
 
+        assertEquals(window.isSticky, true)
+        assertTrue(window.isFloating)
         assertEquals(window.nodeWorkspace, workspaceA)
-        assertTrue(window.parent === parentBefore)
+    }
+
+    func testStickyOnPreservesAlreadyFloatingWindow() async throws {
+        let workspaceA = Workspace.get(byName: "a")
+        var window: TestWindow!
+        window = TestWindow.new(id: 1, parent: workspaceA) // Direct child of workspace = floating
+        _ = window.focusWindow()
+
+        assertTrue(window.isFloating)
+
+        try await parseCommand("sticky on").cmdOrDie.run(.defaultEnv, .emptyStdin)
+
+        assertEquals(window.isSticky, true)
+        assertTrue(window.isFloating)
+        assertEquals(window.nodeWorkspace, workspaceA)
+    }
+
+    func testStickyOffDoesNotReTile() async throws {
+        let workspaceA = Workspace.get(byName: "a")
+        var window: TestWindow!
+        workspaceA.rootTilingContainer.apply {
+            window = TestWindow.new(id: 1, parent: $0)
+        }
+        _ = window.focusWindow()
+
+        try await parseCommand("sticky on").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertTrue(window.isFloating)
+
+        try await parseCommand("sticky off").cmdOrDie.run(.defaultEnv, .emptyStdin)
+
+        assertEquals(window.isSticky, false)
+        assertTrue(window.isFloating) // Still floating, not auto-re-tiled
+    }
+
+    func testStickyWindowPositioningOnWorkspaceSwitch() {
+        let workspaceA = Workspace.get(byName: "a")
+        let workspaceB = Workspace.get(byName: "b")
+        var window: TestWindow!
+        workspaceA.rootTilingContainer.apply {
+            window = TestWindow.new(id: 1, parent: $0)
+        }
+        window.isSticky = true
+        // Simulate auto-float: sticky on would have made it floating
+        window.bindAsFloatingWindow(to: workspaceA)
+
+        check(workspaceB.focusWorkspace())
+
+        // Sticky floating window should be visually on workspace B
+        assertEquals(window.nodeWorkspace, workspaceA)
+        assertEquals(window.visualWorkspace, workspaceB)
+        assertEquals(windowsVisuallyOnWorkspace(workspaceB).contains(window), true)
     }
 
     func testMoveNodeToWorkspacePreservesStickyState() async throws {

--- a/Sources/AppBundleTests/command/TestCommandTest.swift
+++ b/Sources/AppBundleTests/command/TestCommandTest.swift
@@ -14,13 +14,13 @@ final class TestCommandTest: XCTestCase {
                 .copy(\.infixOperator, .initialized(.equals))
                 .copy(\.rhs, .initialized("foo")),
         )
-        testParseCommandFail("test %{foo} .= foo", msg: "ERROR: Can\'t parse \'foo\'.\n       Possible values: (window-id|window-is-fullscreen|window-title|window-layout|window-parent-container-layout|workspace|workspace-is-focused|workspace-is-visible|workspace-root-container-layout|app-bundle-id|app-name|app-pid|app-exec-path|app-bundle-path|monitor-id|monitor-appkit-nsscreen-screens-id|monitor-name|monitor-is-main)", exitCode: 2)
+        testParseCommandFail("test %{foo} .= foo", msg: "ERROR: Can\'t parse \'foo\'.\n       Possible values: (window-id|window-is-fullscreen|window-is-sticky|window-title|window-layout|window-parent-container-layout|workspace|workspace-is-focused|workspace-is-visible|workspace-root-container-layout|app-bundle-id|app-name|app-pid|app-exec-path|app-bundle-path|monitor-id|monitor-appkit-nsscreen-screens-id|monitor-name|monitor-is-main)", exitCode: 2)
         testParseCommandFail("test foo .= foo", msg: "ERROR: Left hand side must be a single interpolation variable", exitCode: 2)
         testParseCommandFail("test foo%{app-bundle-id} .= foo", msg: "ERROR: Left hand side must be a single interpolation variable", exitCode: 2)
         testParseCommandFail("test", msg: "ERROR: Argument \'<lhs>\' is mandatory\nERROR: Argument \'<operator>\' is mandatory\nERROR: Argument \'<rhs>\' is mandatory", exitCode: 2)
         testParseCommandFail("test foo .= %{app-bundle-id}", msg: "ERROR: Left hand side must be a single interpolation variable\nERROR: Right hand side doesn\'t allow interpolation variables", exitCode: 2)
         testParseCommandFail("test %{app-bundle-id} .= %{app-bundle-id}", msg: "ERROR: Right hand side doesn\'t allow interpolation variables", exitCode: 2)
-        testParseCommandFail("test %{newline} .= foo", msg: "ERROR: Can\'t parse \'newline\'.\n       Possible values: (window-id|window-is-fullscreen|window-title|window-layout|window-parent-container-layout|workspace|workspace-is-focused|workspace-is-visible|workspace-root-container-layout|app-bundle-id|app-name|app-pid|app-exec-path|app-bundle-path|monitor-id|monitor-appkit-nsscreen-screens-id|monitor-name|monitor-is-main)", exitCode: 2)
+        testParseCommandFail("test %{newline} .= foo", msg: "ERROR: Can\'t parse \'newline\'.\n       Possible values: (window-id|window-is-fullscreen|window-is-sticky|window-title|window-layout|window-parent-container-layout|workspace|workspace-is-focused|workspace-is-visible|workspace-root-container-layout|app-bundle-id|app-name|app-pid|app-exec-path|app-bundle-path|monitor-id|monitor-appkit-nsscreen-screens-id|monitor-name|monitor-is-main)", exitCode: 2)
     }
 
     func testExec() async throws {

--- a/Sources/AppBundleTests/tree/TestWindow.swift
+++ b/Sources/AppBundleTests/tree/TestWindow.swift
@@ -3,6 +3,7 @@ import AppKit
 
 final class TestWindow: Window, CustomStringConvertible {
     private var _rect: Rect?
+    var beforeGetAxRect: (@MainActor () async throws -> Void)?
 
     @MainActor
     private init(_ id: UInt32, _ parent: NonLeafTreeNodeObject, _ adaptiveWeight: CGFloat, _ rect: Rect?) {
@@ -37,6 +38,11 @@ final class TestWindow: Window, CustomStringConvertible {
     }
 
     @MainActor override func getAxRect() async throws -> Rect? { // todo change to not Optional
-        _rect
+        try await beforeGetAxRect?()
+        return _rect
+    }
+
+    override func getAxSize() async throws -> CGSize? {
+        _rect.map { CGSize(width: $0.width, height: $0.height) }
     }
 }

--- a/Sources/AppBundleTests/ui/TrayMenuModelTest.swift
+++ b/Sources/AppBundleTests/ui/TrayMenuModelTest.swift
@@ -1,0 +1,39 @@
+@testable import AppBundle
+import XCTest
+
+@MainActor
+final class TrayMenuModelTest: XCTestCase {
+    override func setUp() async throws { setUpWorkspacesForTests() }
+
+    func testFocusedWindowBadgesAreEmptyWithoutFocusedWindow() {
+        assertEquals(menuBarFocusedWindowBadges(for: nil), [])
+    }
+
+    func testFocusedWindowBadgesForFloatingAndStickyWindow() {
+        let workspace = Workspace.get(byName: "a")
+        let window = TestWindow.new(id: 1, parent: workspace)
+        window.isSticky = true
+
+        assertEquals(menuBarFocusedWindowBadges(for: window), [.floating, .sticky])
+    }
+
+    func testFocusedWindowBadgesForTilingWindow() {
+        let workspace = Workspace.get(byName: "a")
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+
+        assertEquals(menuBarFocusedWindowBadges(for: window), [])
+    }
+
+    func testFocusedWindowBadgesForStickyTilingWindow() {
+        let workspace = Workspace.get(byName: "a")
+        let window = TestWindow.new(id: 1, parent: workspace.rootTilingContainer)
+        window.isSticky = true
+
+        assertEquals(menuBarFocusedWindowBadges(for: window), [.sticky])
+    }
+
+    func testFocusedWindowBadgeSymbols() {
+        assertEquals(FocusedWindowBadge.floating.systemImageName, "rectangle.fill.on.rectangle.angled.fill")
+        assertEquals(FocusedWindowBadge.sticky.systemImageName, "pin.fill")
+    }
+}

--- a/Sources/Cli/subcommandDescriptionsGenerated.swift
+++ b/Sources/Cli/subcommandDescriptionsGenerated.swift
@@ -33,6 +33,7 @@ let subcommandDescriptions = [
     ["  reload-config", "Reload currently active config"],
     ["  resize", "Resize the focused window"],
     ["  split", "Split focused window"],
+    ["  sticky", "Toggle sticky mode for the focused window"],
     ["  subscribe", "Subscribe to AeroSpace events and receive notifications via socket"],
     ["  summon-workspace", "Move the requested workspace to the focused monitor."],
     ["  swap", "Swaps the focused window with another window."],

--- a/Sources/Common/cmdArgs/cmdArgsManifest.swift
+++ b/Sources/Common/cmdArgs/cmdArgsManifest.swift
@@ -34,6 +34,7 @@ public enum CmdKind: String, CaseIterable, Equatable, Sendable {
     case reloadConfig = "reload-config"
     case resize
     case split
+    case sticky
     case subscribe
     case summonWorkspace = "summon-workspace"
     case swap
@@ -118,6 +119,8 @@ func initSubcommands() -> [String: any SubCommandParserProtocol] {
                 result[kind.rawValue] = SubCommandParser(parseResizeCmdArgs)
             case .split:
                 result[kind.rawValue] = SubCommandParser(parseSplitCmdArgs)
+            case .sticky:
+                result[kind.rawValue] = SubCommandParser(parseStickyCmdArgs)
             case .subscribe:
                 result[kind.rawValue] = SubCommandParser(parseSubscribeCmdArgs)
             case .summonWorkspace:

--- a/Sources/Common/cmdArgs/impl/ListWindowsCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/ListWindowsCmdArgs.swift
@@ -170,6 +170,7 @@ public enum FormatVar: RawRepresentable, Equatable, CaseIterable, Sendable {
     public enum WindowFormatVar: String, Equatable, CaseIterable, Sendable {
         case windowId = "window-id"
         case windowIsFullscreen = "window-is-fullscreen"
+        case windowIsSticky = "window-is-sticky"
         case windowTitle = "window-title"
         case windowLayout = "window-layout" // An alias for windowParentContainerLayout
         case windowParentContainerLayout = "window-parent-container-layout"

--- a/Sources/Common/cmdArgs/impl/StickyCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/StickyCmdArgs.swift
@@ -1,0 +1,22 @@
+public struct StickyCmdArgs: CmdArgs {
+    /*conforms*/ public var commonState: CmdArgsCommonState
+    public init(rawArgs: StrArrSlice) { self.commonState = .init(rawArgs) }
+    public static let parser: CmdParser<Self> = .init(
+        kind: .sticky,
+        allowInConfig: true,
+        help: sticky_help_generated,
+        flags: [
+            "--fail-if-noop": trueBoolFlag(\.failIfNoop),
+            "--window-id": windowIdSubArgParser(),
+        ],
+        posArgs: [ArgParser(\.toggle, parseToggleEnum)],
+    )
+
+    public var toggle: ToggleEnum = .toggle
+    public var failIfNoop: Bool = false
+}
+
+func parseStickyCmdArgs(_ args: StrArrSlice) -> ParsedCmd<StickyCmdArgs> {
+    parseSpecificCmdArgs(StickyCmdArgs(rawArgs: args), args)
+        .filter("--fail-if-noop requires 'on' or 'off' argument") { $0.failIfNoop.implies($0.toggle == .on || $0.toggle == .off) }
+}

--- a/Sources/Common/cmdHelpGenerated.swift
+++ b/Sources/Common/cmdHelpGenerated.swift
@@ -132,6 +132,11 @@ let resize_help_generated = """
 let split_help_generated = """
     USAGE: split [-h|--help] [--window-id <window-id>] (horizontal|vertical|opposite)
     """
+let sticky_help_generated = """
+    USAGE: sticky [-h|--help] [--window-id <window-id>]
+       OR: sticky [-h|--help] [--window-id <window-id>] [--fail-if-noop] on
+       OR: sticky [-h|--help] [--window-id <window-id>] [--fail-if-noop] off
+    """
 let subscribe_help_generated = """
     USAGE: subscribe [-h|--help] [--all] [--no-send-initial] [<event>...]
     """

--- a/docs/aerospace-list-windows.adoc
+++ b/docs/aerospace-list-windows.adoc
@@ -79,6 +79,7 @@ The following variables can be used inside `<output-format>`:
 %{window-id}:: Number. Window unique ID
 %{window-title}:: String. Window title
 %{window-is-fullscreen}:: Boolean. Is window in fullscreen by `aerospace fullscreen` command
+%{window-is-sticky}:: Boolean. Is window in sticky mode by `aerospace sticky` command
 %{window-layout}:: String. An alias for `%{window-parent-container-layout}`
 %{window-parent-container-layout}:: String. The layout (`v_tiles`, `h_tiles`, `v_accordion`, `h_accordion`, `floating`) of the window's parent container.
 

--- a/docs/aerospace-sticky.adoc
+++ b/docs/aerospace-sticky.adoc
@@ -1,0 +1,43 @@
+= aerospace-sticky(1)
+include::util/man-attributes.adoc[]
+:manname: aerospace-sticky
+// tag::purpose[]
+:manpurpose: Toggle sticky mode for the focused window
+// end::purpose[]
+
+// =========================================================== Synopsis
+== Synopsis
+
+[verse]
+// tag::synopsis[]
+aerospace sticky [-h|--help] [--window-id <window-id>]
+aerospace sticky [-h|--help] [--window-id <window-id>] [--fail-if-noop] on
+aerospace sticky [-h|--help] [--window-id <window-id>] [--fail-if-noop] off
+
+// end::synopsis[]
+
+// =========================================================== Description
+== Description
+
+// tag::body[]
+Sticky windows stay visible when their workspace is hidden.
+
+`sticky` is independent of window layout. It doesn't move the window to another workspace, and it doesn't switch between tiling and floating layout.
+
+If the window is minimized, hidden by macOS, or in macOS native fullscreen, macOS native state still takes precedence. `sticky` only affects AeroSpace workspace visibility.
+
+// =========================================================== Options
+include::util/conditional-options-header.adoc[]
+
+-h, --help:: Print help
+
+--window-id <window-id>::
+include::./util/window-id-flag-desc.adoc[]
+
+*--fail-if-noop*::
+    Exit with non-zero code if the window is already in the requested state.
+
+// end::body[]
+
+// =========================================================== Footer
+include::util/man-footer.adoc[]

--- a/docs/aerospace-sticky.adoc
+++ b/docs/aerospace-sticky.adoc
@@ -22,7 +22,9 @@ aerospace sticky [-h|--help] [--window-id <window-id>] [--fail-if-noop] off
 // tag::body[]
 Sticky windows stay visible when their workspace is hidden.
 
-`sticky` is independent of window layout. It doesn't move the window to another workspace, and it doesn't switch between tiling and floating layout.
+When `sticky on` is called, the window is automatically converted to floating layout. This is by design: a pinned window should not participate in tiling layout, and should float above the active workspace's tiled windows.
+
+`sticky off` clears the sticky flag but does *not* restore tiling layout. To return a window to tiling, use `layout tiling` after `sticky off`.
 
 If the window is minimized, hidden by macOS, or in macOS native fullscreen, macOS native state still takes precedence. `sticky` only affects AeroSpace workspace visibility.
 

--- a/docs/aerospace-test.adoc
+++ b/docs/aerospace-test.adoc
@@ -60,6 +60,7 @@ include::./util/conditional-interpolation-variables-header.adoc[]
 %{window-id}:: Number. Window unique ID
 %{window-title}:: String. Window title
 %{window-is-fullscreen}:: Boolean. Is window in fullscreen by `aerospace fullscreen` command
+%{window-is-sticky}:: Boolean. Is window in sticky mode by `aerospace sticky` command
 %{window-layout}:: String. An alias for `%{window-parent-container-layout}`
 %{window-parent-container-layout}:: String. The layout (`v_tiles`, `h_tiles`, `v_accordion`, `h_accordion`, `floating`) of the window's parent container.
  

--- a/docs/commands.adoc
+++ b/docs/commands.adoc
@@ -168,6 +168,13 @@ include::aerospace-split.adoc[tags=synopsis]
 include::aerospace-split.adoc[tags=purpose]
 include::aerospace-split.adoc[tags=body]
 
+== sticky
+----
+include::aerospace-sticky.adoc[tags=synopsis]
+----
+include::aerospace-sticky.adoc[tags=purpose]
+include::aerospace-sticky.adoc[tags=body]
+
 == swap
 ----
 include::aerospace-swap.adoc[tags=synopsis]

--- a/docs/config-examples/default-config.toml
+++ b/docs/config-examples/default-config.toml
@@ -214,8 +214,7 @@ on-mode-changed = []
     f = ['layout floating tiling', 'mode main'] # Toggle between floating and tiling layout
     backspace = ['close-all-windows-but-current', 'mode main']
 
-    # sticky is not yet supported https://github.com/nikitabobko/AeroSpace/issues/2
-    #s = ['layout sticky tiling', 'mode main']
+    s = ['sticky', 'mode main']
 
     alt-shift-h = ['join-with left', 'mode main']
     alt-shift-j = ['join-with down', 'mode main']


### PR DESCRIPTION
## What changed

Adds initial sticky window support via a new `sticky` command:

- `sticky` toggles the current window
- `sticky on` / `sticky off` force the state
- `--window-id` and `--fail-if-noop` are supported

Sticky windows keep their AeroSpace workspace ownership and layout, but remain visible when their owning workspace is hidden. The implementation centralizes this visual-workspace behavior in window visibility helpers so focus/listing/layout code share the same semantics.

## User impact

Users can now bind sticky behavior directly or use `on-window-detected` rules, for example:

```toml
s = ['sticky', 'mode main']
```

`list-windows` and `test` formatting now expose `%{window-is-sticky}`.

## Notes

Sticky is intentionally independent from tiling/floating layout. It does not reparent windows or move them to another workspace. macOS-native minimized, hidden-app, and fullscreen states still take precedence; sticky only affects AeroSpace workspace visibility.

Refs #2.

## Validation

- `./swift-test.sh`
- `./.deps/swiftformat/swiftformat .`
- `./.deps/swiftlint/swiftlint lint --quiet --fix`
- `git diff --check`
- `./.build/debug/aerospace sticky --help`
