### PR TITLE
Add window-closed subscribe event

### DIFF
--- a/Sources/AppBundle/model/ServerEvent.swift
+++ b/Sources/AppBundle/model/ServerEvent.swift
@@ -45,4 +45,8 @@ public struct ServerEvent: Codable, Sendable {
     public static func bindingTriggered(mode: String, binding: String) -> ServerEvent {
         ServerEvent(_event: .bindingTriggered, mode: mode, binding: binding)
     }
+
+    public static func windowClosed(windowId: UInt32, workspace: String?) -> ServerEvent {
+        ServerEvent(_event: .windowClosed, windowId: windowId, workspace: workspace)
+    }
 }

--- a/Sources/AppBundle/subscriptions.swift
+++ b/Sources/AppBundle/subscriptions.swift
@@ -30,7 +30,7 @@ func handleSubscribeAndWaitTillError(_ connection: NWConnection, _ args: Subscri
                         workspace: f.workspace.name,
                         monitorId_oneBased: f.workspace.workspaceMonitor.monitorId_oneBased ?? 0,
                     )
-                case .windowDetected, .bindingTriggered: continue
+                case .windowDetected, .bindingTriggered, .windowClosed: continue
             }
             if await connection.writeAtomic(event, jsonEncoder).error != nil {
                 return

--- a/Sources/AppBundle/tree/MacWindow.swift
+++ b/Sources/AppBundle/tree/MacWindow.swift
@@ -83,6 +83,7 @@ final class MacWindow: Window {
         if !skipClosedWindowsCache { cacheClosedWindowIfNeeded() }
         let parent = unbindFromParent().parent
         let deadWindowWorkspace = parent.nodeWorkspace
+        broadcastEvent(.windowClosed(windowId: windowId, workspace: deadWindowWorkspace?.name))
         let focus = focus
         if let deadWindowWorkspace, deadWindowWorkspace == focus.workspace ||
             deadWindowWorkspace == prevFocusedWorkspace && prevFocusedWorkspaceDate.distance(to: .now) < 1

--- a/Sources/AppBundleTests/command/SubscribeCmdArgsTest.swift
+++ b/Sources/AppBundleTests/command/SubscribeCmdArgsTest.swift
@@ -31,7 +31,7 @@ final class SubscribeCmdArgsTest: XCTestCase {
             case .failure(let err):
                 let expectedMsg = """
                     ERROR: Can't parse 'unknown-event'.
-                           Possible values: (focus-changed|focused-monitor-changed|focused-workspace-changed|mode-changed|window-detected|binding-triggered)
+                           Possible values: (focus-changed|focused-monitor-changed|focused-workspace-changed|mode-changed|window-detected|binding-triggered|window-closed)
                     """
                 assertEquals(err, .init(expectedMsg, 2))
         }

--- a/Sources/Common/cmdArgs/impl/SubscribeCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/SubscribeCmdArgs.swift
@@ -60,4 +60,5 @@ public enum ServerEventType: String, Codable, CaseIterable, Sendable {
     case modeChanged = "mode-changed"
     case windowDetected = "window-detected"
     case bindingTriggered = "binding-triggered"
+    case windowClosed = "window-closed"
 }

--- a/docs/aerospace-subscribe.adoc
+++ b/docs/aerospace-subscribe.adoc
@@ -50,6 +50,8 @@ window-detected:: Fired when a new window is detected. Includes `windowId`, `wor
 
 binding-triggered:: Fired when a keyboard binding is triggered. Includes `binding`, `mode`.
 
+window-closed:: Fired when a window is closed. Includes `windowId`, `workspace`.
+
 // =========================================================== Output Format
 include::util/conditional-output-format-header.adoc[]
 

--- a/grammar/commands-bnf-grammar.txt
+++ b/grammar/commands-bnf-grammar.txt
@@ -152,4 +152,4 @@ aerospace -h;
 <pid> ::= {{{ aerospace list-apps --format '%{app-pid}%{tab}%{app-name}' }}};
 <monitor_id> ::= all | mouse | focused | {{{ aerospace list-monitors --format '%{monitor-id}%{tab}%{monitor-name}' }}};
 
-<event> ::= focus-changed | focused-monitor-changed | focused-workspace-changed | mode-changed | window-detected | binding-triggered;
+<event> ::= focus-changed | focused-monitor-changed | focused-workspace-changed | mode-changed | window-detected | binding-triggered | window-closed;


### PR DESCRIPTION
What: New subscribe event `window-closed` that fires when a window is removed from AeroSpace’s model (closed, quit, or otherwise destroyed). It is the symmetric counterpart to the existing `window-detected` event.

Why: External tools (overlays, status bars, scripts) that subscribe to AeroSpace events currently have no way to detect a window closing. `window-detected` fires on creation, but nothing fires on removal, so subscribers keep showing windows that no longer exist until an unrelated event (e.g. the next focus change) happens to trigger a refresh. macOS provides no reliable higher-level close signal, and AeroSpace already owns the authoritative removal point, so the event is cheapest and most correct to emit here.

Use case: a companion overview/HUD that mirrors the current window set. Without this event, closing a background window (no focus change) leaves a stale tile until something else happens. `yabai` exposes an equivalent `window_destroyed` signal.

How:
- New `ServerEventType.windowClosed` (wire name: `window-closed`).
- Broadcast from `MacWindow.garbageCollect()` — the single point where a window leaves `allWindowsMap`, so it covers every removal path (close command, `kAXUIElementDestroyedNotification`, refresh reconciliation) and fires exactly once per window.
- Payload: `{"_event":"window-closed","windowId":123,"workspace":"4"}`.
- `sendInitial` skips this transition-only event.
- Docs (`aerospace-subscribe.adoc`) and grammar updated; generated cmd-help unchanged (synopsis untouched).

Testing: `./build-debug.sh` and full `swift test` pass (382 tests, 0 failures), incl. `SubscribeCmdArgsTest`.

Related: https://github.com/nikitabobko/AeroSpace/issues/1514