### PR TITLE
Add --layout filter flag to list-windows

### DIFF
--- a/Sources/AppBundle/command/format.swift
+++ b/Sources/AppBundle/command/format.swift
@@ -234,13 +234,17 @@ func unknownInterpolationVariable(variable: String, _ obj: AeroObj) -> String {
         "Possible values:\n\(getAvailableInterVars(for: obj.kind).joined(separator: "\n").prependLines("  "))"
 }
 
-private func toLayoutString(tc: TilingContainer) -> String {
+private func concreteLayoutDescription(tc: TilingContainer) -> LayoutCmdArgs.LayoutDescription {
     switch (tc.layout, tc.orientation) {
-        case (.tiles, .h): return LayoutCmdArgs.LayoutDescription.h_tiles.rawValue
-        case (.tiles, .v): return LayoutCmdArgs.LayoutDescription.v_tiles.rawValue
-        case (.accordion, .h): return LayoutCmdArgs.LayoutDescription.h_accordion.rawValue
-        case (.accordion, .v): return LayoutCmdArgs.LayoutDescription.v_accordion.rawValue
+        case (.tiles, .h): return .h_tiles
+        case (.tiles, .v): return .v_tiles
+        case (.accordion, .h): return .h_accordion
+        case (.accordion, .v): return .v_accordion
     }
+}
+
+private func toLayoutString(tc: TilingContainer) -> String {
+    concreteLayoutDescription(tc: tc).rawValue
 }
 
 private func toLayoutResult(w: Window) -> Result<Primitive, InterVarExpansionError> {
@@ -255,5 +259,28 @@ private func toLayoutResult(w: Window) -> Result<Primitive, InterVarExpansionErr
 
         case .rootTilingContainer: .failure(.notPossible("Not possible"))
         case .shimContainerRelation: .failure(.windowParentIllegalRelation("Window cannot have a shim container relation"))
+    }
+}
+
+/// Whether `w`'s effective parent-container layout matches `target`. Uses the same
+/// `getChildParentRelation` source of truth as the `%{window-layout` interpolation variable, so
+/// `--layout floating` keeps exactly what `%{window-layout}` prints as `floating`. The `tiling`
+/// token matches every tiling variant; `tiles`/`accordion` match the layout family;
+/// `horizontal`/`vertical` match the orientation; and `h_*`/`v_*` match exactly. Windows with no
+/// parent, an illegal parent relation, or a native/popup relation match nothing.
+func windowMatchesLayout(_ w: Window, _ target: LayoutCmdArgs.LayoutDescription) -> Bool {
+    guard let parent = w.parent else { return false }
+    let relation = getChildParentRelation(child: w, parent: parent)
+    if case .floatingWindow = relation { return target == .floating }
+    guard case .tiling(let tc) = relation else { return false }
+    let concrete = concreteLayoutDescription(tc: tc)
+    if target == concrete { return true }
+    switch target {
+        case .tiling: return true
+        case .tiles: return concrete == .h_tiles || concrete == .v_tiles
+        case .accordion: return concrete == .h_accordion || concrete == .v_accordion
+        case .horizontal: return concrete == .h_tiles || concrete == .h_accordion
+        case .vertical: return concrete == .v_tiles || concrete == .v_accordion
+        default: return false
     }
 }

--- a/Sources/AppBundle/command/impl/ListWindowsCommand.swift
+++ b/Sources/AppBundle/command/impl/ListWindowsCommand.swift
@@ -40,6 +40,10 @@ struct ListWindowsCommand: Command {
             }
         }
 
+        if let layout = args.filteringOptions.layoutFilter {
+            windows = windows.filter { windowMatchesLayout($0, layout) }
+        }
+
         if args.outputOnlyCount {
             return .succ(io.out("\(windows.count)"))
         } else {

--- a/Sources/AppBundleTests/command/ListWindowsTest.swift
+++ b/Sources/AppBundleTests/command/ListWindowsTest.swift
@@ -33,6 +33,16 @@ final class ListWindowsTest: XCTestCase {
         assertNil(parseCommand("list-windows --all --format '%{window-title}' --json").errorOrNil)
     }
 
+    func testParseLayoutFilter() {
+        // Valid tokens parse cleanly
+        assertNil(parseCommand("list-windows --workspace a --layout floating --format '%{window-id}'").errorOrNil)
+        assertNil(parseCommand("list-windows --workspace a --layout tiling --format '%{window-id}'").errorOrNil)
+        assertNil(parseCommand("list-windows --workspace a --layout h_tiles --format '%{window-id}'").errorOrNil)
+        // Invalid token is rejected with the documented error shape
+        let err = parseCommand("list-windows --workspace a --layout bogus --format '%{window-id}'").errorOrNil
+        assertTrue(err?.starts(with: "ERROR: Can't parse '--layout' argument") ?? false)
+    }
+
     func testInterpolationVariablesConsistency() {
         for kind in AeroObjKind.allCases {
             switch kind {
@@ -182,5 +192,19 @@ final class ListWindowsTest: XCTestCase {
         let mismatching = await parseCommand("list-windows --monitor all --app-bundle-id com.unknown.app --format '%{window-id}'").cmdOrDie.run(.defaultEnv, .emptyStdin)
         assertEquals(mismatching.exitCode.rawValue, 0)
         assertEquals(mismatching.stdout, [])
+    }
+
+    func testRunFilterByLayout() async {
+        let workspace = Workspace.get(byName: "a")
+        TestWindow.new(id: 1, parent: workspace.rootTilingContainer) // tiling
+        TestWindow.new(id: 2, parent: workspace.floatingWindowsContainer) // floating
+
+        let floating = await parseCommand("list-windows --workspace a --layout floating --format '%{window-id}'").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(floating.exitCode.rawValue, 0)
+        assertEquals(floating.stdout, ["2"])
+
+        let tiling = await parseCommand("list-windows --workspace a --layout tiling --format '%{window-id}'").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        assertEquals(tiling.exitCode.rawValue, 0)
+        assertEquals(tiling.stdout, ["1"])
     }
 }

--- a/Sources/Common/cmdArgs/impl/ListWindowsCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/ListWindowsCmdArgs.swift
@@ -17,6 +17,7 @@ public struct ListWindowsCmdArgs: CmdArgs {
             "--workspace": ArgParser(\.filteringOptions.workspaces, parseWorkspaces),
             "--pid": singleValueSubArgParser(\.filteringOptions.pidFilter, "<pid>") { Int32($0).toResult("Can't convert to Int32") },
             "--app-bundle-id": singleValueSubArgParser(\.filteringOptions.appIdFilter, "<app-bundle-id>", Result.success),
+            "--layout": ArgParser(\.filteringOptions.layoutFilter, parseLayoutFilter),
 
             // Formatting flags
             "--format": formatParser(\._format, for: .window),
@@ -45,6 +46,7 @@ public struct ListWindowsCmdArgs: CmdArgs {
         public var workspaces: [WorkspaceFilter] = []
         public var pidFilter: Int32?
         public var appIdFilter: String?
+        public var layoutFilter: LayoutCmdArgs.LayoutDescription?
     }
 }
 
@@ -116,6 +118,19 @@ private func parseWorkspaces(input: SubArgParserInput) -> ParsedCliArgs<[Workspa
         i += 1
     }
     return .succ(workspaces, advanceBy: workspaces.count)
+}
+
+private func parseLayoutFilter(input: SubArgParserInput) -> ParsedCliArgs<LayoutCmdArgs.LayoutDescription?> {
+    guard let arg = input.nonFlagArgOrNil() else {
+        return .fail("'\(input.superArg)' must be followed by '<target-layout>'", advanceBy: 0)
+    }
+    guard let layout = LayoutCmdArgs.LayoutDescription(rawValue: arg) else {
+        return .fail(
+            "Can't parse '--layout' argument. Possible values: \(LayoutCmdArgs.LayoutDescription.unionLiteral)",
+            advanceBy: 1,
+        )
+    }
+    return .succ(layout, advanceBy: 1)
 }
 
 public enum WorkspaceFilter: Equatable, Sendable {


### PR DESCRIPTION
Closes #429.

## Summary

Adds a `--layout <layout>` filter flag to `list-windows`, so the command prints only the windows whose effective layout matches — e.g. `list-windows --layout floating` to list only floating windows (the scratchpad use case from #429).

## Problem

`list-windows` currently dumps every window across the target workspaces. #429 asks for a way to filter by the window's effective layout — floating windows in particular — which is useful for scripting and for inspecting how AeroSpace assigned windows to layouts.

## Changes

- `ListWindowsCmdArgs.swift` — new `--layout <target-layout>` argument. It accepts the same layout tokens the `layout` command uses (`floating`, `tiling`, `tiles`, `accordion`, `horizontal`, `vertical`, `h_tiles`, `v_tiles`, `h_accordion`, `v_accordion`); an invalid token fails with `Can't parse '--layout' argument. Possible values: …`.
- `format.swift` — new `windowMatchesLayout` predicate. It derives the window's effective layout through the same `getChildParentRelation` source of truth that backs the `%{window-layout}` interpolation variable, so `--layout floating` keeps exactly what `%{window-layout}` prints as `floating`. The family tokens are inclusive: `tiling` matches every tiling variant, `tiles`/`accordion` match the layout family, `horizontal`/`vertical` match the orientation, and `h_*`/`v_*` match exactly. Windows with no parent or with an illegal/native/popup parent relation match nothing.
- `ListWindowsCommand.swift` — applies the filter before the count/format stage, so `--count` counts only the matching windows too.
- `ListWindowsTest.swift` — new `testParseLayoutFilter` (valid tokens parse; an invalid token is rejected with the documented error) and `testRunFilterByLayout` (one tiling and one floating window in a workspace; each filter returns only the matching window id). Behavior without the flag is unchanged.

## Testing

- [x] `./test.sh` (build + test + lint + generate) — all tests passed.
- [x] The new tests assert the filter returns only matching windows and that omitting the flag preserves the previous output.

## Notes

Live end-to-end verification against real windows needs Accessibility permission and a running session; it is not exercised by the headless gate. The unit tests cover the filter logic; the build + lint + generate gate covers compilation.
