### PR TITLE
Fix bug: on-window-detected 'layout floating' leaves the window at its tile origin

### DIFF
--- a/Sources/AppBundle/layout/layoutRecursive.swift
+++ b/Sources/AppBundle/layout/layoutRecursive.swift
@@ -24,11 +24,13 @@ extension TreeNode {
                 try await workspace.floatingWindowsContainer.layoutRecursive(point, width: width, height: height, virtual: virtual, context)
             case .floatingWindowsContainer(let container):
                 for window in container.children.filterIsInstance(of: Window.self) {
+                    if window.isAwaitingOnWindowDetected { continue }
                     window.lastAppliedLayoutPhysicalRect = nil
                     window.lastAppliedLayoutVirtualRect = nil
                     try await window.layoutFloatingWindow(context)
                 }
             case .window(let window):
+                if window.isAwaitingOnWindowDetected { break }
                 if window.windowId != currentlyManipulatedWithMouseWindowId {
                     lastAppliedLayoutVirtualRect = virtual
                     if window.isFullscreen && window == context.workspace.rootTilingContainer.mostRecentWindowRecursive {
@@ -105,10 +107,19 @@ extension Window {
 }
 
 extension TilingContainer {
+    /// Children that take part in the layout. Windows still awaiting their `on-window-detected`
+    /// callbacks are left out: reserving space for a window that is about to be moved elsewhere
+    /// makes its siblings jump, and the space is handed back a moment later.
+    @MainActor
+    private var layoutChildren: [TreeNode] {
+        children.filter { ($0 as? Window)?.isAwaitingOnWindowDetected != true }
+    }
+
     @MainActor
     fileprivate func layoutTiles(_ point: CGPoint, width: CGFloat, height: CGFloat, virtual: Rect, _ context: LayoutContext) async throws {
         var point = point
         var virtualPoint = virtual.topLeftCorner
+        let children = layoutChildren
 
         guard let delta = ((orientation == .h ? width : height) - CGFloat(children.sumOfDouble { $0.getWeight(orientation) }))
             .div(children.count) else { return }
@@ -142,7 +153,9 @@ extension TilingContainer {
 
     @MainActor
     fileprivate func layoutAccordion(_ point: CGPoint, width: CGFloat, height: CGFloat, virtual: Rect, _ context: LayoutContext) async throws {
-        guard let mruIndex: Int = mostRecentChild?.ownIndex else { return }
+        guard let mostRecentChild else { return }
+        let children = layoutChildren
+        let mruIndex: Int = children.firstIndex { $0 === mostRecentChild } ?? 0
         for (index, child) in children.enumerated() {
             let padding = CGFloat(config.accordionPadding)
             let (lPadding, rPadding): (CGFloat, CGFloat) = switch index {

--- a/Sources/AppBundle/tree/MacWindow.swift
+++ b/Sources/AppBundle/tree/MacWindow.swift
@@ -32,7 +32,9 @@ final class MacWindow: Window {
         // atomic synchronous section
         if let existing = allWindowsMap[windowId] { return existing }
         let window = MacWindow(windowId, macApp, lastFloatingSize: rect?.size, parent: data.parent, adaptiveWeight: data.adaptiveWeight, index: data.index)
+        window.isAwaitingOnWindowDetected = true
         allWindowsMap[windowId] = window
+        defer { window.isAwaitingOnWindowDetected = false }
 
         try await debugWindowsIfRecording(window, .cancellable)
         if try await !restoreClosedWindowsCacheIfNeeded(newlyDetectedWindow: window) {

--- a/Sources/AppBundle/tree/Window.swift
+++ b/Sources/AppBundle/tree/Window.swift
@@ -5,6 +5,11 @@ open class Window: TreeNode, Hashable {
     let windowId: UInt32
     let app: any AbstractApp
     var lastFloatingSize: CGSize?
+    /// The window is already bound to the tree, but its `on-window-detected` callbacks haven't
+    /// run yet. Until they have, its place in the tree isn't settled: a callback may still move it
+    /// to another workspace, or make it floating. Laying it out in the meantime applies geometry
+    /// that is about to be thrown away, and takes space away from its siblings for a frame.
+    var isAwaitingOnWindowDetected: Bool = false
     var isFullscreen: Bool = false
     var noOuterGapsInFullscreen: Bool = false
     var layoutReason: LayoutReason = .standard


### PR DESCRIPTION
Fixes the bug reported in #2016.

@willzeng274 found the same bug in #2024 and reached the same conclusion about where it
happens. That PR has gone stale (it no longer merges cleanly, and its author later reported
they could no longer reproduce it), so this is a fresh branch against current `main`.
What it adds over #2024: a deterministic reproduction, a trace showing which
session does the damage, a measurement of the `checkCancellation()` approach suggested in
that thread, and a fix that also covers `accordion`.

### Reproduction

100% reproducible on `main` (`d56e1637`), macOS 26.5.2, Apple silicon.

This only reproduces if something runs an `aerospace` CLI command while the window opens.
That is why it looks intermittent by hand. `runLightSession` ends with `layoutWorkspaces()`,
so every socket command triggers a layout. A window manager script that polls
`aerospace list-windows` around the window it just opened hits this every time.

Config:

```toml
default-root-container-layout = 'accordion'
accordion-padding = 30
[gaps]
inner.horizontal = 4
inner.vertical = 4

[[on-window-detected]]
if.app-id = 'com.mitchellh.ghostty'
if.window-title-regex-substring = 'Position Test'
run = 'layout floating'
```

Put two windows on the workspace first, so the tiling container has real children. Then,
with a `while :; do aerospace list-windows --focused; sleep 0.05; done` loop running:

```sh
open -na Ghostty --args --title="Position Test" --shell-integration=none \
  --window-width=104 --window-height=20 \
  --window-position-x=860 --window-position-y=531 \
  -e /bin/sleep 60
```

**Expected:** `x:860 y:561 w:840 h:380` — the requested position.
**Actual:** `x:34 y:34 w:840 h:380` — the *tile origin*, with the application's own size.

### Root cause

`MacWindow.getOrRegister` binds the new window into the tiling tree and then suspends:

```swift
allWindowsMap[windowId] = window
try await debugWindowsIfRecording(window, .cancellable)
if try await !restoreClosedWindowsCacheIfNeeded(newlyDetectedWindow: window) {
    await tryOnWindowDetected(window)   // <- suspends; the title matcher does an AX read
}
```

While it is suspended, another session runs `layoutWorkspaces()` and applies tile geometry
to a window whose place in the tree is not settled yet. `LayoutCommand`'s `.floating` case
then does `setAxFrame(nil, size)` — size only — so the tile origin survives.

A trace of one failing launch, session id in `s=`:

```
s=806  register w=9635 ... rect=(860, 561, 840x380)
s=806  onWindowDetected BEGIN w=9635
s=808  layoutWorkspaces BEGIN cancelled=false
s=808  TILE w=9635 -> (34.0, 34.0) 2492.0x1401.0  taskCancelled=false
s=808  TILE w=9621 -> (34.0, 34.0)                     <- sibling shifted to make room
s=806  FLOAT w=9635 restoreSize=(840.0, 380.0)
s=806  onWindowDetected END w=9635 parent=FloatingWindowsContainer
```

`s=808` is a light session from `socketServer: list-windows`.

@nikitabobko, you asked in #2024 whether adding `checkCancellation()` through the layout
recursion fixes this. I implemented that patch against current `main` and measured it: 8
launches, 8 failures, identical to the unpatched baseline. The trace shows why — the
session that applies the tile geometry logs `taskCancelled=false`. It is a fresh,
uncancelled session that started while the registering session was suspended. There is no
cancellation for `checkCancellation()` to observe.

Two notes on the patch as posted: `layoutFullscreen` is not `throws` on current `main`, so
it does not compile as written, and the floating-window loop it patches has since moved to
`floatingWindowsContainer`.

### The fix

Treat "bound to the tree but `on-window-detected` has not run yet" as a state in which the
window is not ready to be laid out, and do not reserve tiling space for it meanwhile. That
second half also removes the sibling shuffle, in both `tiles` and `accordion` — #2024
handled `tiles` only.

21 lines across 3 files.

### Verification

8 launches per build, same machine, same config:

| Build | Correct |
|---|---|
| `main` (`d56e1637`) | 0/8 |
| `main` + `checkCancellation()` through layout | 0/8 |
| this PR | 8/8 |

With this PR the window is never tiled — zero `TILE` lines for it across all 8 launches —
and the siblings keep identical geometry throughout.

`./test.sh` passes on this branch.

A broader fix, closer to #1311, would make a session wait for an in-flight registration
instead of skipping the window. That is a much bigger change. Tell me if you want it that
way.
