### PR TITLE
feat: add BSP normalization

### DIFF
--- a/Sources/AppBundle/command/impl/MoveCommand.swift
+++ b/Sources/AppBundle/command/impl/MoveCommand.swift
@@ -33,6 +33,14 @@ struct MoveCommand: Command {
                             return .succ
                     }
                 } else {
+                    let outOfLevelTarget = currentWindow.closestParent(hasChildrenInDirection: direction, withLayout: nil)
+                    if config.enableNormalizationBinaryTree, outOfLevelTarget == nil {
+                        // Binary-tree normalization makes "move out" at the workspace edge futile: it
+                        // re-nests the window immediately, so it can never bubble up to the root edge
+                        // that crosses to an adjacent monitor. Treat an edge move as hitting the
+                        // workspace boundary directly (e.g. crossing monitors with all-monitors-outer-frame).
+                        return hitWorkspaceBoundaries(currentWindow, target.workspace, io, args, direction, env)
+                    }
                     return moveOut(tilingWindow: currentWindow, direction: direction, io, args, env)
                 }
             case .floatingWindowsContainer: // floating window

--- a/Sources/AppBundle/config/Config.swift
+++ b/Sources/AppBundle/config/Config.swift
@@ -46,6 +46,7 @@ struct Config: ConvenienceMutable {
     var automaticallyUnhideMacosHiddenApps: Bool = false
     var accordionPadding: Int = 30
     var enableNormalizationOppositeOrientationForNestedContainers: Bool = true
+    var enableNormalizationBinaryTree: Bool = false
     var persistentWorkspaces: OrderedSet<String> = []
     var execOnWorkspaceChange: [String] = [] // todo deprecate
     var keyMapping = KeyMapping()

--- a/Sources/AppBundle/config/parseConfig.swift
+++ b/Sources/AppBundle/config/parseConfig.swift
@@ -138,6 +138,7 @@ private let configParser: [String: any ParserProtocol<Config>] = [
 
     "enable-normalization-flatten-containers": Parser(\.enableNormalizationFlattenContainers, parseBool),
     "enable-normalization-opposite-orientation-for-nested-containers": Parser(\.enableNormalizationOppositeOrientationForNestedContainers, parseBool),
+    "enable-normalization-binary-tree": Parser(\.enableNormalizationBinaryTree, parseBool),
 
     "default-root-container-layout": Parser(\.defaultRootContainerLayout, parseLayout),
     "default-root-container-orientation": Parser(\.defaultRootContainerOrientation, parseDefaultContainerOrientation),

--- a/Sources/AppBundle/model/Rect.swift
+++ b/Sources/AppBundle/model/Rect.swift
@@ -62,4 +62,18 @@ extension Rect {
     var size: CGSize { CGSize(width: width, height: height) }
 
     func getDimension(_ orientation: Orientation) -> CGFloat { orientation == .h ? width : height }
+
+    /// Slice this rect along `axis` into sub-rects sized proportionally to `weights`.
+    func sliced(along axis: Orientation, weights: [CGFloat]) -> [Rect] {
+        let span = getDimension(axis)
+        let total = weights.reduce(0, +)
+        var offset: CGFloat = 0
+        return weights.map { weight in
+            let portion = total > 0 ? span * weight / total : span / CGFloat(weights.count)
+            defer { offset += portion }
+            return axis == .h
+                ? Rect(topLeftX: topLeftX + offset, topLeftY: topLeftY, width: portion, height: height)
+                : Rect(topLeftX: topLeftX, topLeftY: topLeftY + offset, width: width, height: portion)
+        }
+    }
 }

--- a/Sources/AppBundle/tree/TilingContainer.swift
+++ b/Sources/AppBundle/tree/TilingContainer.swift
@@ -53,6 +53,10 @@ extension TilingContainer {
             (child as? TilingContainer)?.normalizeOppositeOrientationForNestedContainers()
         }
     }
+
+    func setOrientation(_ newValue: Orientation) {
+        _orientation = newValue
+    }
 }
 
 enum Layout: String {

--- a/Sources/AppBundle/tree/normalizeContainers.swift
+++ b/Sources/AppBundle/tree/normalizeContainers.swift
@@ -1,7 +1,9 @@
 extension Workspace {
     @MainActor func normalizeContainers() {
         rootTilingContainer.unbindEmptyAndAutoFlatten() // Beware! rootTilingContainer may change after this line of code
-        if config.enableNormalizationOppositeOrientationForNestedContainers {
+        if config.enableNormalizationBinaryTree {
+            rootTilingContainer.normalizeBinaryTree(rect: workspaceMonitor.visibleRectPaddedByOuterGaps)
+        } else if config.enableNormalizationOppositeOrientationForNestedContainers {
             rootTilingContainer.normalizeOppositeOrientationForNestedContainers()
         }
     }
@@ -27,6 +29,30 @@ extension TilingContainer {
             if children.isEmpty && !isRootContainer {
                 unbindFromParent()
             }
+        }
+    }
+
+    @MainActor func normalizeBinaryTree(rect: Rect) {
+        forceBinaryTree()
+        setOrientation(rect.width > rect.height ? .h : .v)
+        switch children.count {
+            case 0: return
+            case 1:
+                (children[0] as? TilingContainer)?.normalizeBinaryTree(rect: rect)
+            default: // 2 — guaranteed by forceBinaryTree
+                let rects = rect.sliced(along: orientation, weights: children.map { $0.getWeight(orientation) })
+                (children[0] as? TilingContainer)?.normalizeBinaryTree(rect: rects[0])
+                (children[1] as? TilingContainer)?.normalizeBinaryTree(rect: rects[1])
+        }
+    }
+
+    @MainActor private func forceBinaryTree() {
+        if children.count <= 2 { return }
+        let toWrap = Array(children.dropFirst())
+        let wrapper = TilingContainer.newHTiles(parent: self, adaptiveWeight: WEIGHT_AUTO, index: 1)
+        for child in toWrap {
+            child.unbindFromParent()
+            child.bind(to: wrapper, adaptiveWeight: WEIGHT_AUTO, index: INDEX_BIND_LAST)
         }
     }
 }

--- a/Sources/AppBundleTests/command/MoveCommandTest.swift
+++ b/Sources/AppBundleTests/command/MoveCommandTest.swift
@@ -11,7 +11,32 @@ final class MoveCommandTest: XCTestCase {
         assertNil(parseCommand("move --fail-if-macos-native-fullscreen --window-id 1 right").errorOrNil)
     }
 
-    func testFailIfFullscreen() async {
+    func testBinaryTree_edgeMoveHitsBoundaryInsteadOfUnnesting() async throws {
+        // With binary-tree normalization on, a window at the workspace edge (nothing in `direction`
+        // anywhere up the tree) must apply the boundary action instead of bubbling out of its
+        // container — otherwise normalization re-nests it and it can never cross to an adjacent
+        // monitor. Here --boundaries-action stop → no-op. (cf. testStop_onInnerNode without binary tree.)
+        config.enableNormalizationBinaryTree = true
+        let workspace = Workspace.get(byName: name)
+        workspace.rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            TilingContainer.newVTiles(parent: $0, adaptiveWeight: 1).apply {
+                assertEquals(TestWindow.new(id: 2, parent: $0).focusWindow(), true)
+                TestWindow.new(id: 3, parent: $0)
+            }
+        }
+
+        let result = try await parseCommand("move --boundaries-action stop right").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(
+            workspace.layoutDescription,
+            .workspace([
+                .h_tiles([.window(1), .v_tiles([.window(2), .window(3)])]),
+            ]),
+        )
+        assertEquals(result.exitCode.rawValue, 0)
+    }
+
+    func testFailIfFullscreen() async throws {
         let root = Workspace.get(byName: name).rootTilingContainer.apply {
             let window = TestWindow.new(id: 1, parent: $0)
             assertEquals(window.focusWindow(), true)

--- a/Sources/AppBundleTests/tree/TreeNodeTest.swift
+++ b/Sources/AppBundleTests/tree/TreeNodeTest.swift
@@ -72,6 +72,46 @@ final class TreeNodeTest: XCTestCase {
         assertEquals(workspace.rootTilingContainer.children.count, 0)
     }
 
+    func testNormalizeContainers_bsp_forceBinary() {
+        config.enableNormalizationBinaryTree = true
+        let workspace = Workspace.get(byName: name)
+        workspace.rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            TestWindow.new(id: 2, parent: $0)
+            TestWindow.new(id: 3, parent: $0)
+            TestWindow.new(id: 4, parent: $0)
+        }
+        workspace.normalizeContainers()
+        // 1920x1080 → root .h; split → first child rect is half-width 960x1080 → .v; next .h; etc.
+        assertEquals(
+            .h_tiles([
+                .window(1),
+                .v_tiles([
+                    .window(2),
+                    .h_tiles([.window(3), .window(4)]),
+                ]),
+            ]),
+            workspace.rootTilingContainer.layoutDescription,
+        )
+    }
+
+    func testNormalizeContainers_bsp_orientsByRect() {
+        config.enableNormalizationBinaryTree = true
+        let workspace = Workspace.get(byName: name)
+        // Start with the "wrong" orientation; BSP should flip it.
+        workspace.rootTilingContainer.apply {
+            $0.setOrientation(.v)
+            TestWindow.new(id: 1, parent: $0)
+            TestWindow.new(id: 2, parent: $0)
+        }
+        workspace.normalizeContainers()
+        // 1920x1080 wide → .h
+        assertEquals(
+            .h_tiles([.window(1), .window(2)]),
+            workspace.rootTilingContainer.layoutDescription,
+        )
+    }
+
     func testNormalizeContainers_flattenContainers() {
         let workspace = Workspace.get(byName: name) // Don't cache root node
         workspace.rootTilingContainer.apply {

--- a/docs/config-examples/default-config.toml
+++ b/docs/config-examples/default-config.toml
@@ -20,6 +20,9 @@ auto-reload-config = false
 # Normalizations. See: https://nikitabobko.github.io/AeroSpace/guide#normalization
 enable-normalization-flatten-containers = true
 enable-normalization-opposite-orientation-for-nested-containers = true
+# When true, forces the tree to be binary and orients each container by the aspect ratio of its rect
+# (horizontal if wider than tall, vertical otherwise). Overrides the opposite-orientation normalization.
+enable-normalization-binary-tree = false
 
 # See: https://nikitabobko.github.io/AeroSpace/guide#layouts
 # The 'accordion-padding' specifies the size of accordion padding

--- a/docs/guide.adoc
+++ b/docs/guide.adoc
@@ -361,6 +361,16 @@ Configured by `enable-normalization-flatten-containers`
 . Containers that nest into each other must have opposite orientations.
 Configured by `enable-normalization-opposite-orientation-for-nested-containers`
 
+An optional third normalization, "binary tree" (off by default), can be enabled with
+`enable-normalization-binary-tree`.
+When enabled, it overrides the opposite-orientation normalization and applies two rules to every tiling container:
+
+. The tree is forced to be binary: any container with more than two children has its rightmost siblings
+  wrapped in a new sub-container until exactly two remain.
+. Each container is oriented based on the aspect ratio of its allotted rect: `horizontal` if width > height,
+  `vertical` otherwise. The rect is computed top-down starting from the workspace's visible rect, split in
+  half (by children weights) at every level.
+
 [.lead]
 *Example 1*
 
@@ -409,6 +419,7 @@ Though you can disable normalizations by placing these lines to your config:
 ----
 enable-normalization-flatten-containers = false
 enable-normalization-opposite-orientation-for-nested-containers = false
+enable-normalization-binary-tree = false
 ----
 
 Unless you're hardcore i3 user who knows what they are doing, it's recommended to keep the normalizations enabled.


### PR DESCRIPTION
Cf. #260.

## What
A new `enable-normalization-binary-tree` config option. When enabled, every tiling container is normalized to at most two children, with each level's orientation derived from its rectangle's aspect ratio, producing an i3/bspwm-style binary space partition.

## Why
Users coming from BSP-style window managers expect new splits to follow the longer edge automatically instead of piling siblings into a single container.

## How
`NormalizeBinaryTree()` recursively wraps surplus children into a nested container (`forceBinaryTree`), then sets each level's orientation and split position from its computed rect. Gated behind the new flag in `normalizeContainers()`; `setOrientation` is exposed on `TilingContainer` for it.

## PR checklist

- [x] Explain your changes in the relevant commit messages rather than in the PR description. The PR description must not contain more information than the commit messages (except for images and other media).
- [x] Each commit must explain what/why/how and motivation in its description. https://cbea.ms/git-commit/
- [x] Don't forget to link the appropriate issues/discussions in commit messages (if applicable).
- [x] Each commit must be an atomic change (a PR may contain several commits). Don't introduce new functional changes together with refactorings in the same commit.
- [x] `./test.sh` exits with non-zero exit code.
- [x] Avoid merge commits, always rebase and force push.