### PR TITLE
Implement enable-normalization command: per-workspace normalization overrides

### DIFF
--- a/Sources/AppBundle/command/cmdManifest.swift
+++ b/Sources/AppBundle/command/cmdManifest.swift
@@ -22,6 +22,8 @@ extension CmdArgs {
                 command = EchoCommand(args: self as! EchoCmdArgs)
             case .enable:
                 command = EnableCommand(args: self as! EnableCmdArgs)
+            case .enableNormalization:
+                command = EnableNormalizationCommand(args: self as! EnableNormalizationCmdArgs)
             case .eval:
                 command = EvalCommand(args: self as! EvalCmdArgs)
             case .execAndForget:

--- a/Sources/AppBundle/command/impl/EnableNormalizationCommand.swift
+++ b/Sources/AppBundle/command/impl/EnableNormalizationCommand.swift
@@ -1,0 +1,33 @@
+import Common
+
+struct EnableNormalizationCommand: Command {
+    let args: EnableNormalizationCmdArgs
+    /*conforms*/ let shouldResetClosedWindowsCache = true
+
+    func run(_ env: CmdEnv, _ io: CmdIo) async -> BinaryExitCode {
+        guard let target = args.resolveTargetOrReportError(env, io) else { return .fail }
+        let workspace = target.workspace
+        let kind = args.kind.val
+        // An override lives only as long as its workspace. Refuse to install one on a
+        // workspace that garbageCollectUnusedWorkspaces is about to destroy, instead of
+        // succeeding with no lasting effect.
+        if args.targetState.val != .reset && workspace.isDoomedToGarbageCollection {
+            return .fail(io.err("Workspace '\(workspace.name)' is empty and invisible, so it would be garbage-collected together with the override. Focus the workspace first, or add it to 'persistent-workspaces'"))
+        }
+        switch args.targetState.val {
+            case .on, .off:
+                let newValue = args.targetState.val == .on
+                if workspace.normalizationOverride[kind] == newValue {
+                    if args.failIfNoop { return .fail }
+                    let state = newValue ? "enabled" : "disabled"
+                    return .succ(io.err("Normalization '\(kind.rawValue)' is already \(state) on workspace '\(workspace.name)'. Tip: use --fail-if-noop to exit with non-zero code"))
+                }
+                workspace.normalizationOverride[kind] = newValue
+            case .toggle:
+                workspace.normalizationOverride[kind] = !workspace.isNormalizationEnabled(kind)
+            case .reset:
+                workspace.normalizationOverride.removeValue(forKey: kind)
+        }
+        return .succ
+    }
+}

--- a/Sources/AppBundle/command/impl/SplitCommand.swift
+++ b/Sources/AppBundle/command/impl/SplitCommand.swift
@@ -6,10 +6,10 @@ struct SplitCommand: Command {
     /*conforms*/ let shouldResetClosedWindowsCache = true
 
     func run(_ env: CmdEnv, _ io: CmdIo) -> BinaryExitCode {
-        if config.enableNormalizationFlattenContainers {
-            return .fail(io.err("'split' has no effect when 'enable-normalization-flatten-containers' normalization enabled. My recommendation: keep the normalizations enabled, and prefer 'join-with' over 'split'."))
-        }
         guard let target = args.resolveTargetOrReportError(env, io) else { return .fail }
+        if target.workspace.isNormalizationEnabled(.flattenContainers) {
+            return .fail(io.err("'split' has no effect when 'enable-normalization-flatten-containers' normalization enabled. My recommendation: keep the normalizations enabled, and prefer 'join-with' over 'split'. Alternatively, disable the normalization on this workspace: 'aerospace enable-normalization --workspace \(target.workspace.name) flatten-containers off'"))
+        }
         guard let window = target.windowOrNil else {
             return .fail(io.err(noWindowIsFocused))
         }

--- a/Sources/AppBundle/config/parseConfig.swift
+++ b/Sources/AppBundle/config/parseConfig.swift
@@ -293,17 +293,17 @@ struct ParseConfigResult {
             .flatMap { $0.commands.flatten() }
             .contains { $0 is SplitCommand }
         if containsSplitCommand {
-            c.errors += [.init(
+            c.warnings.append(.init(
                 .emptyRoot, // todo Make 'split' + flatten normalization prettier
                 """
                 The config contains:
                 1. usage of 'split' command
                 2. enable-normalization-flatten-containers = true
-                These two settings don't play nicely together. 'split' command has no effect when enable-normalization-flatten-containers is disabled.
+                These two settings don't play nicely together: 'split' has no effect on workspaces where the flatten-containers normalization is enabled.
 
-                My recommendation: keep the normalizations enabled, and prefer 'join-with' over 'split'.
+                My recommendation: keep the normalizations enabled, and prefer 'join-with' over 'split'. Alternatively, disable the normalization on a single workspace with 'aerospace enable-normalization flatten-containers off'.
                 """,
-            )]
+            ))
         }
     }
     if config.configVersion < .max {

--- a/Sources/AppBundle/tree/TilingContainer.swift
+++ b/Sources/AppBundle/tree/TilingContainer.swift
@@ -32,7 +32,7 @@ extension TilingContainer {
         if orientation == targetOrientation {
             return
         }
-        if config.enableNormalizationOppositeOrientationForNestedContainers {
+        if isNormalizationEnabled(.oppositeOrientationForNestedContainers) {
             var orientation = targetOrientation
             parentsWithSelf
                 .filterIsInstance(of: TilingContainer.self)

--- a/Sources/AppBundle/tree/Workspace.swift
+++ b/Sources/AppBundle/tree/Workspace.swift
@@ -80,16 +80,22 @@ final class Workspace: TreeNode, NonLeafTreeNodeObject, Hashable, Comparable {
         return "Workspace(\(description))"
     }
 
+    /// True when garbageCollectUnusedWorkspaces would destroy this workspace.
+    @MainActor
+    var isDoomedToGarbageCollection: Bool {
+        !config.persistentWorkspaces.contains(name)
+            && isEffectivelyEmpty
+            && !isVisible
+            && name != focus.workspace.name
+    }
+
     @MainActor
     static func garbageCollectUnusedWorkspaces() {
         for name in config.persistentWorkspaces {
             _ = get(byName: name) // Make sure that all persistent workspaces are "cached"
         }
         workspaceNameToWorkspace = workspaceNameToWorkspace.filter { (_, workspace: Workspace) in
-            config.persistentWorkspaces.contains(workspace.name) ||
-                !workspace.isEffectivelyEmpty ||
-                workspace.isVisible ||
-                workspace.name == focus.workspace.name
+            !workspace.isDoomedToGarbageCollection
         }
     }
 

--- a/Sources/AppBundle/tree/Workspace.swift
+++ b/Sources/AppBundle/tree/Workspace.swift
@@ -35,6 +35,11 @@ final class Workspace: TreeNode, NonLeafTreeNodeObject, Hashable, Comparable {
     nonisolated private let nameLogicalSegments: StringLogicalSegments
     /// `assignedMonitorPoint` must be interpreted only when the workspace is invisible
     fileprivate var assignedMonitorPoint: CGPoint? = nil
+    /// Per-workspace overrides for normalization flags. Empty by default; absent
+    /// kinds fall through to the global config value. Lives as long as the
+    /// workspace itself: `garbageCollectUnusedWorkspaces` destroys the override
+    /// together with the workspace. Not persisted across restarts.
+    var normalizationOverride: [NormalizationKind: Bool] = [:]
 
     @MainActor
     private init(_ name: String) {

--- a/Sources/AppBundle/tree/normalizeContainers.swift
+++ b/Sources/AppBundle/tree/normalizeContainers.swift
@@ -1,6 +1,9 @@
 extension Workspace {
     @MainActor func normalizeContainers() {
-        rootTilingContainer.unbindEmptyAndAutoFlatten() // Beware! rootTilingContainer may change after this line of code
+        // Always called: the function also removes effectively-empty containers
+        // regardless of the flatten flag.
+        // Beware! rootTilingContainer may change after this line of code
+        rootTilingContainer.unbindEmptyAndAutoFlatten(allowFlatten: config.enableNormalizationFlattenContainers)
         if config.enableNormalizationOppositeOrientationForNestedContainers {
             rootTilingContainer.normalizeOppositeOrientationForNestedContainers()
         }
@@ -8,13 +11,13 @@ extension Workspace {
 }
 
 extension TilingContainer {
-    @MainActor fileprivate func unbindEmptyAndAutoFlatten() {
-        if let child = children.singleOrNil(), config.enableNormalizationFlattenContainers && (child is TilingContainer || !isRootContainer) {
+    @MainActor fileprivate func unbindEmptyAndAutoFlatten(allowFlatten: Bool) {
+        if let child = children.singleOrNil(), allowFlatten && (child is TilingContainer || !isRootContainer) {
             child.unbindFromParent()
             let mru = parent?.mostRecentChild
             let previousBinding = unbindFromParent()
             child.bind(to: previousBinding.parent, adaptiveWeight: previousBinding.adaptiveWeight, index: previousBinding.index)
-            (child as? TilingContainer)?.unbindEmptyAndAutoFlatten()
+            (child as? TilingContainer)?.unbindEmptyAndAutoFlatten(allowFlatten: allowFlatten)
             if mru != self {
                 mru?.markAsMostRecentChild()
             } else {
@@ -22,7 +25,7 @@ extension TilingContainer {
             }
         } else {
             for child in children {
-                (child as? TilingContainer)?.unbindEmptyAndAutoFlatten()
+                (child as? TilingContainer)?.unbindEmptyAndAutoFlatten(allowFlatten: allowFlatten)
             }
             if children.isEmpty && !isRootContainer {
                 unbindFromParent()

--- a/Sources/AppBundle/tree/normalizeContainers.swift
+++ b/Sources/AppBundle/tree/normalizeContainers.swift
@@ -1,10 +1,29 @@
+import Common
+
+extension TreeNode {
+    /// Returns the node's workspace override if set, otherwise the global config flag.
+    /// A detached node belongs to no workspace, so it resolves to the global config.
+    @MainActor func isNormalizationEnabled(_ kind: NormalizationKind) -> Bool {
+        nodeWorkspace?.normalizationOverride[kind] ?? config.isNormalizationEnabledGlobally(kind)
+    }
+}
+
+extension Config {
+    fileprivate func isNormalizationEnabledGlobally(_ kind: NormalizationKind) -> Bool {
+        switch kind {
+            case .flattenContainers: enableNormalizationFlattenContainers
+            case .oppositeOrientationForNestedContainers: enableNormalizationOppositeOrientationForNestedContainers
+        }
+    }
+}
+
 extension Workspace {
     @MainActor func normalizeContainers() {
         // Always called: the function also removes effectively-empty containers
         // regardless of the flatten flag.
         // Beware! rootTilingContainer may change after this line of code
-        rootTilingContainer.unbindEmptyAndAutoFlatten(allowFlatten: config.enableNormalizationFlattenContainers)
-        if config.enableNormalizationOppositeOrientationForNestedContainers {
+        rootTilingContainer.unbindEmptyAndAutoFlatten(allowFlatten: isNormalizationEnabled(.flattenContainers))
+        if isNormalizationEnabled(.oppositeOrientationForNestedContainers) {
             rootTilingContainer.normalizeOppositeOrientationForNestedContainers()
         }
     }

--- a/Sources/AppBundleTests/command/EnableNormalizationCommandTest.swift
+++ b/Sources/AppBundleTests/command/EnableNormalizationCommandTest.swift
@@ -1,0 +1,254 @@
+@testable import AppBundle
+import Common
+import XCTest
+
+@MainActor
+final class EnableNormalizationCommandTest: XCTestCase {
+    override func setUp() async throws { setUpWorkspacesForTests() }
+
+    func testParse() {
+        let command = parseCommand("enable-normalization flatten-containers on").cmdOrNil?.flatten().singleOrNil()
+        XCTAssertTrue(command is EnableNormalizationCommand)
+        let args = (command as! EnableNormalizationCommand).args
+        assertEquals(args.kind.val, .flattenContainers)
+        assertEquals(args.targetState.val, .on)
+        assertEquals(args.failIfNoop, false)
+        XCTAssertNil(args.workspaceName)
+
+        let command2 = parseCommand("enable-normalization --workspace foo --fail-if-noop opposite-orientation-for-nested-containers off").cmdOrNil?.flatten().singleOrNil()
+        XCTAssertTrue(command2 is EnableNormalizationCommand)
+        let args2 = (command2 as! EnableNormalizationCommand).args
+        assertEquals(args2.kind.val, .oppositeOrientationForNestedContainers)
+        assertEquals(args2.targetState.val, .off)
+        assertEquals(args2.failIfNoop, true)
+        assertEquals(args2.workspaceName?.raw, "foo")
+    }
+
+    func testParseFailIfNoopIncompatibleWithToggleAndReset() {
+        assertEquals(
+            parseCommand("enable-normalization flatten-containers toggle --fail-if-noop").errorOrNil,
+            "--fail-if-noop is incompatible with 'toggle' or 'reset' arguments",
+        )
+        assertEquals(
+            parseCommand("enable-normalization flatten-containers reset --fail-if-noop").errorOrNil,
+            "--fail-if-noop is incompatible with 'toggle' or 'reset' arguments",
+        )
+    }
+
+    func testParseInvalidKind() {
+        let error = parseCommand("enable-normalization bogus on").errorOrNil
+        XCTAssertNotNil(error)
+        XCTAssertTrue(error?.contains("bogus") == true, "error must name the unparsable argument: \(error ?? "nil")")
+        XCTAssertTrue(error?.contains("flatten-containers|opposite-orientation-for-nested-containers") == true, "error must list the possible values: \(error ?? "nil")")
+    }
+
+    func testParseMissingArgs() {
+        let error = parseCommand("enable-normalization").errorOrNil
+        XCTAssertNotNil(error)
+        XCTAssertTrue(error?.contains("flatten-containers|opposite-orientation-for-nested-containers") == true, "error must mention the mandatory <kind> placeholder: \(error ?? "nil")")
+    }
+
+    func testOverride_on_takesPrecedenceOverGlobalOff() {
+        config.enableNormalizationOppositeOrientationForNestedContainers = false
+        let workspace = Workspace.get(byName: name)
+        workspace.normalizationOverride[.oppositeOrientationForNestedContainers] = true
+
+        XCTAssertTrue(workspace.isNormalizationEnabled(.oppositeOrientationForNestedContainers))
+    }
+
+    func testOverride_off_takesPrecedenceOverGlobalOn() {
+        config.enableNormalizationOppositeOrientationForNestedContainers = true
+        let workspace = Workspace.get(byName: name)
+        workspace.normalizationOverride[.oppositeOrientationForNestedContainers] = false
+
+        XCTAssertFalse(workspace.isNormalizationEnabled(.oppositeOrientationForNestedContainers))
+    }
+
+    func testOverride_isPerWorkspace() {
+        config.enableNormalizationOppositeOrientationForNestedContainers = false
+        let a = Workspace.get(byName: "ws-A-\(name)")
+        let b = Workspace.get(byName: "ws-B-\(name)")
+        a.normalizationOverride[.oppositeOrientationForNestedContainers] = true
+
+        XCTAssertTrue(a.isNormalizationEnabled(.oppositeOrientationForNestedContainers))
+        XCTAssertFalse(b.isNormalizationEnabled(.oppositeOrientationForNestedContainers))
+    }
+
+    func testOverride_appliedAtRefreshTime() {
+        config.enableNormalizationOppositeOrientationForNestedContainers = false
+        let workspace = Workspace.get(byName: name)
+        workspace.normalizationOverride[.oppositeOrientationForNestedContainers] = true
+        workspace.rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            TilingContainer.newHTiles(parent: $0, adaptiveWeight: 1).apply {
+                TestWindow.new(id: 2, parent: $0)
+                TestWindow.new(id: 3, parent: $0)
+            }
+        }
+
+        workspace.normalizeContainers()
+
+        // opposite-orientation ran on this workspace despite the global flag being off.
+        assertEquals(
+            workspace.rootTilingContainer.layoutDescription,
+            .h_tiles([
+                .window(1),
+                .v_tiles([.window(2), .window(3)]),
+            ]),
+        )
+    }
+
+    /// The override lives only as long as the workspace: garbage collection of an
+    /// empty invisible workspace destroys the override together with the workspace.
+    func testOverride_diesWithWorkspaceGC() {
+        config.enableNormalizationOppositeOrientationForNestedContainers = false
+        let doomedName = "ws-gc-doomed"
+        Workspace.get(byName: doomedName).normalizationOverride[.oppositeOrientationForNestedContainers] = true
+
+        Workspace.garbageCollectUnusedWorkspaces()
+        XCTAssertFalse(Workspace.all.contains { $0.name == doomedName }, "precondition: empty invisible workspace must be garbage-collected")
+
+        let revived = Workspace.get(byName: doomedName)
+        XCTAssertNil(revived.normalizationOverride[.oppositeOrientationForNestedContainers])
+        XCTAssertFalse(revived.isNormalizationEnabled(.oppositeOrientationForNestedContainers))
+    }
+
+    func testChangeOrientation_overrideOn_cascadesToAncestors() {
+        // Global opposite-orientation normalization is off via setUpWorkspacesForTests.
+        let workspace = focus.workspace
+        workspace.normalizationOverride[.oppositeOrientationForNestedContainers] = true
+        let root = workspace.rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            TilingContainer.newVTiles(parent: $0, adaptiveWeight: 1).apply {
+                TestWindow.new(id: 2, parent: $0)
+            }
+        }
+        let nested = root.children[1] as! TilingContainer
+
+        nested.changeOrientation(.h)
+
+        assertEquals(root.layoutDescription, .v_tiles([
+            .window(1),
+            .h_tiles([.window(2)]),
+        ]))
+    }
+
+    func testChangeOrientation_overrideOff_globalOn_doesNotCascade() {
+        config.enableNormalizationOppositeOrientationForNestedContainers = true
+        let workspace = focus.workspace
+        workspace.normalizationOverride[.oppositeOrientationForNestedContainers] = false
+        let root = workspace.rootTilingContainer.apply {
+            TestWindow.new(id: 1, parent: $0)
+            TilingContainer.newVTiles(parent: $0, adaptiveWeight: 1).apply {
+                TestWindow.new(id: 2, parent: $0)
+            }
+        }
+        let nested = root.children[1] as! TilingContainer
+
+        nested.changeOrientation(.h)
+
+        assertEquals(root.layoutDescription, .h_tiles([
+            .window(1),
+            .h_tiles([.window(2)]),
+        ]))
+    }
+
+    func testCommand_on_setsOverride() async {
+        let workspace = focus.workspace
+        _ = await parseCommand("enable-normalization opposite-orientation-for-nested-containers on").cmdOrDie
+            .run(.defaultEnv.withWorkspaceName(workspace.name), .emptyStdin)
+
+        assertEquals(workspace.normalizationOverride[.oppositeOrientationForNestedContainers], true)
+    }
+
+    func testCommand_off_setsOverride() async {
+        let workspace = focus.workspace
+        _ = await parseCommand("enable-normalization opposite-orientation-for-nested-containers off").cmdOrDie
+            .run(.defaultEnv.withWorkspaceName(workspace.name), .emptyStdin)
+
+        assertEquals(workspace.normalizationOverride[.oppositeOrientationForNestedContainers], false)
+    }
+
+    func testCommand_toggle_flipsEffectiveValue() async {
+        config.enableNormalizationOppositeOrientationForNestedContainers = false
+        let workspace = focus.workspace
+
+        _ = await parseCommand("enable-normalization opposite-orientation-for-nested-containers toggle").cmdOrDie
+            .run(.defaultEnv.withWorkspaceName(workspace.name), .emptyStdin)
+        assertEquals(workspace.normalizationOverride[.oppositeOrientationForNestedContainers], true)
+
+        _ = await parseCommand("enable-normalization opposite-orientation-for-nested-containers toggle").cmdOrDie
+            .run(.defaultEnv.withWorkspaceName(workspace.name), .emptyStdin)
+        assertEquals(workspace.normalizationOverride[.oppositeOrientationForNestedContainers], false)
+    }
+
+    func testCommand_reset_clearsOverride() async {
+        let workspace = focus.workspace
+        workspace.normalizationOverride[.oppositeOrientationForNestedContainers] = true
+
+        _ = await parseCommand("enable-normalization opposite-orientation-for-nested-containers reset").cmdOrDie
+            .run(.defaultEnv.withWorkspaceName(workspace.name), .emptyStdin)
+
+        XCTAssertNil(workspace.normalizationOverride[.oppositeOrientationForNestedContainers])
+    }
+
+    /// Repeating 'on' when the override is already set is a noop: without
+    /// --fail-if-noop the command reports it on stderr and succeeds, following
+    /// the same convention as the 'enable' and 'workspace' commands.
+    func testCommand_on_noop_succeedsWithoutFailIfNoop() async {
+        let workspace = focus.workspace
+        workspace.normalizationOverride[.oppositeOrientationForNestedContainers] = true
+
+        let result = await parseCommand("enable-normalization opposite-orientation-for-nested-containers on").cmdOrDie
+            .run(.defaultEnv.withWorkspaceName(workspace.name), .emptyStdin)
+
+        assertEquals(result.exitCode.rawValue, 0)
+        XCTAssertFalse(result.stderr.isEmpty, "noop must be reported on stderr")
+        assertEquals(workspace.normalizationOverride[.oppositeOrientationForNestedContainers], true)
+    }
+
+    func testCommand_on_noop_failsWithFailIfNoop() async {
+        let workspace = focus.workspace
+        workspace.normalizationOverride[.oppositeOrientationForNestedContainers] = true
+
+        let result = await parseCommand("enable-normalization opposite-orientation-for-nested-containers on --fail-if-noop").cmdOrDie
+            .run(.defaultEnv.withWorkspaceName(workspace.name), .emptyStdin)
+
+        assertEquals(result.exitCode.rawValue, 2)
+    }
+
+    /// '--workspace <name>' targets a non-focused workspace without leaking the
+    /// override onto the focused one. Without the flag the command would fall
+    /// through to `focus.workspace`.
+    func testCommand_withWorkspaceFlag_targetsNonFocusedWorkspace() async {
+        // Hardcoded simple name so WorkspaceName.parse accepts it; XCTest's
+        // 'name' property contains brackets that are not legal in workspace
+        // names.
+        let otherName = "ws-flag-target"
+        let focused = focus.workspace
+        let other = Workspace.get(byName: otherName)
+        assertNotEquals(focused.name, other.name)
+        // A window keeps 'other' out of the doomed-workspace refusal: overrides
+        // can only be set on workspaces that survive garbage collection.
+        TestWindow.new(id: 1, parent: other.rootTilingContainer)
+
+        _ = await parseCommand("enable-normalization --workspace \(otherName) opposite-orientation-for-nested-containers off").cmdOrDie
+            .run(.defaultEnv, .emptyStdin)
+
+        assertEquals(other.normalizationOverride[.oppositeOrientationForNestedContainers], false)
+        XCTAssertNil(focused.normalizationOverride[.oppositeOrientationForNestedContainers], "override must not leak to the focused workspace")
+    }
+
+    /// Setting an override on a workspace that garbage collection is about to
+    /// destroy would silently have no effect, so the command refuses instead.
+    func testCommand_onEmptyInvisibleWorkspace_fails() async {
+        let doomedName = "ws-doomed"
+
+        let result = await parseCommand("enable-normalization --workspace \(doomedName) flatten-containers on").cmdOrDie
+            .run(.defaultEnv, .emptyStdin)
+
+        assertEquals(result.exitCode.rawValue, 2)
+        XCTAssertFalse(result.stderr.isEmpty, "refusal must be explained on stderr")
+        XCTAssertNil(Workspace.get(byName: doomedName).normalizationOverride[.flattenContainers])
+    }
+}

--- a/Sources/AppBundleTests/command/SplitCommandTest.swift
+++ b/Sources/AppBundleTests/command/SplitCommandTest.swift
@@ -69,4 +69,57 @@ final class SplitCommandTest: XCTestCase {
             .window(2),
         ]))
     }
+
+    func testSplit_globalFlattenOn_refused() async {
+        config.enableNormalizationFlattenContainers = true
+        let root = Workspace.get(byName: name).rootTilingContainer.apply {
+            assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)
+            TestWindow.new(id: 2, parent: $0)
+        }
+
+        let result = await parseCommand("split vertical").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode.rawValue, 2)
+        assertEquals(root.layoutDescription, .h_tiles([
+            .window(1),
+            .window(2),
+        ]))
+    }
+
+    func testSplit_globalFlattenOn_workspaceOverrideOff_works() async {
+        config.enableNormalizationFlattenContainers = true
+        let workspace = Workspace.get(byName: name)
+        workspace.normalizationOverride[.flattenContainers] = false
+        let root = workspace.rootTilingContainer.apply {
+            assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)
+            TestWindow.new(id: 2, parent: $0)
+        }
+
+        await parseCommand("split vertical").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(root.layoutDescription, .h_tiles([
+            .v_tiles([
+                .window(1),
+            ]),
+            .window(2),
+        ]))
+    }
+
+    func testSplit_globalFlattenOff_workspaceOverrideOn_refused() async {
+        let workspace = Workspace.get(byName: name)
+        workspace.normalizationOverride[.flattenContainers] = true
+        let root = workspace.rootTilingContainer.apply {
+            assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)
+            TestWindow.new(id: 2, parent: $0)
+        }
+
+        let result = await parseCommand("split vertical").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(result.exitCode.rawValue, 2)
+        XCTAssertFalse(result.stderr.isEmpty, "refusal must be reported on stderr")
+        // The tip must target the workspace the refusal was computed from, which
+        // is not necessarily the focused one.
+        assertTrue(result.stderr.joined(separator: "\n").contains("--workspace \(workspace.name)"))
+        assertEquals(root.layoutDescription, .h_tiles([
+            .window(1),
+            .window(2),
+        ]))
+    }
 }

--- a/Sources/AppBundleTests/config/ConfigTest.swift
+++ b/Sources/AppBundleTests/config/ConfigTest.swift
@@ -265,23 +265,25 @@ final class ConfigTest: XCTestCase {
     }
 
     func testSplitCommandAndFlattenContainersNormalization() {
-        let errors = parseConfig(
+        let result = parseConfig(
             """
+            config-version = 2
             enable-normalization-flatten-containers = true
             [mode.main.binding]
             [mode.foo.binding]
                 alt-s = 'split horizontal'
             """,
-        ).strErrors
+        )
         let expected = """
-            [ERROR] The config contains:
+            [WARNING] The config contains:
             1. usage of 'split' command
             2. enable-normalization-flatten-containers = true
-            These two settings don't play nicely together. 'split' command has no effect when enable-normalization-flatten-containers is disabled.
+            These two settings don't play nicely together: 'split' has no effect on workspaces where the flatten-containers normalization is enabled.
 
-            My recommendation: keep the normalizations enabled, and prefer 'join-with' over 'split'.
+            My recommendation: keep the normalizations enabled, and prefer 'join-with' over 'split'. Alternatively, disable the normalization on a single workspace with 'aerospace enable-normalization flatten-containers off'.
             """
-        assertEquals(errors, [expected])
+        assertEquals(result.strErrors, [])
+        assertEquals(result.strWarnings, [expected])
     }
 
     func testParseWorkspaceToMonitorAssignment() {

--- a/Sources/AppBundleTests/testUtil.swift
+++ b/Sources/AppBundleTests/testUtil.swift
@@ -29,6 +29,7 @@ func setUpWorkspacesForTests() {
         for child in workspace.children {
             child.unbindFromParent()
         }
+        workspace.normalizationOverride = [:]
     }
     check(Workspace.get(byName: "setUpWorkspacesForTests").focusWorkspace())
     Workspace.garbageCollectUnusedWorkspaces()

--- a/Sources/Cli/subcommandDescriptionsGenerated.swift
+++ b/Sources/Cli/subcommandDescriptionsGenerated.swift
@@ -8,6 +8,7 @@ let subcommandDescriptions = [
     ["  config", "Query AeroSpace config options"],
     ["  debug-windows", "Interactive command to record Accessibility API debug information to create bug reports"],
     ["  echo", "Print arguments and interpolation variables to stdout"],
+    ["  enable-normalization", "Set or clear a per-workspace override for a refresh-time normalization"],
     ["  enable", "Temporarily disable window management"],
     ["  eval", "Send multiple commands to AeroSpace at once"],
     ["  false", "Return false value"],

--- a/Sources/Common/cmdArgs/cmdArgsManifest.swift
+++ b/Sources/Common/cmdArgs/cmdArgsManifest.swift
@@ -8,6 +8,7 @@ public enum CmdKind: String, CaseIterable, Equatable, Sendable {
     case debugWindows = "debug-windows"
     case echo
     case enable
+    case enableNormalization = "enable-normalization"
     case eval
     case execAndForget = "exec-and-forget"
 
@@ -70,6 +71,8 @@ func initSubcommands() -> [String: any SubCommandParserProtocol] {
                 result[kind.rawValue] = SubCommandParser(EchoCmdArgs.init)
             case .enable:
                 result[kind.rawValue] = SubCommandParser(parseEnableCmdArgs)
+            case .enableNormalization:
+                result[kind.rawValue] = SubCommandParser(parseEnableNormalizationCmdArgs)
             case .eval:
                 result[kind.rawValue] = SubCommandParser(EvalCmdArgs.init)
             case .execAndForget:

--- a/Sources/Common/cmdArgs/impl/EnableNormalizationCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/EnableNormalizationCmdArgs.swift
@@ -1,0 +1,38 @@
+public struct EnableNormalizationCmdArgs: CmdArgs {
+    /*conforms*/ public var commonState: CmdArgsCommonState
+    fileprivate init(rawArgs: StrArrSlice) { self.commonState = .init(rawArgs) }
+    public static let parser: CmdParser<Self> = .init(
+        kind: .enableNormalization,
+        help: enable_normalization_help_generated,
+        flags: [
+            "--fail-if-noop": trueBoolFlag(\.failIfNoop),
+            "--workspace": workspaceSubArgParser(),
+        ],
+        posArgs: [
+            newMandatoryPosArgParser(\.kind, parseNormalizationKind, placeholder: NormalizationKind.unionLiteral),
+            newMandatoryPosArgParser(\.targetState, parseNormalizationState, placeholder: EnableNormalizationCmdArgs.State.unionLiteral),
+        ],
+    )
+    public var kind: Lateinit<NormalizationKind> = .uninitialized
+    public var targetState: Lateinit<State> = .uninitialized
+    public var failIfNoop: Bool = false
+
+    public enum State: String, CaseIterable, Sendable {
+        case on, off, toggle, reset
+    }
+}
+
+func parseEnableNormalizationCmdArgs(_ args: StrArrSlice) -> ParsedCmd<EnableNormalizationCmdArgs> {
+    parseSpecificCmdArgs(EnableNormalizationCmdArgs(rawArgs: args), args)
+        .filterNot("--fail-if-noop is incompatible with 'toggle' or 'reset' arguments") {
+            ($0.targetState.val == .toggle || $0.targetState.val == .reset) && $0.failIfNoop
+        }
+}
+
+private func parseNormalizationKind(i: PosArgParserInput) -> ParsedCliArgs<NormalizationKind> {
+    .init(parseEnum(i.arg, NormalizationKind.self), advanceBy: 1)
+}
+
+private func parseNormalizationState(i: PosArgParserInput) -> ParsedCliArgs<EnableNormalizationCmdArgs.State> {
+    .init(parseEnum(i.arg, EnableNormalizationCmdArgs.State.self), advanceBy: 1)
+}

--- a/Sources/Common/cmdHelpGenerated.swift
+++ b/Sources/Common/cmdHelpGenerated.swift
@@ -22,6 +22,12 @@ let debug_windows_help_generated = """
 let echo_help_generated = """
     USAGE: echo [-h|--help] [--stderr] [--window-id <window-id>] -- <string>...
     """
+let enable_normalization_help_generated = """
+    USAGE: enable-normalization [-h|--help] [--workspace <workspace>] <kind> on [--fail-if-noop]
+       OR: enable-normalization [-h|--help] [--workspace <workspace>] <kind> off [--fail-if-noop]
+       OR: enable-normalization [-h|--help] [--workspace <workspace>] <kind> toggle
+       OR: enable-normalization [-h|--help] [--workspace <workspace>] <kind> reset
+    """
 let enable_help_generated = """
     USAGE: enable [-h|--help] toggle
        OR: enable [-h|--help] on [--fail-if-noop]

--- a/Sources/Common/model/NormalizationKind.swift
+++ b/Sources/Common/model/NormalizationKind.swift
@@ -1,0 +1,7 @@
+/// Identifies a refresh-time normalization that may be enabled or disabled
+/// independently of the others. Raw value matches the corresponding
+/// `enable-normalization-<kebab-name>` config key.
+public enum NormalizationKind: String, CaseIterable, Sendable, Equatable {
+    case flattenContainers = "flatten-containers"
+    case oppositeOrientationForNestedContainers = "opposite-orientation-for-nested-containers"
+}

--- a/docs/aerospace-enable-normalization.adoc
+++ b/docs/aerospace-enable-normalization.adoc
@@ -1,0 +1,53 @@
+= aerospace-enable-normalization(1)
+include::util/man-attributes.adoc[]
+:manname: aerospace-enable-normalization
+// tag::purpose[]
+:manpurpose: Set or clear a per-workspace override for a refresh-time normalization
+// end::purpose[]
+
+// =========================================================== Synopsis
+== Synopsis
+[verse]
+// tag::synopsis[]
+aerospace enable-normalization [-h|--help] [--workspace <workspace>] <kind> on [--fail-if-noop]
+aerospace enable-normalization [-h|--help] [--workspace <workspace>] <kind> off [--fail-if-noop]
+aerospace enable-normalization [-h|--help] [--workspace <workspace>] <kind> toggle
+aerospace enable-normalization [-h|--help] [--workspace <workspace>] <kind> reset
+
+// end::synopsis[]
+
+// =========================================================== Description
+== Description
+
+// tag::body[]
+{manpurpose}
+
+The override is scoped to a single workspace (the focused workspace by default, or the workspace named by `--workspace`) and lives as long as the workspace itself: AeroSpace destroys workspaces that become empty and invisible (unless they are listed in `persistent-workspaces`), and the override is destroyed with them.
+Overrides are not persisted across AeroSpace restarts.
+Setting an override on a workspace that would be destroyed immediately is an error.
+
+`<kind>` is one of `flatten-containers`, `opposite-orientation-for-nested-containers` (the suffix of the corresponding `enable-normalization-<kebab-name>` global config key).
+
+* `on` sets the workspace override to true regardless of the global config.
+* `off` sets the workspace override to false regardless of the global config.
+* `toggle` flips the current effective value (override if set, otherwise global config).
+* `reset` clears the workspace override so the workspace falls back to the global config value.
+
+`on`, `off`, and `toggle` all install an override, even when the resulting value coincides with the global config.
+While the override is set, later changes to the global config key (including `aerospace reload-config`) have no effect on that workspace until you run `reset`.
+
+See the broader normalization-framework discussion in https://github.com/nikitabobko/AeroSpace/issues/260[issue #260].
+
+// =========================================================== Options
+include::util/conditional-options-header.adoc[]
+
+-h, --help:: Print help
+--fail-if-noop:: Exit with non-zero exit code if the override is already in the requested state. Only valid with `on` or `off`.
+
+--workspace <workspace>::
+include::./util/workspace-flag-desc.adoc[]
+
+// end::body[]
+
+// =========================================================== Footer
+include::util/man-footer.adoc[]

--- a/docs/aerospace-split.adoc
+++ b/docs/aerospace-split.adoc
@@ -31,8 +31,9 @@ The argument configures orientation of the newly created container.
 
 *If the parent of the focused window contains only a single child* (the window itself), then `split` command changes the orientation of the parent container
 
-IMPORTANT: `split` command has no effect if `enable-normalization-flatten-containers` is turned on.
-Consider using `join-with` if you want to keep `enable-normalization-flatten-containers` enabled
+IMPORTANT: `split` command has no effect on workspaces where the `enable-normalization-flatten-containers` normalization is in effect.
+Consider using `join-with` if you want to keep `enable-normalization-flatten-containers` enabled.
+Alternatively, disable the normalization on a single workspace with `aerospace enable-normalization --workspace <workspace> flatten-containers off`
 
 // =========================================================== Options
 include::util/conditional-options-header.adoc[]

--- a/docs/commands.adoc
+++ b/docs/commands.adoc
@@ -54,6 +54,13 @@ include::aerospace-enable.adoc[tags=synopsis]
 include::aerospace-enable.adoc[tags=purpose]
 include::aerospace-enable.adoc[tags=body]
 
+== enable-normalization
+----
+include::aerospace-enable-normalization.adoc[tags=synopsis]
+----
+include::aerospace-enable-normalization.adoc[tags=purpose]
+include::aerospace-enable-normalization.adoc[tags=body]
+
 == eval
 ----
 include::aerospace-eval.adoc[tags=synopsis]

--- a/docs/guide.adoc
+++ b/docs/guide.adoc
@@ -413,6 +413,10 @@ enable-normalization-opposite-orientation-for-nested-containers = false
 
 Unless you're hardcore i3 user who knows what they are doing, it's recommended to keep the normalizations enabled.
 
+Each normalization can also be overridden on a per-workspace basis with the xref:commands.adoc#enable-normalization[`enable-normalization`] command.
+The override beats the global config for the targeted workspace and lives as long as the workspace itself; pass `reset` to remove it.
+This is the per-workspace control mentioned in https://github.com/nikitabobko/AeroSpace/issues/260[issue #260].
+
 [#floating-windows]
 === Floating windows
 

--- a/grammar/commands-bnf-grammar.txt
+++ b/grammar/commands-bnf-grammar.txt
@@ -27,6 +27,9 @@ aerospace -h;
     | enable [--fail-if-noop] on [--fail-if-noop]
     | enable [--fail-if-noop] off [--fail-if-noop]
 
+    | enable-normalization [--workspace <workspace>|--fail-if-noop]... <normalization_kind> (on|off) [--workspace <workspace>|--fail-if-noop]...
+    | enable-normalization [--workspace <workspace>] <normalization_kind> (toggle|reset) [--workspace <workspace>]
+
     | eval [--stdin]
 
     | false
@@ -125,6 +128,7 @@ aerospace -h;
 <number> ::= {{{ true }}};
 <monitor_pattern> ::= {{{ true }}};
 <layouts> ::= h_tiles|v_tiles|h_accordion|v_accordion|tiles|accordion|horizontal|vertical|tiling|floating;
+<normalization_kind> ::= flatten-containers|opposite-orientation-for-nested-containers;
 
 <list_workspaces1_flag> ::= --visible [no] | --empty [no] | --format <output_format> | --format <output_format> | --count | --json;
 


### PR DESCRIPTION
Implements the "change normalizations with command on per-workspace basis" part of #260.

```
aerospace enable-normalization [--workspace <workspace>] <kind> (on|off|toggle|reset)
```

`<kind>` is the suffix of an `enable-normalization-<kind>` config key: `flatten-containers` or `opposite-orientation-for-nested-containers`. The command sets a workspace-scoped override that beats the global config for that workspace only; `reset` removes it so the workspace falls back to the config. The override lives as long as the workspace itself (AeroSpace destroys workspaces that become empty and invisible) and is not persisted across restarts. All consumers of the two flags honor the per-workspace value, including `split` and the orientation cascade. Details, use cases, and testing notes are in the commit messages.

## Context

I've been running this mechanism in my fork since April 30 as part of a BSP-shape normalization prototype (demo and feedback thread: #2076). This PR is deliberately cut down to just the per-workspace command for the two existing normalizers, to be reviewable on its own. If this direction works for you, I'd offer the `bsp-shape` normalizer as a separate follow-up PR - and I'm happy to reshape either.

## Disclosure

Built with AI assistance (Claude Code). Architecture choices and test design are mine; most of the implementation code was generated, then reviewed and dogfooded by me.

## PR checklist

- [x] Explain your changes in the relevant commit messages rather than in the PR description. The PR description must not contain more information than the commit messages (except for images and other media).
- [x] Each commit must explain what/why/how and motivation in its description. https://cbea.ms/git-commit/
- [x] Don't forget to link the appropriate issues/discussions in commit messages (if applicable).
- [x] Each commit must be an atomic change (a PR may contain several commits). Don't introduce new functional changes together with refactorings in the same commit.
- [ ] `./test.sh` exits with non-zero exit code.
- [x] Avoid merge commits, always rebase and force push.
