### PR TITLE
Fix bug: floating windows get nudged away from right/bottom edges on unhide

### DIFF
--- a/Sources/AppBundle/tree/MacWindow.swift
+++ b/Sources/AppBundle/tree/MacWindow.swift
@@ -132,6 +132,14 @@ final class MacWindow: Window {
                 let absolutePoint = topLeftCorner - monitorRect.topLeftCorner
                 prevUnhiddenProportionalPositionInsideWorkspaceRect =
                     CGPoint(x: absolutePoint.x / monitorRect.width, y: absolutePoint.y / monitorRect.height)
+                // Refresh lastFloatingSize from the live AX rect so that unhideFromCorner
+                // clamps against the window's actual current size rather than a size cached
+                // at window-detect time. Otherwise windows resized after detection get nudged
+                // away from the right/bottom workspace edges on every unhide.
+                // https://github.com/nikitabobko/AeroSpace/issues/1519
+                if isFloating {
+                    lastFloatingSize = windowRect.size
+                }
             }
         }
         let p: CGPoint


### PR DESCRIPTION
## Problem

`unhideFromCorner` clamps the restored position against `lastFloatingSize` (clamp added in 8134ad00, #1964), but `lastFloatingSize` is only written at window detection, in `EnableCommand`, and in `LayoutCommand`'s floating toggle — never when the user resizes the window. So any floating window resized after detection gets clamped against stale dimensions on every workspace unhide: it is nudged away from the right/bottom workspace edges by the size delta, or pinned to the top-left corner when the stale size exceeds the workspace.

Repro: float a window, resize it larger, place it near the bottom-right, switch workspace away and back — the window comes back shifted.

## Fix

Refresh `lastFloatingSize` from the live AX rect in `hideInCorner`, where the rect has already been fetched for the proportional-position save (zero extra AX calls). Guarded with `isFloating` so a tiled window being corner-parked cannot pollute the size that `layout floating` later restores (`LayoutCommand.swift` uses it to re-apply the last floating frame).

Same idea as the unsubmitted draft jli/AeroSpace#1 (credit to @jli, who reports the full test suite passing with this change and session-testing it on macOS 15.7.2).

Relates to #1519 (this does not implement the proper floating-window sizing discussed there — it only stops the existing clamp from using stale data).

## Testing

- `swift build` clean with Swift 6.3.3.
- The XCTest suite was not run locally (no full Xcode on this machine) — relying on CI here.
- I have not run the patched binary myself; the change mirrors jli's session-tested draft, plus the `isFloating` guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)