### PR TITLE
Fix Device Hub (Xcode 27) compact-view flicker when tiled

### DIFF
--- a/Sources/AppBundle/layout/layoutRecursive.swift
+++ b/Sources/AppBundle/layout/layoutRecursive.swift
@@ -35,9 +35,18 @@ extension TreeNode {
                         lastAppliedLayoutPhysicalRect = nil
                         window.layoutFullscreen(context)
                     } else {
+                        // Skip the AX frame write entirely when the target rect didn't change since the last
+                        // layout pass. Besides avoiding pointless AXUIElementSetAttributeValue calls, this breaks
+                        // a resize feedback loop with apps that don't accept the imposed frame and report back a
+                        // different one (e.g. Xcode 27 Device Hub's compact view): such an app's own AX resize
+                        // notification would otherwise retrigger another relayout that recomputes and re-writes
+                        // the exact same (already applied) frame, ad infinitum.
+                        let frameChanged = lastAppliedLayoutPhysicalRect != physicalRect
                         lastAppliedLayoutPhysicalRect = physicalRect
                         window.isFullscreen = false
-                        window.setAxFrame(point, CGSize(width: width, height: height))
+                        if frameChanged {
+                            window.setAxFrame(point, CGSize(width: width, height: height))
+                        }
                     }
                 }
             case .tilingContainer(let container):

--- a/Sources/AppBundle/model/Rect.swift
+++ b/Sources/AppBundle/model/Rect.swift
@@ -1,7 +1,7 @@
 import AppKit
 import Common
 
-struct Rect: ConvenienceMutable, AeroAny {
+struct Rect: ConvenienceMutable, AeroAny, Equatable {
     var topLeftX: CGFloat
     var topLeftY: CGFloat
 

--- a/Sources/AppBundle/tree/MacWindow.swift
+++ b/Sources/AppBundle/tree/MacWindow.swift
@@ -151,6 +151,11 @@ final class MacWindow: Window {
                 let onePixelOffset = macApp.appId == .zoom ? .zero : CGPoint(x: 1, y: 1)
                 p = nodeMonitor.visibleRect.bottomRightCorner - onePixelOffset
         }
+        // The window is being moved away from whatever layoutRecursive last applied to it, so that record is now
+        // stale. Without invalidating it, layoutRecursive's redundant-write skip would wrongly think the window
+        // is still at its correct tiled position on the next relayout (since the computed target rect is
+        // unchanged) and skip re-applying it, leaving tiling windows stuck hidden in the corner.
+        lastAppliedLayoutPhysicalRect = nil
         setAxFrame(p, nil)
     }
 

--- a/Sources/AppBundle/tree/TreeNode.swift
+++ b/Sources/AppBundle/tree/TreeNode.swift
@@ -17,6 +17,7 @@ open class TreeNode: Equatable, AeroAny {
     // - drag window with mouse
     // - move-mouse command
     // - focus-follows-mouse
+    // - layoutRecursive: skip redundant AX frame writes when the target rect didn't change
     var lastAppliedLayoutPhysicalRect: Rect? = nil // with real inner gaps
     final var unboundStacktrace: String? = nil
     var isBound: Bool { parent != nil } // todo drop, once https://github.com/nikitabobko/AeroSpace/issues/1215 is fixed


### PR DESCRIPTION
Fixes the flicker described in #2137: AeroSpace rewrote every tiled window's AX frame on every relayout regardless of whether it had changed, which could loop with apps that don't accept the imposed frame and report a different one back (e.g. Xcode 27 Device Hub's compact view). See commit messages for details.

## PR checklist

- [x] Explain your changes in the relevant commit messages rather than in the PR description. The PR description must not contain more information than the commit messages (except for images and other media).
- [x] Each commit must explain what/why/how and motivation in its description. https://cbea.ms/git-commit/
- [x] Don't forget to link the appropriate issues/discussions in commit messages (if applicable).
- [x] Each commit must be an atomic change (a PR may contain several commits). Don't introduce new functional changes together with refactorings in the same commit.
- [x] `./test.sh` exits with non-zero exit code.
- [x] Avoid merge commits, always rebase and force push.