### PR TITLE
Fix #101: focus the correct cross-monitor window via private SkyLight API

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,6 +35,11 @@ let package = Package(
             name: "PrivateApi",
             path: "Sources/PrivateApi",
             publicHeadersPath: "include",
+            linkerSettings: [
+                // _SLPSSetFrontProcessWithOptions / SLPSPostEventRecordTo (used by aeroMakeKeyWindow for
+                // the issue #101 cross-monitor focus fix) live in the private SkyLight framework.
+                .unsafeFlags(["-F/System/Library/PrivateFrameworks", "-framework", "SkyLight"]),
+            ],
         ),
         .target(
             name: "Common",

--- a/Sources/AppBundle/initAppBundle.swift
+++ b/Sources/AppBundle/initAppBundle.swift
@@ -3,6 +3,7 @@ import Common
 import Foundation
 
 @MainActor public func initAppBundle() {
+    checkFocusPrivateApiCrashGuard()
     Task.startUnstructured {
         initTerminationHandler()
         unsafe _isCli = false
@@ -32,6 +33,20 @@ import Foundation
             smartLayoutAtStartup()
             _ = await config.afterStartupCommand.run(.defaultEnv, .emptyStdin)
         }
+    }
+}
+
+// https://github.com/nikitabobko/AeroSpace/issues/101 (idea: comment 2568238564)
+// Best-effort guard for the private SkyLight focus API used in MacApp.nativeFocus. If the in-use flag
+// is still set at startup, a previous session most likely died inside the private call, so disable the
+// private path and fall back to the public-API behavior. Best-effort because UserDefaults flushes
+// asynchronously (a very fast crash may not be caught) and a hard kill during the brief in-use window
+// could disable it spuriously. Once disabled it stays disabled until the key is cleared, e.g.
+// `defaults delete bobko.aerospace private-focus-api-disabled-after-crash`.
+@MainActor private func checkFocusPrivateApiCrashGuard() {
+    if UserDefaults.standard.bool(forKey: privateFocusApiInUseKey) {
+        UserDefaults.standard.set(true, forKey: privateFocusApiDisabledKey)
+        UserDefaults.standard.set(false, forKey: privateFocusApiInUseKey)
     }
 }
 

--- a/Sources/AppBundle/tree/MacApp.swift
+++ b/Sources/AppBundle/tree/MacApp.swift
@@ -1,5 +1,11 @@
 import AppKit
 import Common
+import PrivateApi
+
+// UserDefaults keys for the best-effort private-focus-API crash guard (see checkFocusPrivateApiCrashGuard
+// in initAppBundle.swift). https://github.com/nikitabobko/AeroSpace/issues/101
+let privateFocusApiInUseKey = "private-focus-api-in-use"
+let privateFocusApiDisabledKey = "private-focus-api-disabled-after-crash"
 
 // Potential alternative implementation
 // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0392-custom-actor-executors.md
@@ -130,6 +136,21 @@ final class MacApp: AbstractApp {
     @MainActor func nativeFocus(_ windowId: UInt32) {
         if serverArgs.isReadOnly { return }
         MacApp.focusJob?.cancel()
+        // #101: the public path below can't reliably key the *requested* window of a multi-window app
+        // across monitors when "Displays have separate Spaces" is on. Use the private SkyLight API to
+        // key the exact window (see aeroMakeKeyWindow). The private call is bracketed by a best-effort
+        // crash flag so it disables itself on next launch if it ever crashes (checkFocusPrivateApiCrashGuard).
+        if NSScreen.screensHaveSeparateSpaces, monitors.count > 1,
+           !UserDefaults.standard.bool(forKey: privateFocusApiDisabledKey)
+        {
+            MacApp.focusJob = withWindowAsync(windowId, .cancellable) { [pid] window, job in
+                UserDefaults.standard.set(true, forKey: privateFocusApiInUseKey)
+                aeroMakeKeyWindow(pid, windowId)
+                UserDefaults.standard.set(false, forKey: privateFocusApiInUseKey)
+                AXUIElementPerformAction(window, kAXRaiseAction as CFString)
+            }
+            return
+        }
         // Performance optimization. If possible avoid doing AX requests
         // (important for apps which are slow at responding even such basic AX requests. E.g. Godot)
         // Beware of the macOS bug: https://github.com/nikitabobko/AeroSpace/issues/101

--- a/Sources/PrivateApi/include/private.h
+++ b/Sources/PrivateApi/include/private.h
@@ -25,4 +25,10 @@
 // func _AXUIElementGetWindow(_ axUiElement: AXUIElement, _ id: inout CGWindowID) -> AXError
 AXError _AXUIElementGetWindow(AXUIElementRef element, uint32_t *identifier);
 
+// Reliably makes window `wid` of process `pid` the key window, bypassing the public accessibility API
+// which focuses the wrong window of the same app across monitors when "Displays have separate Spaces"
+// is enabled. Implemented with private SkyLight (WindowServer) APIs, the same technique used by yabai
+// and Amethyst. See https://github.com/nikitabobko/AeroSpace/issues/101
+void aeroMakeKeyWindow(pid_t pid, uint32_t wid);
+
 #endif

--- a/Sources/PrivateApi/include/private.m
+++ b/Sources/PrivateApi/include/private.m
@@ -1,2 +1,31 @@
 // This file exists purely because xcode doesn't like header only targets, SPM is fine with them
 #import "private.h"
+#import <Carbon/Carbon.h> // GetProcessForPID, ProcessSerialNumber
+#import <string.h>        // memcpy, memset
+
+// Private SkyLight (WindowServer) symbols. Same key-window sequence used by yabai and Amethyst.
+// https://github.com/Hammerspoon/hammerspoon/issues/370#issuecomment-545545468
+extern CGError _SLPSSetFrontProcessWithOptions(ProcessSerialNumber *psn, uint32_t wid, uint32_t mode);
+extern CGError SLPSPostEventRecordTo(ProcessSerialNumber *psn, uint8_t *bytes);
+
+void aeroMakeKeyWindow(pid_t pid, uint32_t wid) {
+    ProcessSerialNumber psn;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations" // GetProcessForPID is the documented way to obtain a PSN
+    if (GetProcessForPID(pid, &psn) != noErr) { return; }
+#pragma clang diagnostic pop
+
+    // 0x200 == kCPSUserGenerated: mark the activation as user-initiated.
+    _SLPSSetFrontProcessWithOptions(&psn, wid, 0x200);
+
+    // Two synthesized WindowServer key-window events; they differ only in byte 0x08 (0x01 then 0x02).
+    uint8_t bytes[0xf8] = {0};
+    bytes[0x04] = 0xf8;
+    bytes[0x3a] = 0x10;
+    memcpy(bytes + 0x3c, &wid, sizeof(uint32_t));
+    memset(bytes + 0x20, 0xff, 0x10);
+    bytes[0x08] = 0x01;
+    SLPSPostEventRecordTo(&psn, bytes);
+    bytes[0x08] = 0x02;
+    SLPSPostEventRecordTo(&psn, bytes);
+}


### PR DESCRIPTION
## What this fixes

Closes #101.

When **"Displays have separate Spaces" is enabled with more than one monitor**, focusing one window of an app that also has windows on another monitor sometimes focuses the *wrong* window — a different window of the same app on another monitor — and drags that monitor to a different workspace. It's intermittent, and it's been reported many times (#229, #591, #726, discussions #1476/#1705/#1937).

## Root cause

`nativeFocus` uses the public path `kAXMain` + `AXRaise` + `NSRunningApplication.activate(...)`. The problem is the last step: **`activate` is app-level, not window-level.** Per AppKit, activation brings the app's *own* main/key window forward — and for a multi-window app that key window is often the one the user most recently touched, which may live on a different monitor. So macOS makes *that* window key instead of the one we raised, AeroSpace observes focus land there, and follows it — switching the other monitor's visible workspace. The public API has no way to say "activate app X **and** make window W key."

## The fix

Use the private SkyLight (WindowServer) API to name the exact `CGWindowID` that becomes key — the same long-standing technique used by **yabai** and **Amethyst** (origin: [Hammerspoon#370](https://github.com/Hammerspoon/hammerspoon/issues/370#issuecomment-545545468)): `_SLPSSetFrontProcessWithOptions` + two synthesized `SLPSPostEventRecordTo` key-window records + `AXRaise`.

Design choices aimed at the concerns raised in the issue thread:

- **All private-API usage is contained in the existing `PrivateApi` C module**, right next to `_AXUIElementGetWindow`. Swift sees exactly one new function, `aeroMakeKeyWindow(pid, wid)`; the byte-poking and the `GetProcessForPID` deprecation live in the `.m`.
- **Best-effort crash guard** (implementing the idea from [#101 (comment)](https://github.com/nikitabobko/AeroSpace/issues/101#issuecomment-2568238564)): a `UserDefaults` flag is set immediately before the private call and cleared immediately after. If it's still set at the next launch — a previous session likely died inside the private call — the private path is disabled and AeroSpace falls back to the existing public-API behavior. It is **best-effort**: `UserDefaults` flushes asynchronously (a very fast crash may not be caught) and a hard kill during the brief in-use window could disable it spuriously. Both failure modes degrade to today's upstream behavior, so neither introduces new harm. Happy to harden it — see Open questions.
- **Narrowly gated**: the private path runs *only* when `NSScreen.screensHaveSeparateSpaces` **and** `monitors.count > 1` **and** the crash guard hasn't disabled it. With separate Spaces off, or a single monitor, the existing paths are byte-for-byte unchanged.

Net diff: +77 lines, 5 files. No new dependency; SkyLight is a system framework, linked only on the `PrivateApi` target.

## Testing

- Full `./test.sh` passes locally: builds clean under `-Xswiftc -warnings-as-errors`, swift tests, `swiftformat`, `swiftlint`, `periphery` (no unused code), `generate.sh`, and `check-uncommitted-files.sh`.
- **The behavior was verified against the real bug on hardware** (macOS 26.3, 3 monitors, separate Spaces on) using a **byte-identical `@_silgen_name` Swift prototype** of this SLPS sequence: I reproduced the exact failure first — armed a same-app window on a hidden workspace of monitor A, then focused that app's window on monitor B, and monitor A flipped away — then confirmed the fix holds monitor A and focus lands on the requested window. **This PR re-expresses that same sequence in the `PrivateApi` C module.** The C version builds clean and emits the identical WindowServer events, but I have not re-run the built C binary on the rig.

Honest scope: verified by one person on one setup, and the bug is intermittent by nature (it depends on the app's most-recently-key window), so wider testing is welcome — especially on 2-monitor setups and with non-Electron apps.

## Prior art / credit

- The crash-guard idea is [nikitabobko's own](https://github.com/nikitabobko/AeroSpace/issues/101#issuecomment-2568238564).
- The SkyLight sequence follows yabai (`window_manager_make_key_window`) and Amethyst ([PR #1530](https://github.com/ianyh/Amethyst/pull/1530), which fixed the same cross-monitor symptom).
- `titouv` sketched an earlier version on a fork; this reworks it onto the `PrivateApi` module and adds the crash guard + gating.

## Open questions (happy to adjust)

- **Hardening the crash guard**, if you'd prefer it stronger than best-effort: force a synchronous flush around the private call, only disable after N repeated crashes, and/or log one line when it disables. It's currently a single shared flag while focus bodies run on per-app threads, so overlapping private focus calls could mis-account — a per-call counter would fix that. I kept it minimal since it's your design idea.
- Should disabling surface a one-time dialog to the user (as you floated in the issue)? Left silent for now to keep the change small.
