### PR TITLE
Add 120fps animated window resize/move

### DIFF
--- a/Sources/AppBundle/config/Config.swift
+++ b/Sources/AppBundle/config/Config.swift
@@ -56,6 +56,7 @@ struct Config: ConvenienceCopyable {
     var onFocusedMonitorChanged: [any Command] = []
 
     var gaps: Gaps = .zero
+    var animation: AnimationConfig = .default
     var workspaceToMonitorForceAssignment: [String: [MonitorDescription]] = [:]
     var modes: [String: Mode] = [:]
     var onWindowDetected: [WindowDetectedCallback] = []

--- a/Sources/AppBundle/config/parseAnimation.swift
+++ b/Sources/AppBundle/config/parseAnimation.swift
@@ -1,0 +1,65 @@
+import Common
+import Foundation
+
+struct AnimationConfig: ConvenienceCopyable, Equatable, Sendable {
+    var enabled: Bool
+    /// Animation duration in milliseconds. Reasonable range: 30-500.
+    var durationMs: Int
+    /// Target frames per second for the interpolation. Reasonable range: 30-240.
+    /// Note: actual achieved fps depends on how fast the target app responds to AX size/position requests.
+    var fps: Int
+    /// Easing curve to apply to the interpolation parameter t in [0, 1].
+    var easing: AnimationEasing
+
+    static let `default` = AnimationConfig(
+        enabled: true,
+        durationMs: 150,
+        fps: 120,
+        easing: .easeOutCubic,
+    )
+
+    /// Effective frame interval in seconds, derived from `fps`.
+    var frameIntervalSec: Double { 1.0 / Double(max(1, fps)) }
+    /// Effective duration in seconds.
+    var durationSec: Double { Double(max(0, durationMs)) / 1000.0 }
+}
+
+enum AnimationEasing: String, Sendable {
+    case linear
+    case easeOutCubic = "ease-out-cubic"
+    case easeInOutCubic = "ease-in-out-cubic"
+
+    func apply(_ t: Double) -> Double {
+        let clamped = t < 0 ? 0 : (t > 1 ? 1 : t)
+        switch self {
+            case .linear:
+                return clamped
+            case .easeOutCubic:
+                let inv = 1 - clamped
+                return 1 - inv * inv * inv
+            case .easeInOutCubic:
+                return clamped < 0.5
+                    ? 4 * clamped * clamped * clamped
+                    : 1 - pow(-2 * clamped + 2, 3) / 2
+        }
+    }
+}
+
+private let animationParser: [String: any ParserProtocol<AnimationConfig>] = [
+    "enabled": Parser(\.enabled, parseBool),
+    "duration-ms": Parser(\.durationMs) { raw, backtrace in
+        parseInt(raw, backtrace).filter(.semantic(backtrace, "Must be in [0, 5000] range")) { (0 ... 5000).contains($0) }
+    },
+    "fps": Parser(\.fps) { raw, backtrace in
+        parseInt(raw, backtrace).filter(.semantic(backtrace, "Must be in [1, 480] range")) { (1 ... 480).contains($0) }
+    },
+    "easing": Parser(\.easing) { raw, backtrace in
+        parseString(raw, backtrace).flatMap {
+            AnimationEasing(rawValue: $0).orFailure(.semantic(backtrace, "Can't parse animation easing '\($0)'. Possible values: linear, ease-out-cubic, ease-in-out-cubic"))
+        }
+    },
+]
+
+func parseAnimation(_ raw: Json, _ backtrace: ConfigBacktrace, _ errors: inout [ConfigParseError]) -> AnimationConfig {
+    parseTable(raw, .default, animationParser, backtrace, &errors)
+}

--- a/Sources/AppBundle/config/parseConfig.swift
+++ b/Sources/AppBundle/config/parseConfig.swift
@@ -122,6 +122,7 @@ private let configParser: [String: any ParserProtocol<Config>] = [
     modeConfigRootKey: Parser(\.modes, skipParsing(Config().modes)), // Parsed manually
 
     "gaps": Parser(\.gaps, parseGaps),
+    "animation": Parser(\.animation, parseAnimation),
     "workspace-to-monitor-force-assignment": Parser(\.workspaceToMonitorForceAssignment, parseWorkspaceToMonitorAssignment),
     "on-window-detected": Parser(\.onWindowDetected, parseOnWindowDetectedArray),
 

--- a/Sources/AppBundle/tree/MacApp.swift
+++ b/Sources/AppBundle/tree/MacApp.swift
@@ -131,11 +131,11 @@ final class MacApp: AbstractApp {
         }
     }
 
-    func setAxFrame(_ windowId: UInt32, _ topLeft: CGPoint?, _ size: CGSize?) {
+    func setAxFrame(_ windowId: UInt32, _ topLeft: CGPoint?, _ size: CGSize?, animated: AnimationConfig? = nil) {
         setFrameJobs.removeValue(forKey: windowId)?.cancel()
         setFrameJobs[windowId] = withWindowAsync(windowId) { [axApp] window, job in
             try disableAnimations(app: axApp.threadGuarded, job) {
-                try setFrame(window, topLeft, size, job)
+                try setFrame(window, topLeft, size, animated, job)
             }
         }
     }
@@ -144,7 +144,9 @@ final class MacApp: AbstractApp {
         setFrameJobs.removeValue(forKey: windowId)?.cancel()
         try await withWindow(windowId) { [axApp] window, job in
             try disableAnimations(app: axApp.threadGuarded, job) {
-                try setFrame(window, topLeft, size, job)
+                // Don't animate the blocking variant. It's used during shutdown / rare paths
+                // where we want the change to apply synchronously.
+                try setFrame(window, topLeft, size, nil, job)
             }
         }
     }
@@ -371,14 +373,80 @@ extension [UInt32: AxWindow] {
     }
 }
 
-private func setFrame(_ window: AXUIElement, _ topLeft: CGPoint?, _ size: CGSize?, _ job: RunLoopJob) throws {
+private func setFrame(_ window: AXUIElement, _ topLeft: CGPoint?, _ size: CGSize?, _ animation: AnimationConfig?, _ job: RunLoopJob) throws {
     // Set size and then the position. The order is important https://github.com/nikitabobko/AeroSpace/issues/143
     //                                                        https://github.com/nikitabobko/AeroSpace/issues/335
+    if let animation, animation.enabled, animation.durationSec > 0,
+       let topLeft, let size,
+       let startSize = window.get(Ax.sizeAttr),
+       let startTopLeft = window.get(Ax.topLeftCornerAttr),
+       (abs(startSize.width - size.width) > 0.5 ||
+           abs(startSize.height - size.height) > 0.5 ||
+           abs(startTopLeft.x - topLeft.x) > 0.5 ||
+           abs(startTopLeft.y - topLeft.y) > 0.5)
+    {
+        try animateFrame(
+            window: window,
+            startTopLeft: startTopLeft, startSize: startSize,
+            endTopLeft: topLeft, endSize: size,
+            animation: animation,
+            job,
+        )
+        return
+    }
     if let size { window.set(Ax.sizeAttr, size) }
     try job.checkCancellation()
     if let topLeft { window.set(Ax.topLeftCornerAttr, topLeft) } else { return }
     try job.checkCancellation()
     if let size { window.set(Ax.sizeAttr, size) }
+}
+
+private func animateFrame(
+    window: AXUIElement,
+    startTopLeft: CGPoint, startSize: CGSize,
+    endTopLeft: CGPoint, endSize: CGSize,
+    animation: AnimationConfig,
+    _ job: RunLoopJob,
+) throws {
+    let durationSec = animation.durationSec
+    let frameInterval = animation.frameIntervalSec
+    let easing = animation.easing
+    let startTime = CFAbsoluteTimeGetCurrent()
+    var nextDeadline = startTime + frameInterval
+
+    while true {
+        try job.checkCancellation()
+        let now = CFAbsoluteTimeGetCurrent()
+        let elapsed = now - startTime
+        let rawT = durationSec <= 0 ? 1.0 : elapsed / durationSec
+        let t = rawT >= 1.0 ? 1.0 : rawT
+        let eased = easing.apply(t)
+
+        let interpSize = CGSize(
+            width: startSize.width + (endSize.width - startSize.width) * eased,
+            height: startSize.height + (endSize.height - startSize.height) * eased,
+        )
+        let interpTopLeft = CGPoint(
+            x: startTopLeft.x + (endTopLeft.x - startTopLeft.x) * eased,
+            y: startTopLeft.y + (endTopLeft.y - startTopLeft.y) * eased,
+        )
+
+        // Same order as the static setFrame: size, position, size.
+        // The double-size set fixes the issue where, on the final frame,
+        // certain apps (Terminal.app, etc.) snap to a stale size after a position change.
+        window.set(Ax.sizeAttr, interpSize)
+        try job.checkCancellation()
+        window.set(Ax.topLeftCornerAttr, interpTopLeft)
+        try job.checkCancellation()
+        window.set(Ax.sizeAttr, interpSize)
+
+        if t >= 1.0 { return }
+
+        // Pace ourselves to the configured fps; if we're already behind, skip the sleep.
+        let sleep = nextDeadline - CFAbsoluteTimeGetCurrent()
+        if sleep > 0 { Thread.sleep(forTimeInterval: sleep) }
+        nextDeadline += frameInterval
+    }
 }
 
 // Some undocumented magic

--- a/Sources/AppBundle/tree/MacWindow.swift
+++ b/Sources/AppBundle/tree/MacWindow.swift
@@ -185,8 +185,9 @@ final class MacWindow: Window {
         try await macApp.getAxSize(windowId)
     }
 
-    override func setAxFrame(_ topLeft: CGPoint?, _ size: CGSize?) {
-        macApp.setAxFrame(windowId, topLeft, size)
+    @MainActor
+    override func setAxFrame(_ topLeft: CGPoint?, _ size: CGSize?, animated: Bool = true) {
+        macApp.setAxFrame(windowId, topLeft, size, animated: animated ? config.animation : nil)
     }
 
     func setAxFrameBlocking(_ topLeft: CGPoint?, _ size: CGSize?) async throws {

--- a/Sources/AppBundle/tree/Window.swift
+++ b/Sources/AppBundle/tree/Window.swift
@@ -40,7 +40,8 @@ open class Window: TreeNode, Hashable {
     func getAxRect() async throws -> Rect? { die("Not implemented") }
     func getCenter() async throws -> CGPoint? { try await getAxRect()?.center }
 
-    func setAxFrame(_ topLeft: CGPoint?, _ size: CGSize?) { die("Not implemented") }
+    @MainActor
+    func setAxFrame(_ topLeft: CGPoint?, _ size: CGSize?, animated: Bool = true) { die("Not implemented") }
 }
 
 enum LayoutReason: Equatable {

--- a/docs/config-examples/default-config.toml
+++ b/docs/config-examples/default-config.toml
@@ -63,6 +63,20 @@ on-mode-changed = []
 [key-mapping]
     preset = 'qwerty'
 
+# Smooth window resize/move animations.
+# - 'enabled' turns the animation on/off
+# - 'duration-ms' is the total animation duration (0 means instant)
+# - 'fps' is the target frame rate of the interpolation. Achieved fps depends on
+#   how fast each application responds to AX size/position requests. Slow apps
+#   (e.g. some Electron apps) will not actually hit 120fps.
+# - 'easing' shapes the interpolation curve. Possible values:
+#   linear | ease-out-cubic | ease-in-out-cubic
+[animation]
+    enabled = true
+    duration-ms = 150
+    fps = 120
+    easing = 'ease-out-cubic'
+
 # Gaps between windows (inner-*) and between monitor edges (outer-*).
 # Possible values:
 # - Constant:     gaps.outer.top = 8


### PR DESCRIPTION
Introduce an [animation] config section (enabled/duration-ms/fps/easing) and interpolate the AX size+position on the per-app run-loop thread between successive layout passes. Defaults to 120fps over 150ms with ease-out-cubic. Animations cancel cleanly when a new layout arrives.

## PR checklist

- [ ] Explain your changes in the relevant commit messages rather than in the PR description. The PR description must not contain more information than the commit messages (except for images and other media).
- [ ] Each commit must explain what/why/how and motivation in its description. https://cbea.ms/git-commit/
- [ ] Don't forget to link the appropriate issues/discussions in commit messages (if applicable).
- [ ] Each commit must be an atomic change (a PR may contain several commits). Don't introduce new functional changes together with refactorings in the same commit.
- [ ] `./test.sh` exits with non-zero exit code.
- [ ] Avoid merge commits, always rebase and force push.

Failure to follow the checklist with no apparent reasons will result in silent PR rejection.
