### PR TITLE
Insert replaced native-tab windows into their old tree slot

### DIFF
--- a/Sources/AppBundle/focusCache.swift
+++ b/Sources/AppBundle/focusCache.swift
@@ -11,5 +11,10 @@
         _ = nativeFocused?.focusWindow()
         lastKnownNativeFocusedWindowId = nativeFocused?.windowId
     }
-    nativeFocused?.macAppUnsafe.lastNativeFocusedWindowId = nativeFocused?.windowId
+    // Dialogs/sheets (e.g. Finder's "Connect to Server") aren't native-tab group members. Letting
+    // one become the replacement candidate poisons the comparison: it closes normally later, so
+    // whichever tiled window is actually mid-tab-swap when it closes never gets matched.
+    if !(nativeFocused?.parent is FloatingWindowsContainer) {
+        nativeFocused?.macAppUnsafe.lastNativeFocusedWindowId = nativeFocused?.windowId
+    }
 }

--- a/Sources/AppBundle/layout/refresh.swift
+++ b/Sources/AppBundle/layout/refresh.swift
@@ -125,6 +125,7 @@ private func refresh() async throws {
     let mapping = try await MacApp.refreshAllAndGetAliveWindowIds(frontmostAppBundleId: NSWorkspace.shared.frontmostApplication?.bundleIdentifier)
     // A mouse-driven native-tab switch can be observed first by this periodic refresh rather
     // than getFocusedWindow. Preserve the old tree slot before garbage collection removes it.
+    var splicedWindowIds: Set<UInt32> = []
     for (app, refreshResult) in mapping {
         if let replacement = refreshResult.nativeTabReplacement,
            refreshResult.aliveWindowIds.contains(replacement.focusedWindowId)
@@ -134,6 +135,7 @@ private func refresh() async throws {
                 macApp: app,
                 replacingNativeTabWindowId: replacement.staleWindowId,
             )
+            splicedWindowIds.insert(replacement.focusedWindowId)
         }
     }
     let aliveWindowIds = mapping.values.flatMap(\.aliveWindowIds).toSet()
@@ -144,7 +146,7 @@ private func refresh() async throws {
         }
     }
     for (app, refreshResult) in mapping {
-        for windowId in refreshResult.aliveWindowIds {
+        for windowId in refreshResult.aliveWindowIds where !splicedWindowIds.contains(windowId) {
             try await MacWindow.getOrRegister(windowId: windowId, macApp: app)
         }
     }

--- a/Sources/AppBundle/layout/refresh.swift
+++ b/Sources/AppBundle/layout/refresh.swift
@@ -123,15 +123,28 @@ func refreshModel_nonCancellable() async {
 private func refresh() async throws {
     // Garbage collect terminated apps and windows before working with all windows
     let mapping = try await MacApp.refreshAllAndGetAliveWindowIds(frontmostAppBundleId: NSWorkspace.shared.frontmostApplication?.bundleIdentifier)
-    let aliveWindowIds = mapping.values.flatMap(id).toSet()
+    // A mouse-driven native-tab switch can be observed first by this periodic refresh rather
+    // than getFocusedWindow. Preserve the old tree slot before garbage collection removes it.
+    for (app, refreshResult) in mapping {
+        if let replacement = refreshResult.nativeTabReplacement,
+           refreshResult.aliveWindowIds.contains(replacement.focusedWindowId)
+        {
+            _ = try await MacWindow.getOrRegister(
+                windowId: replacement.focusedWindowId,
+                macApp: app,
+                replacingNativeTabWindowId: replacement.staleWindowId,
+            )
+        }
+    }
+    let aliveWindowIds = mapping.values.flatMap(\.aliveWindowIds).toSet()
 
     for window in MacWindow.allWindows {
         if !aliveWindowIds.contains(window.windowId) {
             window.garbageCollect(skipClosedWindowsCache: false)
         }
     }
-    for (app, windowIds) in mapping {
-        for windowId in windowIds {
+    for (app, refreshResult) in mapping {
+        for windowId in refreshResult.aliveWindowIds {
             try await MacWindow.getOrRegister(windowId: windowId, macApp: app)
         }
     }

--- a/Sources/AppBundle/tree/MacApp.swift
+++ b/Sources/AppBundle/tree/MacApp.swift
@@ -118,13 +118,43 @@ final class MacApp: AbstractApp {
 
     // todo merge together with detectNewWindows
     func getFocusedWindow(_ cm: CancellationMode) async throws -> Window? {
-        let windowId = try await thread?.runInLoop(cm) { [nsApp, axApp, windows] job in
-            try axApp.threadGuarded.get(Ax.focusedWindowAttr)
-                .flatMap { try windows.threadGuarded.getOrRegisterAxWindow(windowId: $0.windowId, $0.ax.cast, nsApp, job) }?
-                .windowId
+        // Read on this (the caller's) actor, before hopping to the dedicated AX thread below,
+        // mirroring how lastNativeFocusedWindowId is written in updateFocusCache.
+        let previousFocusedWindowId = lastNativeFocusedWindowId
+        let focused = try await thread?.runInLoop(cm) { [nsApp, axApp, windows, previousFocusedWindowId] job -> (UInt32, UInt32?)? in
+            guard let axFocusedWindow = axApp.threadGuarded.get(Ax.focusedWindowAttr),
+                  let focusedWindow = try windows.threadGuarded.getOrRegisterAxWindow(
+                      windowId: axFocusedWindow.windowId,
+                      axFocusedWindow.ax.cast,
+                      nsApp,
+                      job,
+                  )
+            else {
+                return nil
+            }
+            guard let previousFocusedWindowId,
+                  previousFocusedWindowId != focusedWindow.windowId,
+                  !isLeftMouseButtonDown, // Mirrors the new-window-detection safeguard for tab-drag-out gestures below
+                  windows.threadGuarded[previousFocusedWindowId] != nil
+            else {
+                return (focusedWindow.windowId, nil)
+            }
+            // Apps that fold native tabs into one titlebar (Finder, Ghostty, Fork) keep the old
+            // tab's AX object alive after switching away from it, but drop it from AXWindows.
+            // Scoped to the just-focused-a-moment-ago window only, since that one is guaranteed
+            // to have been on the active Space - a blanket AXWindows/tracked-set intersection
+            // would not be (see windowsAttr's doc comment).
+            guard isMissingFromLiveAxWindows(previousFocusedWindowId, in: axApp.threadGuarded.get(Ax.windowsAttr) ?? []) else {
+                return (focusedWindow.windowId, nil)
+            }
+            windows.threadGuarded.removeValue(forKey: previousFocusedWindowId)
+            return (focusedWindow.windowId, previousFocusedWindowId)
         }
-        guard let windowId else { return nil }
-        return try await MacWindow.getOrRegister(windowId: windowId, macApp: self)
+        guard let (windowId, staleWindowId) = focused else { return nil }
+        if let staleWindowId {
+            setFrameJobs.removeValue(forKey: staleWindowId)?.cancel()
+        }
+        return try await MacWindow.getOrRegister(windowId: windowId, macApp: self, replacingNativeTabWindowId: staleWindowId)
     }
 
     @MainActor func nativeFocus(_ windowId: UInt32) {
@@ -303,9 +333,24 @@ final class MacApp: AbstractApp {
             return []
         }
         guard let thread else { return [] }
-        let (alive, dead) = try await thread.runInLoop(.cancellable) { [nsApp, windows, axApp] (job) -> ([UInt32], [UInt32]) in
+        // Read on this actor before hopping to the dedicated AX thread, same as in getFocusedWindow.
+        let staleTabCandidateId = lastNativeFocusedWindowId
+        let (alive, dead) = try await thread.runInLoop(.cancellable) { [nsApp, windows, axApp, staleTabCandidateId] (job) -> ([UInt32], [UInt32]) in
             var alive: [UInt32: AxWindow] = windows.threadGuarded
             var dead = [UInt32: AxWindow]()
+            let liveWindows = axApp.threadGuarded.get(Ax.windowsAttr) ?? []
+            // Same native-tab-replacement candidate as getFocusedWindow, caught here too so this
+            // periodic refresh (which can run before the focus-change notification that normally
+            // retires it) doesn't flicker the layout by reporting the stale tab as alive.
+            if !isLeftMouseButtonDown,
+               let staleTabCandidateId,
+               alive[staleTabCandidateId] != nil,
+               axApp.threadGuarded.get(Ax.focusedWindowAttr)?.windowId != staleTabCandidateId,
+               isMissingFromLiveAxWindows(staleTabCandidateId, in: liveWindows),
+               let stale = alive.removeValue(forKey: staleTabCandidateId)
+            {
+                dead[staleTabCandidateId] = stale
+            }
             // Second line of defence against lock screen. See the first line of defence: closedWindowsCache
             // Second and third lines of defence are technically needed only to avoid potential flickering
             if frontmostAppBundleId != lockScreenAppBundleId {
@@ -315,7 +360,7 @@ final class MacApp: AbstractApp {
                 }
             }
 
-            for (id, window) in axApp.threadGuarded.get(Ax.windowsAttr) ?? [] {
+            for (id, window) in liveWindows {
                 try job.checkCancellation()
                 try alive.getOrRegisterAxWindow(windowId: id, window, nsApp, job)
             }
@@ -399,6 +444,12 @@ extension [UInt32: AxWindow] {
             return nil
         }
     }
+}
+
+// True if `windowId` is missing from the app's live AXWindows list, i.e. a native-tab
+// window it belonged to was replaced by a sibling tab (see getFocusedWindow).
+private func isMissingFromLiveAxWindows(_ windowId: UInt32, in liveWindows: [WindowIdAndAxUiElement]) -> Bool {
+    !liveWindows.contains { $0.windowId == windowId }
 }
 
 private func getAxRect(window: AXUIElement, job: RunLoopJob) throws -> Rect? {

--- a/Sources/AppBundle/tree/MacApp.swift
+++ b/Sources/AppBundle/tree/MacApp.swift
@@ -364,6 +364,7 @@ final class MacApp: AbstractApp {
             var alive: [UInt32: AxWindow] = windows.threadGuarded
             var dead = [UInt32: AxWindow]()
             let liveWindows = axApp.threadGuarded.get(Ax.windowsAttr) ?? []
+            let liveWindowIds = Set(liveWindows.map(\.windowId))
             let focusedWindowId = axApp.threadGuarded.get(Ax.focusedWindowAttr)?.windowId
             var retiredIds = retiredNativeTabWindowIds.threadGuarded
             if let focusedWindowId {
@@ -373,11 +374,14 @@ final class MacApp: AbstractApp {
             // Same native-tab-replacement candidate as getFocusedWindow, caught here too so this
             // periodic refresh (which can run before the focus-change notification that normally
             // retires it) doesn't flicker the layout by reporting the stale tab as alive.
-            if let focusedWindowId,
+            // liveWindowIds.contains(focusedWindowId): don't retire the old slot until the new
+            // window has actually landed in AXWindows this cycle, else it'd be GC'd with nothing
+            // to take its place (AXFocusedWindow can report it a cycle early).
+            if let focusedWindowId, liveWindowIds.contains(focusedWindowId),
                let staleTabCandidateId = nativeTabReplacementCandidate(
                    previousFocusedWindowId: staleTabCandidateId,
                    focusedWindowId: focusedWindowId,
-                   liveWindowIds: Set(liveWindows.map(\.windowId)),
+                   liveWindowIds: liveWindowIds,
                    trackedWindowIds: Set(alive.keys),
                    isMouseButtonDown: isLeftMouseButtonDown,
                ),
@@ -413,6 +417,11 @@ final class MacApp: AbstractApp {
             return (Array(alive.keys), Array(dead.keys), replacement)
         }
         windowsCount = alive.count
+        if let replacement {
+            // Keep it current for backgrounded apps too, else a second native-tab switch while
+            // still backgrounded would compare against the stale pre-switch id.
+            lastNativeFocusedWindowId = replacement.focusedWindowId
+        }
         for windowId in dead {
             setFrameJobs.removeValue(forKey: windowId)?.cancel()
         }

--- a/Sources/AppBundle/tree/MacApp.swift
+++ b/Sources/AppBundle/tree/MacApp.swift
@@ -518,6 +518,12 @@ func nativeTabReplacementCandidate(
     return previousFocusedWindowId
 }
 
+// The old id is already retired by this point, so a cancelled splice would strand it: it can't
+// be re-proposed, and its tree slot gets GC'd with nothing having replaced it.
+func nativeTabReplacementCancellationMode(replacingNativeTabWindowId: UInt32?) -> CancellationMode {
+    replacingNativeTabWindowId != nil ? .nonCancellable : .cancellable
+}
+
 private func getAxRect(window: AXUIElement, job: RunLoopJob) throws -> Rect? {
     guard let topLeftCorner = window.get(Ax.topLeftCornerAttr) else { return nil }
     try job.checkCancellation()

--- a/Sources/AppBundle/tree/MacApp.swift
+++ b/Sources/AppBundle/tree/MacApp.swift
@@ -1,6 +1,18 @@
 import AppKit
 import Common
 
+struct NativeTabWindowReplacement: Sendable {
+    let focusedWindowId: UInt32
+    let staleWindowId: UInt32
+}
+
+struct MacAppRefreshResult: Sendable {
+    let aliveWindowIds: [UInt32]
+    let nativeTabReplacement: NativeTabWindowReplacement?
+
+    static let empty = MacAppRefreshResult(aliveWindowIds: [], nativeTabReplacement: nil)
+}
+
 // Potential alternative implementation
 // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0392-custom-actor-executors.md
 // (only available since macOS 14)
@@ -12,6 +24,10 @@ final class MacApp: AbstractApp {
     private let axApp: ThreadGuardedValue<AXUIElement>
     private let appAxSubscriptions: ThreadGuardedValue<[AxSubscription]> // keep subscriptions in memory
     private let windows: ThreadGuardedValue<[UInt32: AxWindow]> = .init([:])
+    // Native tabs reuse one visible frame while swapping AX window IDs. Once an ID is replaced,
+    // keep it retired even if AXWindows reports it again transiently; focusing/detaching it makes
+    // it eligible again. Without this memory, periodic refreshes resurrect inactive tabs.
+    private let retiredNativeTabWindowIds: ThreadGuardedValue<Set<UInt32>> = .init([])
     private var windowsCount = 0
     var lastNativeFocusedWindowId: UInt32? = nil
     private var thread: Thread?
@@ -75,6 +91,7 @@ final class MacApp: AbstractApp {
 
                 let appAxSubscriptionsThreadGuarded = app?.appAxSubscriptions
                 let windowsThreadGuarded = app?.windows
+                let retiredNativeTabWindowIdsThreadGuarded = app?.retiredNativeTabWindowIds
                 let axAppThreadGuarded = app?.axApp
 
                 Task.startUnstructured { @MainActor in
@@ -87,6 +104,7 @@ final class MacApp: AbstractApp {
 
                     // Destroy AX objects in reverse order of their creation
                     appAxSubscriptionsThreadGuarded?.destroy()
+                    retiredNativeTabWindowIdsThreadGuarded?.destroy()
                     windowsThreadGuarded?.destroy()
                     axAppThreadGuarded?.destroy()
                 }
@@ -121,7 +139,7 @@ final class MacApp: AbstractApp {
         // Read on this (the caller's) actor, before hopping to the dedicated AX thread below,
         // mirroring how lastNativeFocusedWindowId is written in updateFocusCache.
         let previousFocusedWindowId = lastNativeFocusedWindowId
-        let focused = try await thread?.runInLoop(cm) { [nsApp, axApp, windows, previousFocusedWindowId] job -> (UInt32, UInt32?)? in
+        let focused = try await thread?.runInLoop(cm) { [nsApp, axApp, windows, retiredNativeTabWindowIds, previousFocusedWindowId] job -> (UInt32, UInt32?)? in
             guard let axFocusedWindow = axApp.threadGuarded.get(Ax.focusedWindowAttr),
                   let focusedWindow = try windows.threadGuarded.getOrRegisterAxWindow(
                       windowId: axFocusedWindow.windowId,
@@ -132,22 +150,29 @@ final class MacApp: AbstractApp {
             else {
                 return nil
             }
-            guard let previousFocusedWindowId,
-                  previousFocusedWindowId != focusedWindow.windowId,
-                  !isLeftMouseButtonDown, // Mirrors the new-window-detection safeguard for tab-drag-out gestures below
-                  windows.threadGuarded[previousFocusedWindowId] != nil
-            else {
-                return (focusedWindow.windowId, nil)
-            }
+            var retiredIds = retiredNativeTabWindowIds.threadGuarded
+            // A focused retired tab is either being selected again or was detached into its own
+            // window. In both cases it is visible now and must be managed again.
+            retiredIds.remove(focusedWindow.windowId)
+            retiredNativeTabWindowIds.threadGuarded = retiredIds
+
+            let liveWindowIds = Set((axApp.threadGuarded.get(Ax.windowsAttr) ?? []).map(\.windowId))
+            guard let previousFocusedWindowId = nativeTabReplacementCandidate(
+                previousFocusedWindowId: previousFocusedWindowId,
+                focusedWindowId: focusedWindow.windowId,
+                liveWindowIds: liveWindowIds,
+                trackedWindowIds: Set(windows.threadGuarded.keys),
+                isMouseButtonDown: isLeftMouseButtonDown,
+            ) else { return (focusedWindow.windowId, nil) }
             // Apps that fold native tabs into one titlebar (Finder, Ghostty, Fork) keep the old
             // tab's AX object alive after switching away from it, but drop it from AXWindows.
             // Scoped to the just-focused-a-moment-ago window only, since that one is guaranteed
             // to have been on the active Space - a blanket AXWindows/tracked-set intersection
             // would not be (see windowsAttr's doc comment).
-            guard isMissingFromLiveAxWindows(previousFocusedWindowId, in: axApp.threadGuarded.get(Ax.windowsAttr) ?? []) else {
-                return (focusedWindow.windowId, nil)
-            }
             windows.threadGuarded.removeValue(forKey: previousFocusedWindowId)
+            retiredIds = retiredNativeTabWindowIds.threadGuarded
+            retiredIds.insert(previousFocusedWindowId)
+            retiredNativeTabWindowIds.threadGuarded = retiredIds
             return (focusedWindow.windowId, previousFocusedWindowId)
         }
         guard let (windowId, staleWindowId) = focused else { return nil }
@@ -287,17 +312,17 @@ final class MacApp: AbstractApp {
     }
 
     @MainActor
-    static func refreshAllAndGetAliveWindowIds(frontmostAppBundleId: String?) async throws -> [MacApp: [UInt32]] {
+    static func refreshAllAndGetAliveWindowIds(frontmostAppBundleId: String?) async throws -> [MacApp: MacAppRefreshResult] {
         for (_, app) in MacApp.allAppsMap { // gc dead apps
             try checkCancellation()
             if app.nsApp.isTerminated {
                 await app.destroy()
             }
         }
-        return try await withThrowingTaskGroup(of: (pid_t, [UInt32]).self, returning: [MacApp: [UInt32]].self) { group in
+        return try await withThrowingTaskGroup(of: (pid_t, MacAppRefreshResult).self, returning: [MacApp: MacAppRefreshResult].self) { group in
             func refreshTheApp(_ nsApp: NSRunningApplication) {
                 group.addTask { @Sendable @MainActor in
-                    guard let app = try await MacApp.getOrRegister(nsApp) else { return (nsApp.processIdentifier, []) }
+                    guard let app = try await MacApp.getOrRegister(nsApp) else { return (nsApp.processIdentifier, .empty) }
                     return (nsApp.processIdentifier, try await app.refreshAndGetAliveWindowIds(frontmostAppBundleId: frontmostAppBundleId))
                 }
             }
@@ -317,62 +342,84 @@ final class MacApp: AbstractApp {
                     refreshTheApp(app.nsApp)
                 }
             }
-            var result: [MacApp: [UInt32]] = [:]
-            for try await (pid, windowIds) in group {
+            var result: [MacApp: MacAppRefreshResult] = [:]
+            for try await (pid, refreshResult) in group {
                 if let app = MacApp.allAppsMap[pid] {
-                    result[app] = windowIds
+                    result[app] = refreshResult
                 }
             }
             return result
         }
     }
 
-    private func refreshAndGetAliveWindowIds(frontmostAppBundleId: String?) async throws -> [UInt32] {
+    private func refreshAndGetAliveWindowIds(frontmostAppBundleId: String?) async throws -> MacAppRefreshResult {
         if nsApp.isTerminated {
             await destroy()
-            return []
+            return .empty
         }
-        guard let thread else { return [] }
+        guard let thread else { return .empty }
         // Read on this actor before hopping to the dedicated AX thread, same as in getFocusedWindow.
         let staleTabCandidateId = lastNativeFocusedWindowId
-        let (alive, dead) = try await thread.runInLoop(.cancellable) { [nsApp, windows, axApp, staleTabCandidateId] (job) -> ([UInt32], [UInt32]) in
+        let (alive, dead, replacement) = try await thread.runInLoop(.cancellable) { [nsApp, windows, retiredNativeTabWindowIds, axApp, staleTabCandidateId] (job) -> ([UInt32], [UInt32], NativeTabWindowReplacement?) in
             var alive: [UInt32: AxWindow] = windows.threadGuarded
             var dead = [UInt32: AxWindow]()
             let liveWindows = axApp.threadGuarded.get(Ax.windowsAttr) ?? []
+            let focusedWindowId = axApp.threadGuarded.get(Ax.focusedWindowAttr)?.windowId
+            var retiredIds = retiredNativeTabWindowIds.threadGuarded
+            if let focusedWindowId {
+                retiredIds.remove(focusedWindowId)
+            }
+            var replacement: NativeTabWindowReplacement?
             // Same native-tab-replacement candidate as getFocusedWindow, caught here too so this
             // periodic refresh (which can run before the focus-change notification that normally
             // retires it) doesn't flicker the layout by reporting the stale tab as alive.
-            if !isLeftMouseButtonDown,
-               let staleTabCandidateId,
-               alive[staleTabCandidateId] != nil,
-               axApp.threadGuarded.get(Ax.focusedWindowAttr)?.windowId != staleTabCandidateId,
-               isMissingFromLiveAxWindows(staleTabCandidateId, in: liveWindows),
+            if let focusedWindowId,
+               let staleTabCandidateId = nativeTabReplacementCandidate(
+                   previousFocusedWindowId: staleTabCandidateId,
+                   focusedWindowId: focusedWindowId,
+                   liveWindowIds: Set(liveWindows.map(\.windowId)),
+                   trackedWindowIds: Set(alive.keys),
+                   isMouseButtonDown: isLeftMouseButtonDown,
+               ),
                let stale = alive.removeValue(forKey: staleTabCandidateId)
             {
                 dead[staleTabCandidateId] = stale
+                retiredIds.insert(staleTabCandidateId)
+                replacement = NativeTabWindowReplacement(
+                    focusedWindowId: focusedWindowId,
+                    staleWindowId: staleTabCandidateId,
+                )
             }
             // Second line of defence against lock screen. See the first line of defence: closedWindowsCache
             // Second and third lines of defence are technically needed only to avoid potential flickering
             if frontmostAppBundleId != lockScreenAppBundleId {
-                (alive, dead) = try alive.partition {
+                let (stillAlive, newlyDead) = try alive.partition {
                     try job.checkCancellation()
-                    return $0.value.ax.containingWindowId() != nil
+                    return $0.value.ax.containingWindowId() != nil && !retiredIds.contains($0.key)
+                }
+                alive = stillAlive
+                for (id, window) in newlyDead {
+                    dead[id] = window
                 }
             }
 
-            for (id, window) in liveWindows {
+            for (id, window) in liveWindows where !retiredIds.contains(id) {
                 try job.checkCancellation()
                 try alive.getOrRegisterAxWindow(windowId: id, window, nsApp, job)
             }
 
             windows.threadGuarded = alive
-            return (Array(alive.keys), Array(dead.keys))
+            retiredNativeTabWindowIds.threadGuarded = retiredIds
+            return (Array(alive.keys), Array(dead.keys), replacement)
         }
         windowsCount = alive.count
         for windowId in dead {
             setFrameJobs.removeValue(forKey: windowId)?.cancel()
         }
-        return alive
+        return MacAppRefreshResult(
+            aliveWindowIds: alive,
+            nativeTabReplacement: replacement,
+        )
     }
 
     private func destroy() async {
@@ -446,10 +493,20 @@ extension [UInt32: AxWindow] {
     }
 }
 
-// True if `windowId` is missing from the app's live AXWindows list, i.e. a native-tab
-// window it belonged to was replaced by a sibling tab (see getFocusedWindow).
-private func isMissingFromLiveAxWindows(_ windowId: UInt32, in liveWindows: [WindowIdAndAxUiElement]) -> Bool {
-    !liveWindows.contains { $0.windowId == windowId }
+func nativeTabReplacementCandidate(
+    previousFocusedWindowId: UInt32?,
+    focusedWindowId: UInt32,
+    liveWindowIds: Set<UInt32>,
+    trackedWindowIds: Set<UInt32>,
+    isMouseButtonDown: Bool,
+) -> UInt32? {
+    guard !isMouseButtonDown,
+          let previousFocusedWindowId,
+          previousFocusedWindowId != focusedWindowId,
+          trackedWindowIds.contains(previousFocusedWindowId),
+          !liveWindowIds.contains(previousFocusedWindowId)
+    else { return nil }
+    return previousFocusedWindowId
 }
 
 private func getAxRect(window: AXUIElement, job: RunLoopJob) throws -> Rect? {

--- a/Sources/AppBundle/tree/MacWindow.swift
+++ b/Sources/AppBundle/tree/MacWindow.swift
@@ -16,9 +16,18 @@ final class MacWindow: Window {
 
     @MainActor
     @discardableResult
-    static func getOrRegister(windowId: UInt32, macApp: MacApp) async throws -> MacWindow {
-        if let existing = allWindowsMap[windowId] { return existing }
+    static func getOrRegister(
+        windowId: UInt32,
+        macApp: MacApp,
+        replacingNativeTabWindowId: UInt32? = nil,
+    ) async throws -> MacWindow {
+        if let existing = existingWindowDiscardingStaleReplacement(windowId: windowId, macApp: macApp, replacingNativeTabWindowId: replacingNativeTabWindowId) {
+            return existing
+        }
         let rect = try await macApp.getAxRect(windowId, .cancellable)
+        if let replacement = try await replacementWindowIfApplicable(windowId: windowId, macApp: macApp, rect: rect, staleWindowId: replacingNativeTabWindowId) {
+            return replacement
+        }
         let data = try await unbindAndGetBindingDataForNewWindow(
             windowId,
             macApp,
@@ -30,15 +39,75 @@ final class MacWindow: Window {
         )
 
         // atomic synchronous section
-        if let existing = allWindowsMap[windowId] { return existing }
+        if let existing = existingWindowDiscardingStaleReplacement(windowId: windowId, macApp: macApp, replacingNativeTabWindowId: replacingNativeTabWindowId) {
+            return existing
+        }
+        if let replacement = try await replacementWindowIfApplicable(windowId: windowId, macApp: macApp, rect: rect, staleWindowId: replacingNativeTabWindowId) {
+            return replacement
+        }
         let window = MacWindow(windowId, macApp, lastFloatingSize: rect?.size, parent: data.parent, adaptiveWeight: data.adaptiveWeight, index: data.index)
         allWindowsMap[windowId] = window
+        discardNativeTabWindow(replacingNativeTabWindowId, from: macApp)
 
         try await debugWindowsIfRecording(window, .cancellable)
         if try await !restoreClosedWindowsCacheIfNeeded(newlyDetectedWindow: window) {
             await tryOnWindowDetected(window)
         }
         return window
+    }
+
+    // A replacement tab is the same logical window as the one it replaces, just under a new AX
+    // window id, so it's spliced into the exact tree slot (parent, index, weight, floating size,
+    // fullscreen state, cached layout geometry) the old one occupied, instead of going through
+    // on-window-detected / MRU placement as if it were a newly opened window.
+    @MainActor
+    private static func registerNativeTabReplacement(windowId: UInt32, macApp: MacApp, rect: Rect?, staleWindowId: UInt32?) -> MacWindow? {
+        guard let staleWindowId, let oldWindow = allWindowsMap[staleWindowId], oldWindow.macApp === macApp,
+              let (_, bindingData) = takeNativeTabReplacementBinding(from: oldWindow)
+        else {
+            return nil
+        }
+        allWindowsMap.removeValue(forKey: oldWindow.windowId)
+
+        let window = MacWindow(
+            windowId,
+            macApp,
+            lastFloatingSize: oldWindow.lastFloatingSize ?? rect?.size,
+            parent: bindingData.parent,
+            adaptiveWeight: bindingData.adaptiveWeight,
+            index: bindingData.index,
+        )
+        window.isFullscreen = oldWindow.isFullscreen
+        window.noOuterGapsInFullscreen = oldWindow.noOuterGapsInFullscreen
+        window.layoutReason = oldWindow.layoutReason
+        window.lastAppliedLayoutVirtualRect = oldWindow.lastAppliedLayoutVirtualRect
+        window.lastAppliedLayoutPhysicalRect = oldWindow.lastAppliedLayoutPhysicalRect
+        window.prevUnhiddenProportionalPositionInsideWorkspaceRect = oldWindow.prevUnhiddenProportionalPositionInsideWorkspaceRect
+        allWindowsMap[windowId] = window
+        return window
+    }
+
+    @MainActor
+    private static func discardNativeTabWindow(_ windowId: UInt32?, from macApp: MacApp) {
+        guard let windowId, let window = allWindowsMap[windowId], window.macApp === macApp else { return }
+        allWindowsMap.removeValue(forKey: windowId)
+        if window.isBound {
+            window.unbindFromParent()
+        }
+    }
+
+    @MainActor
+    private static func existingWindowDiscardingStaleReplacement(windowId: UInt32, macApp: MacApp, replacingNativeTabWindowId: UInt32?) -> MacWindow? {
+        guard let existing = allWindowsMap[windowId] else { return nil }
+        discardNativeTabWindow(replacingNativeTabWindowId, from: macApp)
+        return existing
+    }
+
+    @MainActor
+    private static func replacementWindowIfApplicable(windowId: UInt32, macApp: MacApp, rect: Rect?, staleWindowId: UInt32?) async throws -> MacWindow? {
+        guard let replacement = registerNativeTabReplacement(windowId: windowId, macApp: macApp, rect: rect, staleWindowId: staleWindowId) else { return nil }
+        try await debugWindowsIfRecording(replacement, .cancellable)
+        return replacement
     }
 
     // var description: String {
@@ -197,6 +266,12 @@ final class MacWindow: Window {
     override func getAxRect(_ cm: CancellationMode) async throws -> Rect? {
         try await macApp.getAxRect(windowId, cm)
     }
+}
+
+@MainActor
+func takeNativeTabReplacementBinding(from staleWindow: Window?) -> (window: Window, bindingData: BindingData)? {
+    guard let staleWindow, staleWindow.isBound else { return nil }
+    return (staleWindow, staleWindow.unbindFromParent())
 }
 
 extension Window {

--- a/Sources/AppBundle/tree/MacWindow.swift
+++ b/Sources/AppBundle/tree/MacWindow.swift
@@ -24,7 +24,7 @@ final class MacWindow: Window {
         if let existing = existingWindowDiscardingStaleReplacement(windowId: windowId, macApp: macApp, replacingNativeTabWindowId: replacingNativeTabWindowId) {
             return existing
         }
-        let rect = try await macApp.getAxRect(windowId, .cancellable)
+        let rect = try await macApp.getAxRect(windowId, nativeTabReplacementCancellationMode(replacingNativeTabWindowId: replacingNativeTabWindowId))
         if let replacement = try await replacementWindowIfApplicable(windowId: windowId, macApp: macApp, rect: rect, staleWindowId: replacingNativeTabWindowId) {
             return replacement
         }

--- a/Sources/AppBundleTests/tree/NativeTabWindowReplacementTest.swift
+++ b/Sources/AppBundleTests/tree/NativeTabWindowReplacementTest.swift
@@ -1,0 +1,54 @@
+@testable import AppBundle
+import XCTest
+
+@MainActor
+final class NativeTabWindowReplacementTest: XCTestCase {
+    override func setUp() async throws { setUpWorkspacesForTests() }
+
+    func testReplacementPreservesNestedTreeSlotAndWeight() throws {
+        let root = Workspace.get(byName: name).rootTilingContainer
+        let container = TilingContainer.newHTiles(parent: root, adaptiveWeight: 1, index: INDEX_BIND_LAST)
+        TestWindow.new(id: 1, parent: container)
+        let oldWindow = TestWindow.new(id: 2, parent: container, adaptiveWeight: 3)
+        TestWindow.new(id: 3, parent: container)
+
+        let replacement = takeNativeTabReplacementBinding(from: oldWindow)
+        let bindingData = try XCTUnwrap(replacement).bindingData
+        let newWindow = TestWindow.new(id: 4, parent: root)
+        newWindow.bind(
+            to: bindingData.parent,
+            adaptiveWeight: bindingData.adaptiveWeight,
+            index: bindingData.index,
+        )
+
+        assertEquals(container.layoutDescription, .h_tiles([.window(1), .window(4), .window(3)]))
+        assertEquals(newWindow.getWeight(.h), 3)
+    }
+
+    func testNoReplacementWhenStaleWindowIsNil() {
+        let replacement = takeNativeTabReplacementBinding(from: nil)
+        XCTAssertNil(replacement)
+    }
+
+    func testNoReplacementWhenStaleWindowIsAlreadyUnbound() {
+        let root = Workspace.get(byName: name).rootTilingContainer
+        let window = TestWindow.new(id: 1, parent: root)
+        window.unbindFromParent()
+
+        let replacement = takeNativeTabReplacementBinding(from: window)
+
+        XCTAssertNil(replacement)
+    }
+
+    func testReplacementUnbindsExactlyTheGivenWindow() {
+        let root = Workspace.get(byName: name).rootTilingContainer
+        let untouched = TestWindow.new(id: 1, parent: root)
+        let staleWindow = TestWindow.new(id: 2, parent: root)
+
+        let replacement = takeNativeTabReplacementBinding(from: staleWindow)
+
+        XCTAssertNotNil(replacement)
+        XCTAssertTrue(untouched.isBound)
+        XCTAssertFalse(staleWindow.isBound)
+    }
+}

--- a/Sources/AppBundleTests/tree/NativeTabWindowReplacementTest.swift
+++ b/Sources/AppBundleTests/tree/NativeTabWindowReplacementTest.swift
@@ -91,4 +91,12 @@ final class NativeTabWindowReplacementTest: XCTestCase {
             isMouseButtonDown: true,
         ))
     }
+
+    func testReplacementRectFetchIsNonCancellable() {
+        XCTAssertEqual(nativeTabReplacementCancellationMode(replacingNativeTabWindowId: 2), .nonCancellable)
+    }
+
+    func testNewWindowRectFetchStaysCancellable() {
+        XCTAssertEqual(nativeTabReplacementCancellationMode(replacingNativeTabWindowId: nil), .cancellable)
+    }
 }

--- a/Sources/AppBundleTests/tree/NativeTabWindowReplacementTest.swift
+++ b/Sources/AppBundleTests/tree/NativeTabWindowReplacementTest.swift
@@ -51,4 +51,44 @@ final class NativeTabWindowReplacementTest: XCTestCase {
         XCTAssertTrue(untouched.isBound)
         XCTAssertFalse(staleWindow.isBound)
     }
+
+    func testDetectsNativeTabReplacement() {
+        assertEquals(
+            nativeTabReplacementCandidate(
+                previousFocusedWindowId: 1,
+                focusedWindowId: 2,
+                liveWindowIds: [2],
+                trackedWindowIds: [1, 2],
+                isMouseButtonDown: false,
+            ),
+            1,
+        )
+    }
+
+    func testDoesNotReplaceLiveOrUntrackedPreviousWindow() {
+        XCTAssertNil(nativeTabReplacementCandidate(
+            previousFocusedWindowId: 1,
+            focusedWindowId: 2,
+            liveWindowIds: [1, 2],
+            trackedWindowIds: [1, 2],
+            isMouseButtonDown: false,
+        ))
+        XCTAssertNil(nativeTabReplacementCandidate(
+            previousFocusedWindowId: 1,
+            focusedWindowId: 2,
+            liveWindowIds: [2],
+            trackedWindowIds: [2],
+            isMouseButtonDown: false,
+        ))
+    }
+
+    func testDefersNativeTabReplacementWhileDragging() {
+        XCTAssertNil(nativeTabReplacementCandidate(
+            previousFocusedWindowId: 1,
+            focusedWindowId: 2,
+            liveWindowIds: [2],
+            trackedWindowIds: [1, 2],
+            isMouseButtonDown: true,
+        ))
+    }
 }


### PR DESCRIPTION
Fixes #68. Same approach as #2206, scoped to a single stale window per
focus-change instead of reconciling the whole tracked-window set.

## PR checklist

- [x] Explain your changes in the relevant commit messages rather than in the PR description.
- [x] Each commit must explain what/why/how and motivation in its description.
- [x] Don't forget to link the appropriate issues/discussions in commit messages (if applicable).
- [x] Each commit must be an atomic change.
- [x] `./test.sh` exits with zero exit code.
- [x] Avoid merge commits, always rebase and force push.
