### PR TITLE
Surface floating-window status: menu-bar indicators + %{window-is-floating} format variable

### DIFF
--- a/Sources/AppBundle/command/format.swift
+++ b/Sources/AppBundle/command/format.swift
@@ -162,6 +162,7 @@ extension FormatVar {
                 return switch f {
                     case .windowId: .success(.int(w.window.windowId))
                     case .windowIsFullscreen: .success(.bool(w.window.isFullscreen))
+                    case .windowIsFloating: isFloatingResult(w: w.window)
                     case .windowTitle: .success(.string(w.title.orDie("Title wasn't prefeched")))
                     case .windowLayout, .windowParentContainerLayout: toLayoutResult(w: w.window)
                 }
@@ -228,6 +229,11 @@ private func toLayoutString(tc: TilingContainer) -> String {
         case (.accordion, .h): return LayoutCmdArgs.LayoutDescription.h_accordion.rawValue
         case (.accordion, .v): return LayoutCmdArgs.LayoutDescription.v_accordion.rawValue
     }
+}
+
+private func isFloatingResult(w: Window) -> Result<Primitive, String> {
+    guard let parent = w.parent else { return .failure("NULL-PARENT") }
+    return .success(.bool(getChildParentRelation(child: w, parent: parent) == .floatingWindow))
 }
 
 private func toLayoutResult(w: Window) -> Result<Primitive, String> {

--- a/Sources/AppBundle/ui/MenuBarLabel.swift
+++ b/Sources/AppBundle/ui/MenuBarLabel.swift
@@ -64,6 +64,7 @@ struct MenuBarLabel: View {
                             name: item.name,
                             isActive: item.isFocused,
                             hasFullscreenWindows: item.hasFullscreenWindows,
+                            isFocusedWindowFloating: item.isFocusedWindowFloating,
                         )
                         itemView(for: trayItem)
                             .opacity(item.isVisible ? 1 : 0.5)
@@ -95,7 +96,7 @@ struct MenuBarLabel: View {
                 .bold()
                 .padding(.bottom, 6)
             ForEach(otherWorkspaces, id: \.name) { item in
-                itemView(for: TrayItem(type: .workspace, name: item.name, isActive: false, hasFullscreenWindows: item.hasFullscreenWindows))
+                itemView(for: TrayItem(type: .workspace, name: item.name, isActive: false, hasFullscreenWindows: item.hasFullscreenWindows, isFocusedWindowFloating: item.isFocusedWindowFloating))
             }
         }
         .opacity(0.6)
@@ -111,13 +112,23 @@ struct MenuBarLabel: View {
     @ViewBuilder
     fileprivate func itemView(for item: TrayItem) -> some View {
         let view = itemSubView(for: item)
-        if item.hasFullscreenWindows {
-            let strokeStyle = StrokeStyle(lineWidth: 2, lineCap: .square, lineJoin: .miter, miterLimit: 10, dash: [10, 5], dashPhase: 3)
+        if item.hasFullscreenWindows || item.isFocusedWindowFloating {
+            // Fullscreen → dashed border around the square. Focused-window-floating →
+            // dotted border on the focused workspace's square. Fullscreen wins: a square
+            // that has a fullscreen window shows only the dashed border, never the dotted
+            // one (a window that's both fullscreen and floating reads as fullscreen).
+            let fullscreenStroke = StrokeStyle(lineWidth: 2, lineCap: .square, lineJoin: .miter, miterLimit: 10, dash: [10, 5], dashPhase: 3)
+            let floatingStroke = StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round, dash: [0.1, 6])
             view
                 .padding(4)
                 .overlay {
-                    RoundedRectangle(cornerRadius: itemCornerRadius, style: .continuous)
-                        .strokeBorder(finalColor, style: strokeStyle)
+                    if item.hasFullscreenWindows {
+                        RoundedRectangle(cornerRadius: itemCornerRadius, style: .continuous)
+                            .strokeBorder(finalColor, style: fullscreenStroke)
+                    } else if item.isFocusedWindowFloating {
+                        RoundedRectangle(cornerRadius: itemCornerRadius, style: .continuous)
+                            .strokeBorder(finalColor, style: floatingStroke)
+                    }
                 }
         } else {
             view

--- a/Sources/AppBundle/ui/TrayMenuModel.swift
+++ b/Sources/AppBundle/ui/TrayMenuModel.swift
@@ -18,6 +18,7 @@ public final class TrayMenuModel: ObservableObject {
 @MainActor func updateTrayText() {
     let sortedMonitors = sortedMonitors
     let focus = focus
+    let focusedWindowIsFloating = focus.windowOrNil?.isFloating == true
     TrayMenuModel.shared.trayText = (activeMode?.takeIf { $0 != mainModeId }?.first.map { "(\($0.uppercased())) " } ?? "") +
         sortedMonitors
         .map {
@@ -48,6 +49,7 @@ public final class TrayMenuModel: ObservableObject {
             isEffectivelyEmpty: $0.isEffectivelyEmpty,
             isVisible: $0.isVisible,
             hasFullscreenWindows: hasFullscreenWindows,
+            isFocusedWindowFloating: focus.workspace == $0 && focusedWindowIsFloating,
         )
     }
     var items = sortedMonitors.map {
@@ -57,10 +59,11 @@ public final class TrayMenuModel: ObservableObject {
             name: $0.activeWorkspace.name,
             isActive: $0.activeWorkspace == focus.workspace,
             hasFullscreenWindows: hasFullscreenWindows,
+            isFocusedWindowFloating: $0.activeWorkspace == focus.workspace && focusedWindowIsFloating,
         )
     }
     let mode = activeMode?.takeIf { $0 != mainModeId }?.first.map {
-        TrayItem(type: .mode, name: $0.uppercased(), isActive: true, hasFullscreenWindows: false)
+        TrayItem(type: .mode, name: $0.uppercased(), isActive: true, hasFullscreenWindows: false, isFocusedWindowFloating: false)
     }
     if let mode {
         items.insert(mode, at: 0)
@@ -75,6 +78,7 @@ struct WorkspaceViewModel: Hashable {
     let isEffectivelyEmpty: Bool
     let isVisible: Bool
     let hasFullscreenWindows: Bool
+    let isFocusedWindowFloating: Bool
 }
 
 enum TrayItemType: String, Hashable {
@@ -89,6 +93,7 @@ struct TrayItem: Hashable, Identifiable {
     let name: String
     let isActive: Bool
     let hasFullscreenWindows: Bool
+    let isFocusedWindowFloating: Bool
     var systemImageName: String? {
         // System image type is only valid for numbers 0 to 50 and single capital char workspace name
         switch Int(name) {

--- a/Sources/AppBundle/ui/TrayMenuModel.swift
+++ b/Sources/AppBundle/ui/TrayMenuModel.swift
@@ -27,10 +27,16 @@ public final class TrayMenuModel: ObservableObject {
         }
         .joined(separator: " │ ")
     TrayMenuModel.shared.workspaces = Workspace.all.map {
-        let apps = $0.allLeafWindowsRecursive.map { $0.app.name?.takeIf { !$0.isEmpty } }.filterNotNil().toSet()
+        let windows = $0.allLeafWindowsRecursive
+        let appName = { (w: Window) in w.app.name?.takeIf { !$0.isEmpty } }
+        let apps = windows.map(appName).filterNotNil().toSet()
+        // Apps that have at least one floating window in this workspace get a leading ⬚ marker
+        let floatingApps = windows.filter(\.isFloating).map(appName).filterNotNil().toSet()
         let dash = " - "
         let suffix = switch true {
-            case !apps.isEmpty: dash + apps.sorted().joinTruncating(separator: ", ", length: 25)
+            case !apps.isEmpty: dash + apps.sorted()
+            .map { floatingApps.contains($0) ? "⬚ \($0)" : $0 }
+            .joinTruncating(separator: ", ", length: 25)
             case $0.isVisible: dash + $0.workspaceMonitor.name
             default: ""
         }

--- a/Sources/AppBundleTests/command/TestCommandTest.swift
+++ b/Sources/AppBundleTests/command/TestCommandTest.swift
@@ -14,13 +14,13 @@ final class TestCommandTest: XCTestCase {
                 .copy(\.infixOperator, .initialized(.equals))
                 .copy(\.rhs, .initialized("foo")),
         )
-        testParseCommandFail("test %{foo} .= foo", msg: "ERROR: Can\'t parse \'foo\'.\n       Possible values: (window-id|window-is-fullscreen|window-title|window-layout|window-parent-container-layout|workspace|workspace-is-focused|workspace-is-visible|workspace-root-container-layout|app-bundle-id|app-name|app-pid|app-exec-path|app-bundle-path|monitor-id|monitor-appkit-nsscreen-screens-id|monitor-name|monitor-is-main)", exitCode: 2)
+        testParseCommandFail("test %{foo} .= foo", msg: "ERROR: Can\'t parse \'foo\'.\n       Possible values: (window-id|window-is-fullscreen|window-is-floating|window-title|window-layout|window-parent-container-layout|workspace|workspace-is-focused|workspace-is-visible|workspace-root-container-layout|app-bundle-id|app-name|app-pid|app-exec-path|app-bundle-path|monitor-id|monitor-appkit-nsscreen-screens-id|monitor-name|monitor-is-main)", exitCode: 2)
         testParseCommandFail("test foo .= foo", msg: "ERROR: Left hand side must be a single interpolation variable", exitCode: 2)
         testParseCommandFail("test foo%{app-bundle-id} .= foo", msg: "ERROR: Left hand side must be a single interpolation variable", exitCode: 2)
         testParseCommandFail("test", msg: "ERROR: Argument \'<lhs>\' is mandatory\nERROR: Argument \'<operator>\' is mandatory\nERROR: Argument \'<rhs>\' is mandatory", exitCode: 2)
         testParseCommandFail("test foo .= %{app-bundle-id}", msg: "ERROR: Left hand side must be a single interpolation variable\nERROR: Right hand side doesn\'t allow interpolation variables", exitCode: 2)
         testParseCommandFail("test %{app-bundle-id} .= %{app-bundle-id}", msg: "ERROR: Right hand side doesn\'t allow interpolation variables", exitCode: 2)
-        testParseCommandFail("test %{newline} .= foo", msg: "ERROR: Can\'t parse \'newline\'.\n       Possible values: (window-id|window-is-fullscreen|window-title|window-layout|window-parent-container-layout|workspace|workspace-is-focused|workspace-is-visible|workspace-root-container-layout|app-bundle-id|app-name|app-pid|app-exec-path|app-bundle-path|monitor-id|monitor-appkit-nsscreen-screens-id|monitor-name|monitor-is-main)", exitCode: 2)
+        testParseCommandFail("test %{newline} .= foo", msg: "ERROR: Can\'t parse \'newline\'.\n       Possible values: (window-id|window-is-fullscreen|window-is-floating|window-title|window-layout|window-parent-container-layout|workspace|workspace-is-focused|workspace-is-visible|workspace-root-container-layout|app-bundle-id|app-name|app-pid|app-exec-path|app-bundle-path|monitor-id|monitor-appkit-nsscreen-screens-id|monitor-name|monitor-is-main)", exitCode: 2)
     }
 
     func testExec() async throws {

--- a/Sources/Common/cmdArgs/impl/ListWindowsCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/ListWindowsCmdArgs.swift
@@ -170,6 +170,7 @@ public enum FormatVar: RawRepresentable, Equatable, CaseIterable, Sendable {
     public enum WindowFormatVar: String, Equatable, CaseIterable, Sendable {
         case windowId = "window-id"
         case windowIsFullscreen = "window-is-fullscreen"
+        case windowIsFloating = "window-is-floating"
         case windowTitle = "window-title"
         case windowLayout = "window-layout" // An alias for windowParentContainerLayout
         case windowParentContainerLayout = "window-parent-container-layout"

--- a/docs/aerospace-list-windows.adoc
+++ b/docs/aerospace-list-windows.adoc
@@ -79,6 +79,7 @@ The following variables can be used inside `<output-format>`:
 %{window-id}:: Number. Window unique ID
 %{window-title}:: String. Window title
 %{window-is-fullscreen}:: Boolean. Is window in fullscreen by `aerospace fullscreen` command
+%{window-is-floating}:: Boolean. `true` if the window is floating (its parent container is the workspace itself rather than a tiling container)
 %{window-layout}:: String. An alias for `%{window-parent-container-layout}`
 %{window-parent-container-layout}:: String. The layout (`v_tiles`, `h_tiles`, `v_accordion`, `h_accordion`, `floating`) of the window's parent container.
 

--- a/docs/aerospace-test.adoc
+++ b/docs/aerospace-test.adoc
@@ -60,6 +60,7 @@ include::./util/conditional-interpolation-variables-header.adoc[]
 %{window-id}:: Number. Window unique ID
 %{window-title}:: String. Window title
 %{window-is-fullscreen}:: Boolean. Is window in fullscreen by `aerospace fullscreen` command
+%{window-is-floating}:: Boolean. `true` if the window is floating (its parent container is the workspace itself rather than a tiling container)
 %{window-layout}:: String. An alias for `%{window-parent-container-layout}`
 %{window-parent-container-layout}:: String. The layout (`v_tiles`, `h_tiles`, `v_accordion`, `h_accordion`, `floating`) of the window's parent container.
  


### PR DESCRIPTION
## Summary

Currently there's no at-a-glance way to tell whether a window is floating — you have to read `%{window-layout}` output. This adds a few small, complementary ways to surface floating state, mirroring how **fullscreen** state is already surfaced.

CLI: **`%{window-is-floating}` format variable** for `list-windows` / `test`, mirroring the existing `%{window-is-fullscreen}` boolean. It's derived from the canonical parent relation (`getChildParentRelation(child:parent:) == .floatingWindow` — the same source `%{window-layout}` uses to report `floating`), not the `Window.isFloating` helper. Parser possible-values, `test` expectations, and the `list-windows` / `test` docs are updated.

GUI: **Floating window marker in the tray dropdown.** In the per-workspace app list, any app that has a floating window in that workspace is prefixed with `⬚`, paralleling the existing surfacing of fullscreen state.

GUI: **Floating window indicator on the menu-bar workspace square.** Fullscreen workspaces already get an always-visible **dashed** border around their square (`MenuBarLabel.itemView`). This adds a **dotted**-border counterpart that appears on the focused workspace's square when the focused window is floating.

<img width="418" height="283" alt="image" src="https://github.com/user-attachments/assets/ac86c581-62b7-4b12-a0bd-70e3a8df230b" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
