### PR TITLE
Add workspace-layout-changed subscribe event

### DIFF
--- a/Sources/AppBundle/command/format.swift
+++ b/Sources/AppBundle/command/format.swift
@@ -221,7 +221,7 @@ func unknownInterpolationVariable(variable: String, _ obj: AeroObj) -> String {
         "Possible values:\n\(getAvailableInterVars(for: obj.kind).joined(separator: "\n").prependLines("  "))"
 }
 
-private func toLayoutString(tc: TilingContainer) -> String {
+func toLayoutString(tc: TilingContainer) -> String {
     switch (tc.layout, tc.orientation) {
         case (.tiles, .h): return LayoutCmdArgs.LayoutDescription.h_tiles.rawValue
         case (.tiles, .v): return LayoutCmdArgs.LayoutDescription.v_tiles.rawValue

--- a/Sources/AppBundle/command/impl/LayoutCommand.swift
+++ b/Sources/AppBundle/command/impl/LayoutCommand.swift
@@ -61,6 +61,12 @@ struct LayoutCommand: Command {
             let targetLayout = targetLayout ?? parent.layout
             parent.layout = targetLayout
             parent.changeOrientation(targetOrientation)
+            if parent.isRootContainer {
+                broadcastEvent(.workspaceLayoutChanged(
+                    workspace: window.nodeWorkspace?.name ?? "",
+                    layout: toLayoutString(tc: parent),
+                ))
+            }
             return .succ
         case .workspace, .macosMinimizedWindowsContainer, .macosFullscreenWindowsContainer,
              .macosPopupWindowsContainer, .macosHiddenAppsWindowsContainer:

--- a/Sources/AppBundle/model/ServerEvent.swift
+++ b/Sources/AppBundle/model/ServerEvent.swift
@@ -19,6 +19,8 @@ public struct ServerEvent: Codable, Sendable {
     private var mode: String?
     // periphery:ignore - false positive unused warning. The var properties are serialized to JSON
     private var binding: String?
+    // periphery:ignore - false positive unused warning. The var properties are serialized to JSON
+    private var layout: String?
 
     public var eventType: ServerEventType { _event }
 
@@ -44,5 +46,9 @@ public struct ServerEvent: Codable, Sendable {
 
     public static func bindingTriggered(mode: String, binding: String) -> ServerEvent {
         ServerEvent(_event: .bindingTriggered, mode: mode, binding: binding)
+    }
+
+    public static func workspaceLayoutChanged(workspace: String, layout: String) -> ServerEvent {
+        ServerEvent(_event: .workspaceLayoutChanged, workspace: workspace, layout: layout)
     }
 }

--- a/Sources/AppBundle/subscriptions.swift
+++ b/Sources/AppBundle/subscriptions.swift
@@ -30,7 +30,7 @@ func handleSubscribeAndWaitTillError(_ connection: NWConnection, _ args: Subscri
                         workspace: f.workspace.name,
                         monitorId_oneBased: f.workspace.workspaceMonitor.monitorId_oneBased ?? 0,
                     )
-                case .windowDetected, .bindingTriggered: continue
+                case .windowDetected, .bindingTriggered, .workspaceLayoutChanged: continue
             }
             if await connection.writeAtomic(event, jsonEncoder).error != nil {
                 return

--- a/Sources/AppBundleTests/command/SubscribeCmdArgsTest.swift
+++ b/Sources/AppBundleTests/command/SubscribeCmdArgsTest.swift
@@ -31,7 +31,7 @@ final class SubscribeCmdArgsTest: XCTestCase {
             case .failure(let err):
                 let expectedMsg = """
                     ERROR: Can't parse 'unknown-event'.
-                           Possible values: (focus-changed|focused-monitor-changed|focused-workspace-changed|mode-changed|window-detected|binding-triggered)
+                           Possible values: (focus-changed|focused-monitor-changed|focused-workspace-changed|mode-changed|window-detected|binding-triggered|workspace-layout-changed)
                     """
                 assertEquals(err, .init(expectedMsg, 2))
         }

--- a/Sources/Common/cmdArgs/impl/SubscribeCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/SubscribeCmdArgs.swift
@@ -61,4 +61,5 @@ public enum ServerEventType: String, Codable, CaseIterable, Sendable {
     case modeChanged = "mode-changed"
     case windowDetected = "window-detected"
     case bindingTriggered = "binding-triggered"
+    case workspaceLayoutChanged = "workspace-layout-changed"
 }


### PR DESCRIPTION
I needed a way to react to layout changes in a subscribe-based workflow. Currently, there’s no event for this.

This PR adds a workspace-layout-changed event. It is emitted after the root container layout changes (tiles <-> accordion) and includes the workspace name and layout string (using the same format as %{window-parent-container-layout}).

The event is intentionally limited to root containers (parent.isRootContainer). Emitting events for nested containers would be misleading at the workspace level, and nested containers are typically flattened by the default normalization behavior.

All tests pass, including the full ./test.sh suite.

Feedback on the approach, scope, or naming is welcome. 😄