### PR TITLE
fix(balance-sizes): preserve total weight instead of resetting to a constant

### DIFF
--- a/Sources/AppBundle/command/impl/BalanceSizesCommand.swift
+++ b/Sources/AppBundle/command/impl/BalanceSizesCommand.swift
@@ -15,11 +15,21 @@ struct BalanceSizesCommand: Command {
 
 @MainActor
 private func balance(_ parent: TilingContainer) {
+    switch parent.layout {
+        case .tiles:
+            // Redistribute the weights that the container already has, instead of assigning an arbitrary constant.
+            // Weights are only converted to real sizes by the layout pass, which happens once after the whole list of
+            // commands of a binding has run. Preserving the total keeps the weights meaningful for commands that run
+            // later in the same list (e.g. `resize`) https://github.com/nikitabobko/AeroSpace/issues/1837
+            let total = CGFloat(parent.children.sumOfDouble { $0.getWeight(parent.orientation) })
+            if let equalWeight = total.div(parent.children.count) {
+                for child in parent.children {
+                    child.setWeight(parent.orientation, equalWeight)
+                }
+            }
+        case .accordion: break // Do nothing
+    }
     for child in parent.children {
-        switch parent.layout {
-            case .tiles: child.setWeight(parent.orientation, 1)
-            case .accordion: break // Do nothing
-        }
         if let child = child as? TilingContainer {
             balance(child)
         }

--- a/Sources/AppBundleTests/command/BalanceSizesCommandTest.swift
+++ b/Sources/AppBundleTests/command/BalanceSizesCommandTest.swift
@@ -18,8 +18,55 @@ final class BalanceSizesCommandTest: XCTestCase {
         await parseCommand("balance-sizes").cmdOrDie
             .run(.defaultEnv.withWorkspaceName(name), .emptyStdin)
 
+        // The total (1 + 2 + 3) is preserved and split equally
         for window in workspace.rootTilingContainer.children {
-            assertEquals(window.getWeight(workspace.rootTilingContainer.orientation), 1)
+            assertEquals(window.getWeight(workspace.rootTilingContainer.orientation), 2)
         }
+    }
+
+    func testBalanceSizes_nestedContainerPreservesItsOwnTotal() async {
+        var container: TilingContainer!
+        var window1: Window!
+        var window2: Window!
+        var window3: Window!
+        Workspace.get(byName: name).rootTilingContainer.apply {
+            window1 = TestWindow.new(id: 1, parent: $0, adaptiveWeight: 4)
+            container = TilingContainer.newVTiles(parent: $0, adaptiveWeight: 8).apply {
+                window2 = TestWindow.new(id: 2, parent: $0, adaptiveWeight: 1)
+                window3 = TestWindow.new(id: 3, parent: $0, adaptiveWeight: 5)
+            }
+        }
+
+        await parseCommand("balance-sizes").cmdOrDie
+            .run(.defaultEnv.withWorkspaceName(name), .emptyStdin)
+
+        assertEquals(window1.hWeight, 6) // (4 + 8) / 2
+        assertEquals(container.hWeight, 6)
+        assertEquals(window2.vWeight, 3) // (1 + 5) / 2
+        assertEquals(window3.vWeight, 3)
+    }
+
+    // https://github.com/nikitabobko/AeroSpace/issues/1837
+    func testBalanceSizesThenResize_behavesLikeResizeAlone() async {
+        var window1: Window!
+        var window2: Window!
+        var window3: Window!
+        Workspace.get(byName: name).rootTilingContainer.apply {
+            window1 = TestWindow.new(id: 1, parent: $0, adaptiveWeight: 2)
+            window2 = TestWindow.new(id: 2, parent: $0, adaptiveWeight: 4)
+            window3 = TestWindow.new(id: 3, parent: $0, adaptiveWeight: 6)
+        }
+        _ = window1.focusWindow()
+
+        // Both commands run within a single session, so no layout pass normalizes the weights in between
+        await parseCommand("balance-sizes").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        await parseCommand("resize width 6").cmdOrDie.run(.defaultEnv, .emptyStdin)
+
+        // balance-sizes makes it 4, 4, 4. Then diff = 6 - 4 = 2, childDiff = 1
+        assertEquals(window1.hWeight, 6)
+        assertEquals(window2.hWeight, 3)
+        assertEquals(window3.hWeight, 3)
+        // The total is unchanged, so the following layout pass doesn't scale the windows up
+        assertEquals(window1.hWeight + window2.hWeight + window3.hWeight, 12)
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1837. `balance(_:)` assigned a hardcoded weight of `1` to every child, discarding whatever total the container's weights previously summed to.

Weights are only converted to real pixel sizes by the layout pass, which runs once after a whole binding's command list finishes. So when `balance-sizes` and `resize` are chained in the same binding, `resize`'s delta calculation still operates against the pre-existing (larger) weight scale of sibling containers, while the just-balanced children were reset to a tiny constant (`1`) — producing a much wider window than running the same two commands as separate keybind presses.

## Fix

Redistribute the container's existing weight total evenly across its children (`total / children.count`) instead of assigning an arbitrary constant, so later commands in the same list see a consistent scale.

## Test plan

- Updated `testBalanceSizes` (total 1+2+3=6 → each child becomes 2, not the old hardcoded 1)
- Added `testBalanceSizes_nestedContainerPreservesItsOwnTotal`, confirming each nested container's total is redistributed independently
- Added `testBalanceSizesThenResize_behavesLikeResizeAlone`, the regression test for the exact chained-command scenario from the issue

I couldn't run the test suite itself in my environment — `swift test` fails with `error: no such module 'XCTest'`, which I confirmed is pre-existing on a clean `main` checkout with no changes at all (I only have Xcode Command Line Tools, not a full Xcode install). `swift build` (the actual app code) compiles cleanly with this change. Happy to have CI confirm the test suite.