### PR TITLE
debug-windows: add --app-bundle-id flag to dump unregistered AX windows

### DIFF
--- a/Sources/AppBundle/command/impl/DebugWindowsCommand.swift
+++ b/Sources/AppBundle/command/impl/DebugWindowsCommand.swift
@@ -24,6 +24,12 @@ struct DebugWindowsCommand: Command {
     /*conforms*/ let shouldResetClosedWindowsCache = false
 
     func run(_ env: CmdEnv, _ io: CmdIo) async -> BinaryExitCode {
+        if args.windowId != nil && args.appBundleId != nil {
+            return .fail(io.err("--window-id is incompatible with --app-bundle-id"))
+        }
+        if let appBundleId = args.appBundleId {
+            return await dumpAppWindowsDebugInfo(appBundleId, io)
+        }
         if let windowId = args.windowId {
             guard let window = Window.get(byId: windowId) else {
                 return .fail(io.err("Can't find window with the specified window-id: \(windowId)"))
@@ -78,39 +84,94 @@ struct DebugWindowsCommand: Command {
 @MainActor
 private func dumpWindowDebugInfo(_ window: Window, _ cm: CancellationMode) async throws -> String {
     let window = window as! MacWindow
-    let appInfoDic = window.macApp.nsApp.bundleURL.flatMap { Bundle.init(url: $0) }?.infoDictionary ?? [:]
-
     var result: [String: Json] = try await window.dumpAxInfo(cm)
 
     let windowLevel = getWindowLevel(for: window.windowId)
-    let windowLevelJson = windowLevel?.toJson() ?? .null
-    result["Aero.windowLevel"] = windowLevelJson
+    result["Aero.windowLevel"] = windowLevel?.toJson() ?? .null
     result["Aero.axWindowId"] = .int(window.windowId)
-    result["Aero.workspace"] = .stringOrNull(window.nodeWorkspace?.name)
-    result["Aero.treeNodeParent"] = .string(String(describing: window.parent))
-    result["Aero.macOS.version"] = .string(ProcessInfo().operatingSystemVersionString) // because built-in apps might behave differently depending on the OS version
-    result["Aero.App.appBundleId"] = .stringOrNull(window.app.rawAppBundleId)
-    result["Aero.App.pid"] = .int(Int(window.app.pid))
-    result["Aero.App.versionShort"] = .stringOrNull(appInfoDic["CFBundleShortVersionString"] as? String)
-    result["Aero.App.version"] = .stringOrNull(appInfoDic["CFBundleVersion"] as? String)
-    result["Aero.App.nsApp.activationPolicy"] = .string(window.macApp.nsApp.activationPolicy.prettyDescription)
-    result["Aero.App.nsApp.execPath"] = .stringOrNull(window.macApp.nsApp.executableURL?.description)
-    result["Aero.App.nsApp.appBundlePath"] = .stringOrNull(window.macApp.nsApp.bundleURL?.description)
-    result["Aero.AXApp"] = .dict(try await window.macApp.dumpAppAxInfo(cm))
+    result = result + (try await dumpAppDebugInfo(window.macApp, cm))
+    result = result + (await dumpTreeNodeDebugInfo(window))
 
     let isDialog = try await window.isDialogHeuristic(windowLevel, cm)
     let isWindow = try await window.isWindowHeuristic(windowLevel, cm)
     result["Aero.AxUiElementWindowType"] = .string(AxUiElementWindowType.new(isWindow: isWindow, isDialog: { isDialog }).rawValue)
     result["Aero.AxUiElementWindowType_isDialogHeuristic"] = .bool(isDialog)
 
+    return JSONEncoder.aeroSpaceDefault.encodeToString(result).prettyDescription
+        .prefixLines(with: "\(window.app.rawAppBundleId ?? "nil-bundle-id").\(window.windowId) ||| ")
+}
+
+@MainActor
+private func dumpAppDebugInfo(_ macApp: MacApp, _ cm: CancellationMode) async throws -> [String: Json] {
+    let appInfoDic = macApp.nsApp.bundleURL.flatMap { Bundle.init(url: $0) }?.infoDictionary ?? [:]
+    var result: [String: Json] = [:]
+    result["Aero.macOS.version"] = .string(ProcessInfo().operatingSystemVersionString) // because built-in apps might behave differently depending on the OS version
+    result["Aero.App.appBundleId"] = .stringOrNull(macApp.rawAppBundleId)
+    result["Aero.App.pid"] = .int(Int(macApp.pid))
+    result["Aero.App.versionShort"] = .stringOrNull(appInfoDic["CFBundleShortVersionString"] as? String)
+    result["Aero.App.version"] = .stringOrNull(appInfoDic["CFBundleVersion"] as? String)
+    result["Aero.App.nsApp.activationPolicy"] = .string(macApp.nsApp.activationPolicy.prettyDescription)
+    result["Aero.App.nsApp.execPath"] = .stringOrNull(macApp.nsApp.executableURL?.description)
+    result["Aero.App.nsApp.appBundlePath"] = .stringOrNull(macApp.nsApp.bundleURL?.description)
+    result["Aero.AXApp"] = .dict(try await macApp.dumpAppAxInfo(cm))
+    return result
+}
+
+@MainActor
+private func dumpTreeNodeDebugInfo(_ window: MacWindow) async -> [String: Json] {
+    var result: [String: Json] = [:]
+    result["Aero.workspace"] = .stringOrNull(window.nodeWorkspace?.name)
+    result["Aero.treeNodeParent"] = .string(String(describing: window.parent))
     var matchingCallbacks: [Json] = []
     for callback in config.onWindowDetected where await callback.matches(window) {
         matchingCallbacks.append(callback.debugJson)
     }
     result["Aero.on-window-detected"] = .array(matchingCallbacks)
+    return result
+}
 
-    return JSONEncoder.aeroSpaceDefault.encodeToString(result).prettyDescription
-        .prefixLines(with: "\(window.app.rawAppBundleId ?? "nil-bundle-id").\(window.windowId) ||| ")
+@MainActor
+private func dumpAppWindowsDebugInfo(_ appBundleId: String, _ io: CmdIo) async -> BinaryExitCode {
+    let apps = MacApp.allAppsMap.values.filter { $0.rawAppBundleId == appBundleId }
+    if apps.isEmpty {
+        let running = NSWorkspace.shared.runningApplications.filter { $0.bundleIdentifier == appBundleId }
+        return if running.isEmpty {
+            .fail(io.err("No running application with app-bundle-id '\(appBundleId)'"))
+        } else {
+            .fail(io.err(running.map {
+                "Application '\(appBundleId)' (pid=\($0.processIdentifier), activationPolicy=\($0.activationPolicy.prettyDescription)) is running, but it's not registered in AeroSpace"
+            }.joined(separator: "\n")))
+        }
+    }
+    var entries: [String] = []
+    for app in apps {
+        let windowLevels = getAllWindowLevels()
+        guard let appDump = try? await dumpAppDebugInfo(app, .nonCancellable),
+              let dumps = try? await app.dumpAllWindowsAxInfo(windowLevels, .nonCancellable)
+        else { return .fail(io.err(bugPrompt())) }
+        for (index, idAndDump) in dumps.enumerated() {
+            let (windowId, dump) = idAndDump
+            var result = dump + appDump
+            if let windowId {
+                result["Aero.axWindowId"] = .int(windowId)
+                result["Aero.windowLevel"] = windowLevels[windowId]?.toJson() ?? .null
+            } else {
+                result["Aero.axWindowId"] = .null
+                result["Aero.windowLevel"] = .null
+            }
+            if let windowId, let macWindow = MacWindow.allWindowsMap[windowId] {
+                result["Aero.debug.registered"] = .bool(true)
+                result = result + (await dumpTreeNodeDebugInfo(macWindow))
+            } else {
+                result["Aero.debug.registered"] = .bool(false)
+            }
+            let prefix = "\(appBundleId).\(windowId?.description ?? "nil-window-id-\(index)") ||| "
+            entries.append(JSONEncoder.aeroSpaceDefault.encodeToString(result).prettyDescription.prefixLines(with: prefix))
+        }
+    }
+    io.out(entries.joined(separator: "\n\n") + "\n")
+    io.out(disclaimer)
+    return .succ
 }
 
 @MainActor

--- a/Sources/AppBundle/tree/MacApp.swift
+++ b/Sources/AppBundle/tree/MacApp.swift
@@ -232,6 +232,41 @@ final class MacApp: AbstractApp {
         } ?? [:]
     }
 
+    /// Unlike 'dumpWindowAxInfo', it also dumps AX windows that are not treated as windows from AeroSpace perspective.
+    /// The only intended use case is 'debug-windows' command. https://github.com/nikitabobko/AeroSpace/issues/1235
+    func dumpAllWindowsAxInfo(_ windowLevels: [UInt32: MacOsWindowLevel], _ cm: CancellationMode) async throws -> [(windowId: UInt32?, dump: [String: Json])] {
+        try await thread?.runInLoop(cm) { [nsApp, axApp, windows, appId] job in
+            var result: [(windowId: UInt32?, dump: [String: Json])] = []
+            var enumeratedIds: Set<UInt32> = []
+            let app = axApp.threadGuarded
+            func newDump(_ windowId: UInt32?, _ ax: AXUIElement) -> [String: Json] {
+                var dump = dumpAxRecursive(ax, .window)
+                let windowLevel = windowId.flatMap { windowLevels[$0] }
+                let windowType = ax.getWindowType(axApp: app, appId, nsApp.activationPolicy, windowLevel)
+                dump["Aero.AxUiElementWindowType"] = .string(windowType.rawValue)
+                dump["Aero.AxUiElementWindowType_isDialogHeuristic"] = .bool(ax.isDialogHeuristic(appId, windowLevel))
+                return dump
+            }
+            for (windowId, ax) in app.get(Ax.windowsRawAttr) ?? [] {
+                try job.checkCancellation()
+                var dump = newDump(windowId, ax)
+                if windowId == nil {
+                    dump["Aero.debug.windowIdFailed"] = .string("_AXUIElementGetWindow failed or returned kCGNullWindowID. AeroSpace ignores such AX windows")
+                }
+                if let windowId { enumeratedIds.insert(windowId) }
+                result.append((windowId, dump))
+            }
+            // Registered AX windows that are not enumerated in kAXWindowsAttribute (e.g. windows on inactive macOS Spaces)
+            for (windowId, axWindow) in windows.threadGuarded where !enumeratedIds.contains(windowId) {
+                try job.checkCancellation()
+                var dump = newDump(windowId, axWindow.ax)
+                dump["Aero.debug.absentInAxWindowsAttr"] = .bool(true)
+                result.append((windowId, dump))
+            }
+            return result
+        } ?? []
+    }
+
     func dumpAppAxInfo(_ cm: CancellationMode) async throws -> [String: Json] {
         try await thread?.runInLoop(cm) { [axApp] job in
             dumpAxRecursive(axApp.threadGuarded, .app)

--- a/Sources/AppBundle/util/accessibility.swift
+++ b/Sources/AppBundle/util/accessibility.swift
@@ -275,6 +275,15 @@ enum Ax {
         key: kAXWindowsAttribute,
         getter: { ($0 as? NSArray)?.compactMap(windowOrNil).map { ($0.windowId, $0.ax.cast) } ?? [] },
     )
+    /// Unlike 'windowsAttr', it doesn't filter out AX elements without windowId.
+    /// The only intended use case is 'debug-windows' command. https://github.com/nikitabobko/AeroSpace/issues/1235
+    static let windowsRawAttr = ReadableAttrImpl<[WindowIdOrNilAndAxUiElement]>(
+        key: kAXWindowsAttribute,
+        getter: { ($0 as? NSArray)?.map { any in
+            let ax = any as! AXUIElement
+            return (ax.containingWindowId(), ax)
+        } ?? [] },
+    )
     static let focusedWindowAttr = ReadableAttrImpl<WindowIdAndAxUiElementMock>(
         key: kAXFocusedWindowAttribute,
         getter: windowOrNil,
@@ -329,6 +338,7 @@ private func castToAxUiElementMock(_ a: AnyObject) -> AxUiElementMock {
 }
 
 typealias WindowIdAndAxUiElement = (windowId: UInt32, ax: AXUIElement)
+typealias WindowIdOrNilAndAxUiElement = (windowId: UInt32?, ax: AXUIElement)
 typealias WindowIdAndAxUiElementMock = (windowId: UInt32, ax: AxUiElementMock)
 
 private func windowOrNil(_ any: Any?) -> WindowIdAndAxUiElementMock? {

--- a/Sources/AppBundle/windowLevelCache.swift
+++ b/Sources/AppBundle/windowLevelCache.swift
@@ -7,7 +7,16 @@ private var cache: [UInt32: MacOsWindowLevel] = [:]
 @MainActor
 func getWindowLevel(for windowId: UInt32) -> MacOsWindowLevel? {
     if let existing = cache[windowId] { return existing }
+    return refreshWindowLevelCache()?[windowId]
+}
 
+@MainActor
+func getAllWindowLevels() -> [UInt32: MacOsWindowLevel] {
+    refreshWindowLevelCache() ?? cache
+}
+
+@MainActor
+private func refreshWindowLevelCache() -> [UInt32: MacOsWindowLevel]? {
     var result: [UInt32: MacOsWindowLevel] = [:]
     let options = CGWindowListOption(arrayLiteral: .excludeDesktopElements, .optionOnScreenOnly)
     guard let cfArray = CGWindowListCopyWindowInfo(options, CGWindowID(0)) as? [CFDictionary] else { return nil }
@@ -23,7 +32,7 @@ func getWindowLevel(for windowId: UInt32) -> MacOsWindowLevel? {
         result[windowId] = .new(windowLevel: windowLayer)
     }
     cache = result
-    return result[windowId]
+    return result
 }
 
 enum MacOsWindowLevel: Sendable, Equatable {

--- a/Sources/AppBundleTests/command/DebugWindowsCommandTest.swift
+++ b/Sources/AppBundleTests/command/DebugWindowsCommandTest.swift
@@ -1,0 +1,20 @@
+@testable import AppBundle
+import Common
+import XCTest
+
+@MainActor
+final class DebugWindowsCommandTest: XCTestCase {
+    override func setUp() async throws { setUpWorkspacesForTests() }
+
+    func testParse() {
+        testParseSingleCommandSucc("debug-windows", DebugWindowsCmdArgs(rawArgs: []))
+        testParseSingleCommandSucc(
+            "debug-windows --window-id 42",
+            DebugWindowsCmdArgs(rawArgs: []).copy(\.windowId, 42),
+        )
+        testParseSingleCommandSucc(
+            "debug-windows --app-bundle-id com.example.app",
+            DebugWindowsCmdArgs(rawArgs: []).copy(\.appBundleId, "com.example.app"),
+        )
+    }
+}

--- a/Sources/Common/cmdArgs/impl/DebugWindowsCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/DebugWindowsCmdArgs.swift
@@ -6,7 +6,10 @@ public struct DebugWindowsCmdArgs: CmdArgs {
         help: debug_windows_help_generated,
         flags: [
             "--window-id": windowIdSubArgParser(),
+            "--app-bundle-id": singleValueSubArgParser(\.appBundleId, "<app-bundle-id>", Result.success),
         ],
         posArgs: [],
     )
+
+    public var appBundleId: String?
 }

--- a/Sources/Common/cmdHelpGenerated.swift
+++ b/Sources/Common/cmdHelpGenerated.swift
@@ -18,6 +18,7 @@ let config_help_generated = """
     """
 let debug_windows_help_generated = """
     USAGE: debug-windows [-h|--help] [--window-id <window-id>]
+       OR: debug-windows [-h|--help] --app-bundle-id <app-bundle-id>
     """
 let echo_help_generated = """
     USAGE: echo [-h|--help] [--stderr] [--window-id <window-id>] -- <string>...

--- a/docs/aerospace-debug-windows.adoc
+++ b/docs/aerospace-debug-windows.adoc
@@ -10,6 +10,7 @@ include::util/man-attributes.adoc[]
 [verse]
 // tag::synopsis[]
 aerospace debug-windows [-h|--help] [--window-id <window-id>]
+aerospace debug-windows [-h|--help] --app-bundle-id <app-bundle-id>
 
 // end::synopsis[]
 
@@ -28,6 +29,11 @@ The intended usage is the following:
 . Focus problematic window or make the window appear.
 . Run the command one more time to stop the debug session recording and print the results
 
+If the problematic window can't be focused, or if AeroSpace doesn't detect the window at all,
+use `--app-bundle-id` flag to dump debug information about all AX windows of the application,
+including AX windows that are not treated as windows from AeroSpace perspective.
+You can get the app-bundle-id of running applications with `aerospace list-apps` command.
+
 `debug-windows` command is *not stable API*.
 Please *don't rely on* the command existence and output format.
 The only intended use case is to report bugs about incorrect windows handling.
@@ -39,6 +45,11 @@ include::util/conditional-options-header.adoc[]
 
 --window-id <window-id>::
 Print debug information of the specified window right away.
+Usage of this flag disables interactive mode.
+
+--app-bundle-id <app-bundle-id>::
+Print debug information of all AX windows of the specified application right away,
+including AX windows that are not treated as windows from AeroSpace perspective.
 Usage of this flag disables interactive mode.
 
 // end::body[]

--- a/grammar/commands-bnf-grammar.txt
+++ b/grammar/commands-bnf-grammar.txt
@@ -19,7 +19,7 @@ aerospace -h;
     | config --all-keys
     | config --config-path
 
-    | debug-windows [--window-id <window_id>]
+    | debug-windows [--window-id <window_id>|--app-bundle-id <app_bundle_id>]
 
     | echo [--stderr|--window <window_id>]... --
 


### PR DESCRIPTION
Closes #1235

`debug-windows` can only dump windows AeroSpace already registered, which is a problem when the bug is that AeroSpace _didn't_ register something — or registered it as a popup, which can't be focused, so recording mode never sees it and `list-windows` never shows its id.

This adds `aerospace debug-windows --app-bundle-id <id>`. It dumps every AX element the app returns in `kAXWindowsAttribute` without the `windowOrNil` filtering, plus registered windows that are no longer enumerated there. Each entry gets:

- `Aero.debug.registered` — whether the element is in the tree; registered ones also get the usual `Aero.workspace`/`Aero.treeNodeParent`/`Aero.on-window-detected`
- `Aero.debug.windowIdFailed` — for elements dropped because `_AXUIElementGetWindow` failed or returned `kCGNullWindowID` (after 0f6b2e78 these can't be dumped at all)
- `Aero.debug.absentInAxWindowsAttr` — registered windows the app no longer enumerates
- `Aero.AxUiElementWindowType` + `_isDialogHeuristic`, computed in the same pass, so the output can be dropped into `axDumps/` as-is

If the app isn't registered in AeroSpace at all (like FL Studio in #1234), the error reports its pid and activationPolicy.

All AX access happens in a single pass on the app's runloop thread. Window levels are prefetched on the main actor since `getWindowLevel` is `@MainActor`. `--window-id` output is unchanged (shared parts extracted into helpers). Docs, generated help, and completion grammar updated.

Example against Finder — it captures the desktop element that `windowOrNil` exists to filter out:

```
com.apple.finder.nil-window-id-0 |||   "AXDescription" : "desktop",
com.apple.finder.nil-window-id-0 |||   "AXRole" : "AXScrollArea",
com.apple.finder.nil-window-id-0 |||   "Aero.AxUiElementWindowType" : "popup",
com.apple.finder.nil-window-id-0 |||   "Aero.debug.registered" : false,
com.apple.finder.nil-window-id-0 |||   "Aero.debug.windowIdFailed" : "_AXUIElementGetWindow failed or returned kCGNullWindowID. AeroSpace ignores such AX windows",
```

Tested with a `--read-only` debug server against a dozen running apps: registered windows, the Finder desktop element, an unregistered accessory app, a not-running app, and `--window-id` for regressions. `swift test` passes, swiftformat clean.
