### PR TITLE
Add window-dfs-index to list-windows output

### DIFF
--- a/Sources/AppBundle/command/format.swift
+++ b/Sources/AppBundle/command/format.swift
@@ -157,6 +157,7 @@ extension FormatVar {
             case (.window(let w), .window(let f)):
                 return switch f {
                     case .windowId: .success(.int(w.window.windowId))
+                    case .windowDfsIndex: toWindowDfsIndexResult(w: w.window)
                     case .windowIsFullscreen: .success(.bool(w.window.isFullscreen))
                     case .windowTitle: .success(.string(w.title.orDie("Title wasn't prefetched")))
                     case .windowLayout, .windowParentContainerLayout: toLayoutResult(w: w.window)
@@ -256,4 +257,16 @@ private func toLayoutResult(w: Window) -> Result<Primitive, InterVarExpansionErr
         case .rootTilingContainer: .failure(.notPossible("Not possible"))
         case .shimContainerRelation: .failure(.windowParentIllegalRelation("Window cannot have a shim container relation"))
     }
+}
+
+private func toWindowDfsIndexResult(w: Window) -> Result<Primitive, InterVarExpansionError> {
+    let nullWindowDfsIndex = "NULL-WINDOW-DFS-INDEX"
+    guard let workspace = w.nodeWorkspace else { return .success(.string(nullWindowDfsIndex)) }
+    guard let rootTilingContainer = workspace.children
+        .filterIsInstance(of: TilingContainer.self)
+        .singleOrNil()
+    else { return .success(.string(nullWindowDfsIndex)) }
+
+    let dfsIndex = rootTilingContainer.allLeafWindowsRecursive.firstIndex(where: { $0 == w })
+    return .success(dfsIndex.map(Primitive.int) ?? .string(nullWindowDfsIndex))
 }

--- a/Sources/AppBundleTests/command/EchoCommandTest.swift
+++ b/Sources/AppBundleTests/command/EchoCommandTest.swift
@@ -42,7 +42,7 @@ final class EchoCommandTest: XCTestCase {
         testParseCommandFail("echo --", msg: "ERROR: Argument '<string>' is mandatory", exitCode: 2)
         testParseCommandFail("echo foo", msg: "ERROR: Expected: --. Got: 'foo'", exitCode: 2)
         testParseCommandFail("echo --stderr foo", msg: "ERROR: Expected: --. Got: 'foo'", exitCode: 2)
-        testParseCommandFail("echo -- %{foo}", msg: "ERROR: Can't parse 'foo'.\n       Possible values: (window-id|window-is-fullscreen|window-title|window-layout|window-parent-container-layout|workspace|workspace-is-focused|workspace-is-visible|workspace-root-container-layout|app-bundle-id|app-name|app-pid|app-exec-path|app-bundle-path|monitor-id|monitor-appkit-nsscreen-screens-id|monitor-name|monitor-is-main|right-padding|newline|tab)", exitCode: 2)
+        testParseCommandFail("echo -- %{foo}", msg: "ERROR: Can't parse 'foo'.\n       Possible values: (window-id|window-dfs-index|window-is-fullscreen|window-title|window-layout|window-parent-container-layout|workspace|workspace-is-focused|workspace-is-visible|workspace-root-container-layout|app-bundle-id|app-name|app-pid|app-exec-path|app-bundle-path|monitor-id|monitor-appkit-nsscreen-screens-id|monitor-name|monitor-is-main|right-padding|newline|tab)", exitCode: 2)
 
         testParseCommandHelp("echo -h")
         testParseCommandHelp("echo --help")

--- a/Sources/AppBundleTests/command/ListWindowsTest.swift
+++ b/Sources/AppBundleTests/command/ListWindowsTest.swift
@@ -74,6 +74,28 @@ final class ListWindowsTest: XCTestCase {
         }
     }
 
+    func testFormatWindowDfsIndexFollowsWorkspaceDfsOrder() {
+        Workspace.get(byName: name).rootTilingContainer.apply {
+            let w7 = TestWindow.new(id: 7, parent: $0)
+            var w2: Window!
+            var w9: Window!
+            TilingContainer.newVTiles(parent: $0, adaptiveWeight: 1).apply {
+                w2 = TestWindow.new(id: 2, parent: $0)
+                TilingContainer.newHTiles(parent: $0, adaptiveWeight: 1).apply {
+                    w9 = TestWindow.new(id: 9, parent: $0)
+                }
+            }
+
+            // DFS for this tree is: 7, 2, 9
+            let windows = [
+                AeroObj.window(.forTest(window: w9, title: nil)),
+                AeroObj.window(.forTest(window: w7, title: nil)),
+                AeroObj.window(.forTest(window: w2, title: nil)),
+            ]
+            assertSucc(windows.format([.interVar(.formatVar(.window(.windowDfsIndex)))]), ["2", "0", "1"])
+        }
+    }
+
     func testRunFocusedNoWindow() async {
         let result = await parseCommand("list-windows --focused --format '%{window-id}'").cmdOrDie.run(.defaultEnv, .emptyStdin)
         assertEquals(result.exitCode.rawValue, 2)

--- a/Sources/AppBundleTests/command/TestCommandTest.swift
+++ b/Sources/AppBundleTests/command/TestCommandTest.swift
@@ -22,13 +22,13 @@ final class TestCommandTest: XCTestCase {
                 .copy(\.testArgs.rhs, .initialized("foo")),
         )
 
-        testParseCommandFail("test %{foo} = foo", msg: "ERROR: Can\'t parse \'foo\'.\n       Possible values: (window-id|window-is-fullscreen|window-title|window-layout|window-parent-container-layout|workspace|workspace-is-focused|workspace-is-visible|workspace-root-container-layout|app-bundle-id|app-name|app-pid|app-exec-path|app-bundle-path|monitor-id|monitor-appkit-nsscreen-screens-id|monitor-name|monitor-is-main)", exitCode: 2)
+        testParseCommandFail("test %{foo} = foo", msg: "ERROR: Can\'t parse \'foo\'.\n       Possible values: (window-id|window-dfs-index|window-is-fullscreen|window-title|window-layout|window-parent-container-layout|workspace|workspace-is-focused|workspace-is-visible|workspace-root-container-layout|app-bundle-id|app-name|app-pid|app-exec-path|app-bundle-path|monitor-id|monitor-appkit-nsscreen-screens-id|monitor-name|monitor-is-main)", exitCode: 2)
         testParseCommandFail("test foo = foo", msg: "ERROR: Left hand side must be a single interpolation variable", exitCode: 2)
         testParseCommandFail("test foo%{app-bundle-id} = foo", msg: "ERROR: Left hand side must be a single interpolation variable", exitCode: 2)
         testParseCommandFail("test", msg: "ERROR: Argument \'<lhs>\' is mandatory\nERROR: Argument \'<operator>\' is mandatory\nERROR: Argument \'<rhs>\' is mandatory", exitCode: 2)
         testParseCommandFail("test foo = %{app-bundle-id}", msg: "ERROR: Left hand side must be a single interpolation variable\nERROR: Right hand side doesn\'t allow interpolation variables", exitCode: 2)
         testParseCommandFail("test %{app-bundle-id} = %{app-bundle-id}", msg: "ERROR: Right hand side doesn\'t allow interpolation variables", exitCode: 2)
-        testParseCommandFail("test %{newline} = foo", msg: "ERROR: Can\'t parse \'newline\'.\n       Possible values: (window-id|window-is-fullscreen|window-title|window-layout|window-parent-container-layout|workspace|workspace-is-focused|workspace-is-visible|workspace-root-container-layout|app-bundle-id|app-name|app-pid|app-exec-path|app-bundle-path|monitor-id|monitor-appkit-nsscreen-screens-id|monitor-name|monitor-is-main)", exitCode: 2)
+        testParseCommandFail("test %{newline} = foo", msg: "ERROR: Can\'t parse \'newline\'.\n       Possible values: (window-id|window-dfs-index|window-is-fullscreen|window-title|window-layout|window-parent-container-layout|workspace|workspace-is-focused|workspace-is-visible|workspace-root-container-layout|app-bundle-id|app-name|app-pid|app-exec-path|app-bundle-path|monitor-id|monitor-appkit-nsscreen-screens-id|monitor-name|monitor-is-main)", exitCode: 2)
         testParseCommandFail("test %{window-id} = %{invalid}", msg: "ERROR: Right hand side doesn\'t allow interpolation variables", exitCode: 2)
     }
 

--- a/Sources/Common/cmdArgs/impl/ListWindowsCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/ListWindowsCmdArgs.swift
@@ -178,6 +178,7 @@ public enum FormatVar: RawRepresentable, Equatable, CaseIterable, Sendable {
 
     public enum WindowFormatVar: String, Equatable, CaseIterable, Sendable {
         case windowId = "window-id"
+        case windowDfsIndex = "window-dfs-index"
         case windowIsFullscreen = "window-is-fullscreen"
         case windowTitle = "window-title"
         case windowLayout = "window-layout" // An alias for windowParentContainerLayout

--- a/docs/aerospace-list-windows.adoc
+++ b/docs/aerospace-list-windows.adoc
@@ -77,6 +77,8 @@ If not specified, the default `<output-format>` is: +
 The following variables can be used inside `<output-format>`:
 
 %{window-id}:: Number. Window unique ID
+%{window-dfs-index}:: Number. Window DFS index within the workspace root tiling container.
+Floating and macOS native fullscreen/hidden windows are not part of this index and yield `NULL-WINDOW-DFS-INDEX`.
 %{window-title}:: String. Window title
 %{window-is-fullscreen}:: Boolean. Is window in fullscreen by `aerospace fullscreen` command
 %{window-layout}:: String. An alias for `%{window-parent-container-layout}`

--- a/docs/aerospace-test.adoc
+++ b/docs/aerospace-test.adoc
@@ -49,6 +49,7 @@ The way the expression is interpreted depends on the type of `<lhs>` and the inf
 include::./util/conditional-interpolation-variables-header.adoc[]
 
 %{window-id}:: Number. Window unique ID
+%{window-dfs-index}:: Number. Window DFS index within the workspace root tiling container.
 %{window-title}:: String. Window title
 %{window-is-fullscreen}:: Boolean. Is window in fullscreen by `aerospace fullscreen` command
 %{window-layout}:: String. An alias for `%{window-parent-container-layout}`


### PR DESCRIPTION
## PR checklist

- [x] Explain your changes in the relevant commit messages rather than in the PR description.
- [x] Each commit must explain what/why/how and motivation in its description.
- [x] Dont forget to link the appropriate issues/discussions in commit messages (if applicable).
- [x] Each commit must be an atomic change. Dont introduce new functional changes together with refactorings in the same commit.
- [x] `./test.sh` exits with non-zero exit code.
- [x] Avoid merge commits, always rebase and force push.

Expose %{window-dfs-index} in list-windows so client-side sorting by DFS position becomes possible. This fills the gap where the DFS index used by focus --dfs-index is not exposed in output today.

Related: nikitabobko/AeroSpace#491, nikitabobko/AeroSpace#846, nikitabobko/AeroSpace#16, nikitabobko/AeroSpace#429
