### PR TITLE
Fix bug: focus can land on a different window of the same app

### DIFF
--- a/Sources/AppBundle/focusCache.swift
+++ b/Sources/AppBundle/focusCache.swift
@@ -11,5 +11,4 @@
         _ = nativeFocused?.focusWindow()
         lastKnownNativeFocusedWindowId = nativeFocused?.windowId
     }
-    nativeFocused?.macAppUnsafe.lastNativeFocusedWindowId = nativeFocused?.windowId
 }

--- a/Sources/AppBundle/tree/MacApp.swift
+++ b/Sources/AppBundle/tree/MacApp.swift
@@ -13,10 +13,10 @@ final class MacApp: AbstractApp {
     private let appAxSubscriptions: ThreadGuardedValue<[AxSubscription]> // keep subscriptions in memory
     private let windows: ThreadGuardedValue<[UInt32: AxWindow]> = .init([:])
     private var windowsCount = 0
-    var lastNativeFocusedWindowId: UInt32? = nil
     private var thread: Thread?
     private var setFrameJobs: [UInt32: RunLoopJob] = [:]
     @MainActor private static var focusJob: RunLoopJob? = nil
+    @MainActor private static var focusVerification: Task<Void, Never>? = nil
 
     /*conforms*/ var name: String? { nsApp.localizedName }
     /*conforms*/ var execPath: String? { nsApp.executableURL?.path }
@@ -128,14 +128,32 @@ final class MacApp: AbstractApp {
     }
 
     @MainActor func nativeFocus(_ windowId: UInt32) {
+        nativeFocus(windowId, allowRetry: true)
+    }
+
+    /// Focusing a window of an app that isn't frontmost is a race: the AX raise says which window
+    /// should be main, and activating the app makes macOS restore whichever window *it* still holds
+    /// as main. When macOS wins, focus lands on a sibling window — sometimes one parked off-screen
+    /// on another workspace, which drags AeroSpace there with it.
+    ///
+    /// The race can't be removed, so it is checked instead: shortly after asking, look at where
+    /// focus actually landed and ask once more if it went to the wrong window of this app.
+    @MainActor private func nativeFocus(_ windowId: UInt32, allowRetry: Bool) {
         if serverArgs.isReadOnly { return }
         MacApp.focusJob?.cancel()
+        MacApp.focusVerification?.cancel()
+        if allowRetry { verifyFocusLanded(on: windowId) }
         // Performance optimization. If possible avoid doing AX requests
         // (important for apps which are slow at responding even such basic AX requests. E.g. Godot)
         // Beware of the macOS bug: https://github.com/nikitabobko/AeroSpace/issues/101
-        if (!NSScreen.screensHaveSeparateSpaces || monitors.count == 1) &&
-            (lastNativeFocusedWindowId == windowId || windowsCount == 1)
-        {
+        //
+        // `activate` focuses whichever window macOS currently considers the app's main one, which
+        // is only the window being asked for when the app has exactly one. The last window AeroSpace
+        // observed as focused used to be accepted as evidence too, but that records an observation,
+        // and the app's main window drifts from it on its own — a background window taking a link,
+        // an app reordering its own windows. Focusing a window of a multi-window app then activated
+        // a different window of the same app, which reads as focus being stolen.
+        if (!NSScreen.screensHaveSeparateSpaces || monitors.count == 1) && windowsCount == 1 {
             nsApp.activate(options: .activateIgnoringOtherApps)
         } else {
             MacApp.focusJob = withWindowAsync(windowId, .cancellable) { [nsApp] window, job in
@@ -144,6 +162,25 @@ final class MacApp: AbstractApp {
                 AXUIElementPerformAction(window, kAXRaiseAction as CFString)
                 nsApp.activate(options: .activateIgnoringOtherApps)
             }
+        }
+    }
+
+    /// Ask the app where focus actually landed, and ask once more if macOS restored a different
+    /// window of its own. Bounded to a single retry: the second attempt runs with `allowRetry`
+    /// false, so a window that genuinely refuses focus can't turn this into a loop.
+    @MainActor private func verifyFocusLanded(on windowId: UInt32) {
+        MacApp.focusVerification = Task.startUnstructured { @MainActor [weak self] in
+            // Long enough for the activation to have settled, short enough that a wrong window
+            // never becomes something you can act on.
+            try? await Task.sleep(for: .milliseconds(150))
+            guard let self, !Task.isCancelled else { return }
+            // Focus moving to a different app is the user, not this bug. Dragging them back would
+            // be the very thing being fixed here.
+            guard self.nsApp.isActive else { return }
+            guard let landed = try? await self.getFocusedWindow(.nonCancellable),
+                  landed.windowId != windowId
+            else { return }
+            self.nativeFocus(windowId, allowRetry: false)
         }
     }
 


### PR DESCRIPTION
## The bug

`focus` on one window of a multi-window app can focus a *different* window of that app. I hit it constantly with two Safari windows; it also pulled the focused workspace along when the window macOS picked was one AeroSpace had parked off-screen on an inactive workspace.

Conditions, which is why it doesn't reproduce for everyone:

- `Displays have separate Spaces` off, **or** a single monitor
- an app with more than one window
- keyboard-driven focus only — a mouse click focuses natively and never enters this path

## Cause

`MacApp.nativeFocus` has a fast path that skips the per-window AX raise and calls `nsApp.activate()` alone:

```swift
if (!NSScreen.screensHaveSeparateSpaces || monitors.count == 1) &&
    (lastNativeFocusedWindowId == windowId || windowsCount == 1)
```

`activate()` focuses whichever window macOS currently holds as the app's main one. `lastNativeFocusedWindowId` records what AeroSpace last *observed*, and the app's main window drifts from that on its own — a background window taking a link, an app reordering its own windows — so the condition isn't evidence that the requested window is the one `activate()` will bring.

The general path has a residual race too: the AX raise says which window should be main, and activating the app makes macOS restore whichever window *it* holds as main.

## The fix

Two parts:

1. The fast path now requires `windowsCount == 1`, where `activate()` can only mean the requested window. It still covers the case it was added for (apps slow to answer AX requests, which are overwhelmingly single-window).
2. The result is verified rather than assumed: 150ms after asking, check the app's focused window and ask once more if it isn't the one requested. Bounded to a single retry, and skipped when the app is no longer frontmost so that focus moving to another app is left alone.

## Measurements

Two Safari windows, focusing a different app between each attempt:

| | failures |
| --- | --- |
| before | 1 in 8 |
| after part 1 only | 1 in 8 |
| after both | 0 in 24 |

`swift test` passes (382 tests).

Happy to split this into two commits, drop the retry and keep only the fast-path fix, or move the discussion to Discussions first if you'd prefer that — just say which.