### PR TITLE
focusFollowsMouse: keep focus while the mouse is within the focused window's real frame

### DIFF
--- a/Sources/AppBundle/mouse/focusFollowsMouse.swift
+++ b/Sources/AppBundle/mouse/focusFollowsMouse.swift
@@ -29,26 +29,36 @@ import AppKit
             if await isAxWindowUnderMouse(location) == false { return }
             try checkCancellation()
             let workspace = location.monitorApproximation.activeWorkspace
-            var window: Window? = nil
-            for child in workspace.floatingWindowsContainer.mruChildren {
-                try checkCancellation()
-                guard let child = child as? Window else { continue }
-                guard let rect = try await child.getAxRect(.cancellable) else { continue }
-                if rect.contains(location) {
-                    window = child
-                    break
-                }
-            }
-            if window == nil {
-                window = location.findWindowRecursively(in: workspace.rootTilingContainer, virtual: false, fullscreenCoversAll: true)
-            }
-            if let window {
+            if let window = try await location.windowUnderMouseToFocus(in: workspace) {
                 try await runLightSession(.focusFollowsMouse, token) {
                     _ = window.focusWindow()
                     window.nativeFocus()
                 }
             }
         }
+    }
+}
+
+extension CGPoint {
+    @MainActor
+    func windowUnderMouseToFocus(in workspace: Workspace) async throws -> Window? {
+        // The physical frame may be bigger than the requested one (e.g. AX minimum size).
+        // If the mouse is still within the focused window's real frame, keep the focus
+        if let focusedWindow = focus.windowOrNil,
+           let focusedRect = try await focusedWindow.getAxRect(.cancellable),
+           focusedRect.contains(self)
+        {
+            return nil
+        }
+        for child in workspace.floatingWindowsContainer.mruChildren {
+            try checkCancellation()
+            guard let child = child as? Window else { continue }
+            guard let rect = try await child.getAxRect(.cancellable) else { continue }
+            if rect.contains(self) {
+                return child
+            }
+        }
+        return findWindowRecursively(in: workspace.rootTilingContainer, virtual: false, fullscreenCoversAll: true)
     }
 }
 

--- a/Sources/AppBundleTests/mouse/FocusFollowsMouseTest.swift
+++ b/Sources/AppBundleTests/mouse/FocusFollowsMouseTest.swift
@@ -1,0 +1,29 @@
+@testable import AppBundle
+import Common
+import XCTest
+
+@MainActor
+final class FocusFollowsMouseTest: XCTestCase {
+    override func setUp() async throws { setUpWorkspacesForTests() }
+
+    func testKeepFocusWhenMouseIsWithinFocusedWindowRealFrame() async throws {
+        let workspace = Workspace.get(byName: name)
+        var left: Window!
+        workspace.rootTilingContainer.apply {
+            // The layout is 50/50, but the left window doesn't shrink below 600 (AX minimum size)
+            left = TestWindow.new(id: 1, parent: $0, rect: Rect(topLeftX: 0, topLeftY: 0, width: 600, height: 1000))
+            TestWindow.new(id: 2, parent: $0, rect: Rect(topLeftX: 500, topLeftY: 0, width: 500, height: 1000))
+        }
+        left.lastAppliedLayoutPhysicalRect = Rect(topLeftX: 0, topLeftY: 0, width: 500, height: 1000)
+        workspace.rootTilingContainer.children[1].lastAppliedLayoutPhysicalRect = Rect(topLeftX: 500, topLeftY: 0, width: 500, height: 1000)
+        _ = left.focusWindow()
+
+        // The mouse is inside the left window overhang. It's the right window territory according to the layout
+        var window = try await CGPoint(x: 550, y: 500).windowUnderMouseToFocus(in: workspace)
+        assertNil(window)
+
+        // The mouse is past the left window real frame
+        window = try await CGPoint(x: 700, y: 500).windowUnderMouseToFocus(in: workspace)
+        assertEquals(window?.windowId, 2)
+    }
+}


### PR DESCRIPTION
## Problem

With two windows tiled 50/50, if the left window has an AX minimum size that makes it physically wider than its tile, it overlaps the neighbor. Moving the mouse over that overhang (e.g. at 51% of the screen width) switches focus to the covered neighbor, even though the focused window is what's visually under the mouse (it's on top of the z-order).

Root cause: for tiled windows, focus-follows-mouse resolves the window under the cursor via `findWindowRecursively`, which only consults `lastAppliedLayoutPhysicalRect` — the rect the layout *requested*, not the frame the window actually settled on.

## Fix

Before resolving a new window under the mouse, check whether the cursor is still inside the currently focused window's real AX frame. If it is, keep the focus. Once the mouse leaves the real frame, behavior is unchanged.

The resolution logic is extracted from the `NSEvent` monitor closure into `CGPoint.windowUnderMouseToFocus(in:)` so it can be covered by a test (`FocusFollowsMouseTest`). The test is verified to fail without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)