### PR TITLE
FocusCommand: fix 'is already unbound' crash when two focus commands race

### DIFF
--- a/Sources/AppBundle/command/impl/FocusCommand.swift
+++ b/Sources/AppBundle/command/impl/FocusCommand.swift
@@ -131,6 +131,9 @@ struct FocusCommand: Command {
     for window in workspace.floatingWindows {
         // todo bug: we shouldn't access ax api here. What if the window was moved but it wasn't committed to ax yet?
         guard let center = try? await window.getCenter(.nonCancellable) else { continue }
+        // getCenter is a suspension point. Another focus command could have unbound the window in the meantime
+        // https://github.com/nikitabobko/AeroSpace/issues/1311
+        guard window.parent === workspace.floatingWindowsContainer else { continue }
 
         let tilingParent: TilingContainer
         let index: Int
@@ -138,6 +141,9 @@ struct FocusCommand: Command {
             .findWindowRecursively(in: workspace.rootTilingContainer, virtual: true, fullscreenCoversAll: false)
         {
             guard let targetCenter = try? await target.getCenter(.nonCancellable) else { continue }
+            // getCenter is a suspension point. Another focus command could have unbound the window in the meantime
+            // https://github.com/nikitabobko/AeroSpace/issues/1311
+            guard window.parent === workspace.floatingWindowsContainer else { continue }
             guard let _tilingParent = target.parent as? TilingContainer else { continue }
             tilingParent = _tilingParent
             index = switch tilingParent.layout {

--- a/Sources/AppBundleTests/command/FocusCommandTest.swift
+++ b/Sources/AppBundleTests/command/FocusCommandTest.swift
@@ -122,6 +122,140 @@ final class FocusCommandTest: XCTestCase {
         assertEquals(focus.windowOrNil?.windowId, 3)
     }
 
+    // https://github.com/nikitabobko/AeroSpace/issues/1311
+    // 'a' is suspended in the first getCenter of makeFloatingWindowsSeenAsTiling, 'b' unbinds the same floating window
+    // meanwhile. Before the fix, 'a' died with "is already unbound" once it was resumed
+    func testConcurrentFocusOverFloatingWindows() async throws {
+        let workspace = Workspace.get(byName: name)
+        let monitorRect = Rect(topLeftX: 0, topLeftY: 0, width: 1920, height: 1080)
+        // The tiling window covers the whole monitor, so that the second getCenter of the loop is reachable too
+        let tiling = TestWindow.new(id: 1, parent: workspace.rootTilingContainer, rect: monitorRect)
+        tiling.lastAppliedLayoutVirtualRect = monitorRect
+        let floating1 = TestWindow.new(id: 2, parent: workspace.floatingWindowsContainer, rect: Rect(topLeftX: 100, topLeftY: 100, width: 200, height: 200))
+        let floating2 = TestWindow.new(id: 3, parent: workspace.floatingWindowsContainer, rect: Rect(topLeftX: 900, topLeftY: 500, width: 200, height: 200))
+        assertEquals(tiling.focusWindow(), true)
+        assertEquals(workspace.floatingWindows.map(\.windowId), [2, 3])
+
+        let aSuspended = AwaitableOneTimeBroadcastLatch()
+        let aResume = AwaitableOneTimeBroadcastLatch()
+        floating1.onNextGetAxRectForTest = {
+            await aSuspended.signalToAll()
+            try await aResume.await()
+        }
+        let a = Task.startUnstructured { _ = await parseCommand("focus right").cmdOrDie.run(.defaultEnv, .emptyStdin) }
+        try await aSuspended.await()
+        assertTrue(floating1.isBound) // 'a' hasn't unbound it yet
+
+        // floating1's hook is already consumed, so 'b' unbinds floating1 and suspends on floating2
+        let bSuspended = AwaitableOneTimeBroadcastLatch()
+        let bResume = AwaitableOneTimeBroadcastLatch()
+        floating2.onNextGetAxRectForTest = {
+            await bSuspended.signalToAll()
+            try await bResume.await()
+        }
+        let b = Task.startUnstructured { _ = await parseCommand("focus right").cmdOrDie.run(.defaultEnv, .emptyStdin) }
+        try await bSuspended.await()
+        assertFalse(floating1.isBound)
+        assertTrue(floating2.isBound)
+
+        await aResume.signalToAll()
+        await a.value
+        await bResume.signalToAll()
+        await b.value
+
+        // Every floating window is bound back, none is lost, duplicated, or left in the tiling tree
+        assertTrue(floating1.parent === workspace.floatingWindowsContainer)
+        assertTrue(floating2.parent === workspace.floatingWindowsContainer)
+        assertEquals(workspace.floatingWindows.map(\.windowId).sorted(), [2, 3])
+        assertEquals(workspace.rootTilingContainer.allLeafWindowsRecursive.map(\.windowId), [1])
+        assertTrue(tiling.parent === workspace.rootTilingContainer)
+    }
+
+    // https://github.com/nikitabobko/AeroSpace/issues/1311
+    // The same race, but 'a' is suspended in the second getCenter of the loop (the AX read of the tiling window it is
+    // about to be inserted next to). That's why both suspension points must re-validate the window
+    func testConcurrentFocusOverFloatingWindows2() async throws {
+        let workspace = Workspace.get(byName: name)
+        let monitorRect = Rect(topLeftX: 0, topLeftY: 0, width: 1920, height: 1080)
+        let tiling = TestWindow.new(id: 1, parent: workspace.rootTilingContainer, rect: monitorRect)
+        tiling.lastAppliedLayoutVirtualRect = monitorRect
+        let floating1 = TestWindow.new(id: 2, parent: workspace.floatingWindowsContainer, rect: Rect(topLeftX: 100, topLeftY: 100, width: 200, height: 200))
+        let floating2 = TestWindow.new(id: 3, parent: workspace.floatingWindowsContainer, rect: Rect(topLeftX: 900, topLeftY: 500, width: 200, height: 200))
+        assertEquals(tiling.focusWindow(), true)
+
+        let aSuspended = AwaitableOneTimeBroadcastLatch()
+        let aResume = AwaitableOneTimeBroadcastLatch()
+        tiling.onNextGetAxRectForTest = {
+            await aSuspended.signalToAll()
+            try await aResume.await()
+        }
+        let a = Task.startUnstructured { _ = await parseCommand("focus right").cmdOrDie.run(.defaultEnv, .emptyStdin) }
+        try await aSuspended.await()
+        assertTrue(floating1.isBound)
+
+        let bSuspended = AwaitableOneTimeBroadcastLatch()
+        let bResume = AwaitableOneTimeBroadcastLatch()
+        floating2.onNextGetAxRectForTest = {
+            await bSuspended.signalToAll()
+            try await bResume.await()
+        }
+        let b = Task.startUnstructured { _ = await parseCommand("focus right").cmdOrDie.run(.defaultEnv, .emptyStdin) }
+        try await bSuspended.await()
+        assertFalse(floating1.isBound)
+
+        await aResume.signalToAll()
+        await a.value
+        await bResume.signalToAll()
+        await b.value
+
+        assertTrue(floating1.parent === workspace.floatingWindowsContainer)
+        assertTrue(floating2.parent === workspace.floatingWindowsContainer)
+        assertEquals(workspace.floatingWindows.map(\.windowId).sorted(), [2, 3])
+        assertEquals(workspace.rootTilingContainer.allLeafWindowsRecursive.map(\.windowId), [1])
+    }
+
+    // https://github.com/nikitabobko/AeroSpace/issues/1311
+    // The workspace from the report, where all the windows are floating. findWindowRecursively finds no tiling window
+    // under the floating window center, so the loop takes the branch that never reaches the second getCenter, and the
+    // first check is the only thing that stands between 'a' and the already unbound window
+    func testConcurrentFocusOverFloatingWindows3() async throws {
+        let workspace = Workspace.get(byName: name)
+        let floating1 = TestWindow.new(id: 1, parent: workspace.floatingWindowsContainer, rect: Rect(topLeftX: 100, topLeftY: 100, width: 200, height: 200))
+        let floating2 = TestWindow.new(id: 2, parent: workspace.floatingWindowsContainer, rect: Rect(topLeftX: 900, topLeftY: 500, width: 200, height: 200))
+        assertEquals(floating1.focusWindow(), true)
+        assertEquals(workspace.rootTilingContainer.allLeafWindowsRecursive.map(\.windowId), [])
+
+        let aSuspended = AwaitableOneTimeBroadcastLatch()
+        let aResume = AwaitableOneTimeBroadcastLatch()
+        floating1.onNextGetAxRectForTest = {
+            await aSuspended.signalToAll()
+            try await aResume.await()
+        }
+        let a = Task.startUnstructured { _ = await parseCommand("focus right").cmdOrDie.run(.defaultEnv, .emptyStdin) }
+        try await aSuspended.await()
+        assertTrue(floating1.isBound)
+
+        let bSuspended = AwaitableOneTimeBroadcastLatch()
+        let bResume = AwaitableOneTimeBroadcastLatch()
+        floating2.onNextGetAxRectForTest = {
+            await bSuspended.signalToAll()
+            try await bResume.await()
+        }
+        let b = Task.startUnstructured { _ = await parseCommand("focus right").cmdOrDie.run(.defaultEnv, .emptyStdin) }
+        try await bSuspended.await()
+        assertFalse(floating1.isBound)
+
+        await aResume.signalToAll()
+        await a.value
+        await bResume.signalToAll()
+        await b.value
+
+        assertTrue(floating1.parent === workspace.floatingWindowsContainer)
+        assertTrue(floating2.parent === workspace.floatingWindowsContainer)
+        assertEquals(workspace.floatingWindows.map(\.windowId).sorted(), [1, 2])
+        assertEquals(workspace.rootTilingContainer.allLeafWindowsRecursive.map(\.windowId), [])
+    }
+
     func testFocusAlongTheContainerOrientation() async {
         Workspace.get(byName: name).rootTilingContainer.apply {
             assertEquals(TestWindow.new(id: 1, parent: $0).focusWindow(), true)

--- a/Sources/AppBundleTests/tree/TestWindow.swift
+++ b/Sources/AppBundleTests/tree/TestWindow.swift
@@ -4,6 +4,9 @@ import AppKit
 final class TestWindow: Window, CustomStringConvertible {
     private var _rect: Rect?
     var isMacosFullscreenForTest = false
+    // In production, getAxRect is a real suspension point (the read is dispatched to the app AX thread), but the mock
+    // returns right away. The hook is reset after the first invocation
+    @MainActor var onNextGetAxRectForTest: (@MainActor () async throws -> ())?
 
     @MainActor
     private init(_ id: UInt32, _ parent: NonLeafTreeNodeObject, _ adaptiveWeight: CGFloat, _ rect: Rect?) {
@@ -34,7 +37,11 @@ final class TestWindow: Window, CustomStringConvertible {
     override func getTitle(_ cm: CancellationMode) async throws -> String { description }
 
     @MainActor override func getAxRect(_ cm: CancellationMode) async throws -> Rect? { // todo change to not Optional
-        _rect
+        if let hook = onNextGetAxRectForTest {
+            onNextGetAxRectForTest = nil
+            try await hook()
+        }
+        return _rect
     }
 
     @MainActor override func getAxSize(_ cm: CancellationMode) async throws -> CGSize? {


### PR DESCRIPTION
Fixes the "MacWindow is already unbound" crash in the `focus` command over floating windows (#1311). Root cause, evidence, and a CLI reproducer are in the commit messages (and in more detail in my comment on #1311).

**Up-front disclosure: this PR — the patch, the tests, and this description — was written by an AI agent (Claude Code) that I operate; I'm the human in the loop.** I root-caused the crash from a production runtime-error dump, the new regression tests crash unpatched sources and pass with the fix, and I've been running the patched build as my daily window manager — the reproducer no longer crashes it. If you'd rather not review AI-authored patches, feel free to close this without comment — the diagnosis on #1311 stands on its own, and whatever you decide to do with this is entirely your call.

## PR checklist

- [x] Explain your changes in the relevant commit messages rather than in the PR description. The PR description must not contain more information than the commit messages (except for images and other media).
- [x] Each commit must explain what/why/how and motivation in its description. https://cbea.ms/git-commit/
- [x] Don't forget to link the appropriate issues/discussions in commit messages (if applicable).
- [x] Each commit must be an atomic change (a PR may contain several commits). Don't introduce new functional changes together with refactorings in the same commit.
- [x] `./test.sh` exits with non-zero exit code.
- [x] Avoid merge commits, always rebase and force push.
