### PR TITLE
Fall back to global edge when local hide corners are blocked

### DIFF
--- a/Sources/AppBundle/layout/refresh.swift
+++ b/Sources/AppBundle/layout/refresh.swift
@@ -148,8 +148,45 @@ func refreshObs(_: AXObserver, _: AXUIElement, notif: CFString, _: UnsafeMutable
     }
 }
 
-enum OptimalHideCorner {
+enum OptimalHideCorner: Equatable {
     case bottomLeftCorner, bottomRightCorner
+    case globalBottomLeftCorner, globalBottomRightCorner
+}
+
+func optimalHideCorner(for monitor: Rect, among monitors: [Rect]) -> OptimalHideCorner {
+    let xOff = monitor.width * 0.1
+    let yOff = monitor.height * 0.1
+    // brc = bottomRightCorner
+    let brc1 = monitor.bottomRightCorner + CGPoint(x: 2, y: -yOff)
+    let brc2 = monitor.bottomRightCorner + CGPoint(x: -xOff, y: 2)
+    let brc3 = monitor.bottomRightCorner + CGPoint(x: 2, y: 2)
+
+    // blc = bottomLeftCorner
+    let blc1 = monitor.bottomLeftCorner + CGPoint(x: -2, y: -yOff)
+    let blc2 = monitor.bottomLeftCorner + CGPoint(x: xOff, y: 2)
+    let blc3 = monitor.bottomLeftCorner + CGPoint(x: -2, y: 2)
+
+    func contains(_ monitor: Rect, _ point: CGPoint) -> Int { monitor.contains(point) ? 1 : 0 }
+    let important = 10
+    let leftScore = monitors.sumOfInt {
+        contains($0, blc1) + contains($0, blc2) + important * contains($0, blc3)
+    }
+    let rightScore = monitors.sumOfInt {
+        contains($0, brc1) + contains($0, brc2) + important * contains($0, brc3)
+    }
+
+    if leftScore == 0 || rightScore == 0 {
+        return leftScore < rightScore ? .bottomLeftCorner : .bottomRightCorner
+    }
+
+    // Both local corners leak into another display. Park at the closest outer
+    // edge of the complete display layout, where macOS can keep only one pixel
+    // visible without exposing the window body on an adjacent monitor.
+    let globalMinX = monitors.map(\.minX).min() ?? monitor.minX
+    let globalMaxX = monitors.map(\.maxX).max() ?? monitor.maxX
+    let leftDistance = monitor.minX - globalMinX
+    let rightDistance = globalMaxX - monitor.maxX
+    return leftDistance < rightDistance ? .globalBottomLeftCorner : .globalBottomRightCorner
 }
 
 @MainActor
@@ -162,29 +199,13 @@ private func layoutWorkspaces() async throws {
         return
     }
     let monitors = monitors
+    let monitorRects = monitors.map(\.rect)
     var monitorToOptimalHideCorner: [CGPoint: OptimalHideCorner] = [:]
     for monitor in monitors {
-        let xOff = monitor.width * 0.1
-        let yOff = monitor.height * 0.1
-        // brc = bottomRightCorner
-        let brc1 = monitor.rect.bottomRightCorner + CGPoint(x: 2, y: -yOff)
-        let brc2 = monitor.rect.bottomRightCorner + CGPoint(x: -xOff, y: 2)
-        let brc3 = monitor.rect.bottomRightCorner + CGPoint(x: 2, y: 2)
-
-        // blc = bottomLeftCorner
-        let blc1 = monitor.rect.bottomLeftCorner + CGPoint(x: -2, y: -yOff)
-        let blc2 = monitor.rect.bottomLeftCorner + CGPoint(x: xOff, y: 2)
-        let blc3 = monitor.rect.bottomLeftCorner + CGPoint(x: -2, y: 2)
-
-        func contains(_ monitor: Monitor, _ point: CGPoint) -> Int { monitor.rect.contains(point) ? 1 : 0 }
-        let important = 10
-
-        let corner: OptimalHideCorner =
-            monitors.sumOfInt { contains($0, blc1) + contains($0, blc2) + important * contains($0, blc3) } <
-            monitors.sumOfInt { contains($0, brc1) + contains($0, brc2) + important * contains($0, brc3) }
-            ? .bottomLeftCorner
-            : .bottomRightCorner
-        monitorToOptimalHideCorner[monitor.rect.topLeftCorner] = corner
+        monitorToOptimalHideCorner[monitor.rect.topLeftCorner] = optimalHideCorner(
+            for: monitor.rect,
+            among: monitorRects,
+        )
     }
 
     // to reduce flicker, first unhide visible workspaces, then hide invisible ones

--- a/Sources/AppBundle/tree/MacWindow.swift
+++ b/Sources/AppBundle/tree/MacWindow.swift
@@ -139,17 +139,23 @@ final class MacWindow: Window {
         }
         let p: CGPoint
         switch corner {
-            case .bottomLeftCorner:
+            case .bottomLeftCorner, .globalBottomLeftCorner:
                 guard let s = try await getAxSize(.cancellable) else { fallthrough }
                 // Zoom will jump off if you do one pixel offset https://github.com/nikitabobko/AeroSpace/issues/527
                 // todo this ad hoc won't be necessary once I implement optimization suggested by Zalim
                 let onePixelOffset = macApp.appId == .zoom ? .zero : CGPoint(x: 1, y: -1)
-                p = nodeMonitor.visibleRect.bottomLeftCorner + onePixelOffset + CGPoint(x: -s.width, y: 0)
-            case .bottomRightCorner:
+                let targetMonitor = corner == .globalBottomLeftCorner
+                    ? monitors.min(by: { ($0.rect.minX, -$0.rect.maxY) < ($1.rect.minX, -$1.rect.maxY) }) ?? nodeMonitor
+                    : nodeMonitor
+                p = targetMonitor.visibleRect.bottomLeftCorner + onePixelOffset + CGPoint(x: -s.width, y: 0)
+            case .bottomRightCorner, .globalBottomRightCorner:
                 // Zoom will jump off if you do one pixel offset https://github.com/nikitabobko/AeroSpace/issues/527
                 // todo this ad hoc won't be necessary once I implement optimization suggested by Zalim
                 let onePixelOffset = macApp.appId == .zoom ? .zero : CGPoint(x: 1, y: 1)
-                p = nodeMonitor.visibleRect.bottomRightCorner - onePixelOffset
+                let targetMonitor = corner == .globalBottomRightCorner
+                    ? monitors.max(by: { ($0.rect.maxX, $0.rect.maxY) < ($1.rect.maxX, $1.rect.maxY) }) ?? nodeMonitor
+                    : nodeMonitor
+                p = targetMonitor.visibleRect.bottomRightCorner - onePixelOffset
         }
         setAxFrame(p, nil)
     }

--- a/Sources/AppBundleTests/layout/HideCornerTest.swift
+++ b/Sources/AppBundleTests/layout/HideCornerTest.swift
@@ -1,0 +1,31 @@
+@testable import AppBundle
+import XCTest
+
+final class HideCornerTest: XCTestCase {
+    private let center = Rect(topLeftX: 0, topLeftY: 0, width: 1920, height: 1080)
+
+    func testPrefersExistingLocalCornerWhenItIsFree() {
+        let right = Rect(topLeftX: 1920, topLeftY: 300, width: 1080, height: 1920)
+        XCTAssertEqual(
+            optimalHideCorner(for: center, among: [center, right]),
+            .bottomLeftCorner,
+        )
+    }
+
+    func testFallsBackToGlobalEdgeWhenBothLocalCornersAreBlocked() {
+        let left = Rect(topLeftX: -1080, topLeftY: 343, width: 1080, height: 1920)
+        let right = Rect(topLeftX: 1920, topLeftY: 299, width: 1080, height: 1920)
+        let builtIn = Rect(topLeftX: 102, topLeftY: 1080, width: 1512, height: 982)
+        XCTAssertEqual(
+            optimalHideCorner(for: center, among: [center, left, right, builtIn]),
+            .globalBottomRightCorner,
+        )
+    }
+
+    func testPreservesBottomRightTieBreakForSingleMonitor() {
+        XCTAssertEqual(
+            optimalHideCorner(for: center, among: [center]),
+            .bottomRightCorner,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- preserve the existing per-monitor hide-corner selection whenever either local bottom corner is free
- fall back to the nearest outer edge of the complete display layout when both local bottom corners overlap other displays
- add focused tests for single-monitor, one-blocked-corner, and both-blocked-corners layouts

## Root cause

macOS requires at least one pixel of a hidden window to remain on-screen. AeroSpace currently parks an invisible workspace at one of its monitor's bottom corners. When both corners are covered by adjacent displays, the selected point can expose most of the hidden window on the neighboring monitor.

The fallback is intentionally limited to that case. Existing valid monitor arrangements continue using their local monitor corner. The global target is calculated from current monitor geometry and `visibleRect`; no display coordinates are hard-coded.

## Validation

- `swift test` (385 tests passed)
- `swift test --filter HideCornerTest`
- tested on a four-display layout where a 1920x1080 center monitor has portrait displays blocking both bottom corners: the hidden window moved from `1919,1079` (visible on the adjacent display) to the computed outer edge `2999,2187`, then restored to `1,0` when its workspace became visible

Related to #149 and #382.
