### PR TITLE
Add window-moved-to-workspace subscribe event

### DIFF
--- a/Sources/AppBundle/command/impl/MoveNodeToWorkspaceCommand.swift
+++ b/Sources/AppBundle/command/impl/MoveNodeToWorkspaceCommand.swift
@@ -37,9 +37,11 @@ func moveWindowToWorkspace(_ window: Window, _ targetWorkspace: Workspace, _ io:
                 .succ(io.err("Window '\(window.windowId)' already belongs to workspace '\(targetWorkspace.name)'. Tip: use --fail-if-noop to exit with non-zero code"))
         }
     }
+    let prevWorkspace = window.nodeWorkspace?.name
     let targetContainer: NonLeafTreeNodeObject = window.isFloating
         ? targetWorkspace.floatingWindowsContainer
         : targetWorkspace.rootTilingContainer
     window.bind(to: targetContainer, adaptiveWeight: WEIGHT_AUTO, index: index)
+    broadcastEvent(.windowMovedToWorkspace(windowId: window.windowId, workspace: targetWorkspace.name, prevWorkspace: prevWorkspace))
     return .from(bool: focusFollowsWindow ? window.focusWindow() : true)
 }

--- a/Sources/AppBundle/model/ServerEvent.swift
+++ b/Sources/AppBundle/model/ServerEvent.swift
@@ -45,4 +45,8 @@ public struct ServerEvent: Codable, Sendable {
     public static func bindingTriggered(mode: String, binding: String) -> ServerEvent {
         ServerEvent(_event: .bindingTriggered, mode: mode, binding: binding)
     }
+
+    public static func windowMovedToWorkspace(windowId: UInt32, workspace: String, prevWorkspace: String?) -> ServerEvent {
+        ServerEvent(_event: .windowMovedToWorkspace, windowId: windowId, workspace: workspace, prevWorkspace: prevWorkspace)
+    }
 }

--- a/Sources/AppBundle/subscriptions.swift
+++ b/Sources/AppBundle/subscriptions.swift
@@ -30,7 +30,7 @@ func handleSubscribeAndWaitTillError(_ connection: NWConnection, _ args: Subscri
                         workspace: f.workspace.name,
                         monitorId_oneBased: f.workspace.workspaceMonitor.monitorId_oneBased ?? 0,
                     )
-                case .windowDetected, .bindingTriggered: continue
+                case .windowDetected, .bindingTriggered, .windowMovedToWorkspace: continue
             }
             if await connection.writeAtomic(event, jsonEncoder).error != nil {
                 return

--- a/Sources/AppBundleTests/command/SubscribeCmdArgsTest.swift
+++ b/Sources/AppBundleTests/command/SubscribeCmdArgsTest.swift
@@ -31,7 +31,7 @@ final class SubscribeCmdArgsTest: XCTestCase {
             case .failure(let err):
                 let expectedMsg = """
                     ERROR: Can't parse 'unknown-event'.
-                           Possible values: (focus-changed|focused-monitor-changed|focused-workspace-changed|mode-changed|window-detected|binding-triggered)
+                           Possible values: (focus-changed|focused-monitor-changed|focused-workspace-changed|mode-changed|window-detected|binding-triggered|window-moved-to-workspace)
                     """
                 assertEquals(err, .init(expectedMsg, 2))
         }

--- a/Sources/Common/cmdArgs/impl/SubscribeCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/SubscribeCmdArgs.swift
@@ -60,4 +60,5 @@ public enum ServerEventType: String, Codable, CaseIterable, Sendable {
     case modeChanged = "mode-changed"
     case windowDetected = "window-detected"
     case bindingTriggered = "binding-triggered"
+    case windowMovedToWorkspace = "window-moved-to-workspace"
 }


### PR DESCRIPTION
What: New subscribe event `window-moved-to-workspace` that fires when a window moves between workspaces.

Why: External tools (overlays, status bars) subscribing to AeroSpace events have no way to detect workspace membership changes caused by `move-node-to-workspace`. When the last window leaves a non-persistent workspace, `list-workspaces` may drop it, but subscribers receive no event and can show stale workspaces.

How:
- New `ServerEventType.windowMovedToWorkspace` (wire: `window-moved-to-workspace`)
- Broadcast from `moveWindowToWorkspace()` after the window is rebound to the target workspace
- Payload: `{"_event":"window-moved-to-workspace","workspace":"...","prevWorkspace":"...","windowId":123}`
- `sendInitial` skips this transition-only event

Design decisions:
- Emits only for real workspace changes; same-workspace no-ops keep existing behavior
- Naming follows existing kebab-case subscribe events (`focused-workspace-changed`, `workspace-layout-changed`)
- No initial send: current workspace membership is already queryable via `list-windows`/`list-workspaces`

Validation:
- `swift build --quiet`
- `swift test --filter SubscribeCmdArgs`