### PR TITLE
Add configurable image-style menu bar sizes

### DIFF
--- a/Sources/AppBundle/ui/ExperimentalUISettings.swift
+++ b/Sources/AppBundle/ui/ExperimentalUISettings.swift
@@ -13,6 +13,11 @@ struct ExperimentalUISettings {
             UserDefaults.standard.synchronize()
         }
     }
+
+    var size: MenuBarSize {
+        get { UserDefaults.standard.string(forKey: ExperimentalUISettingsItems.size.rawValue).flatMap(MenuBarSize.init) ?? .large }
+        set { UserDefaults.standard.setValue(newValue.rawValue, forKey: ExperimentalUISettingsItems.size.rawValue) }
+    }
 }
 
 enum MenuBarStyle: String, CaseIterable, Identifiable, Equatable, Hashable {
@@ -33,8 +38,25 @@ enum MenuBarStyle: String, CaseIterable, Identifiable, Equatable, Hashable {
     }
 }
 
+enum MenuBarSize: String, CaseIterable, Identifiable {
+    case small
+    case medium
+    case large
+
+    var id: String { rawValue }
+    var pointSize: CGFloat {
+        switch self {
+            case .small: 24
+            case .medium: 32
+            case .large: 40
+        }
+    }
+    var title: String { rawValue.capitalized }
+}
+
 enum ExperimentalUISettingsItems: String {
     case displayStyle
+    case size
 }
 
 @MainActor
@@ -44,6 +66,14 @@ func getExperimentalUISettingsMenu(viewModel: TrayMenuModel) -> some View {
         Text("Menu bar style (macOS 14 or later):")
         ForEach(MenuBarStyle.allCases, id: \.id) { style in
             MenuBarStyleButton(style: style, color: color).environmentObject(viewModel)
+        }
+        Picker("Image style size", selection: Binding(
+            get: { viewModel.experimentalUISettings.size },
+            set: { viewModel.experimentalUISettings.size = $0 },
+        )) {
+            ForEach(MenuBarSize.allCases) { size in
+                Text(size.title).tag(size)
+            }
         }
     } label: {
         Text("Experimental UI Settings (No stability guarantees)")

--- a/Sources/AppBundle/ui/MenuBarLabel.swift
+++ b/Sources/AppBundle/ui/MenuBarLabel.swift
@@ -9,10 +9,11 @@ struct MenuBarLabel: View {
     let color: Color?
     let style: MenuBarStyle?
 
-    let hStackSpacing = CGFloat(6)
-    let itemSize = CGFloat(40)
-    let itemBorderSize = CGFloat(3)
-    let itemCornerRadius = CGFloat(6)
+    private var itemSize: CGFloat { viewModel.experimentalUISettings.size.pointSize }
+    private var hStackSpacing: CGFloat { itemSize * 0.15 }
+    private var itemBorderSize: CGFloat { itemSize * 0.075 }
+    private var itemCornerRadius: CGFloat { itemSize * 0.15 }
+    private var itemFontSize: CGFloat { itemSize * 0.65 }
 
     private var finalColor: Color {
         return color ?? (menuColorScheme == .dark ? Color.white : Color.black)
@@ -90,7 +91,7 @@ struct MenuBarLabel: View {
     private func otherWorkspaces(with otherWorkspaces: [WorkspaceViewModel]) -> some View {
         Group {
             Text("|")
-                .font(.system(.largeTitle))
+                .font(.system(size: itemFontSize))
                 .foregroundStyle(finalColor)
                 .bold()
                 .padding(.bottom, 6)
@@ -103,7 +104,7 @@ struct MenuBarLabel: View {
 
     private func modeSeparator(with design: Font.Design) -> some View {
         Text(":")
-            .font(.system(.largeTitle, design: design))
+            .font(.system(size: itemFontSize, design: design))
             .foregroundStyle(finalColor)
             .bold()
     }
@@ -129,7 +130,7 @@ struct MenuBarLabel: View {
         // If workspace name contains emojis we use the plain emoji in text to avoid visibility issues scaling the emoji to fit the squares
         if item.name.containsEmoji() {
             Text(item.name)
-                .font(.system(.largeTitle))
+                .font(.system(size: itemFontSize))
                 .foregroundStyle(finalColor)
                 .frame(height: itemSize)
         } else {
@@ -142,7 +143,7 @@ struct MenuBarLabel: View {
                     .frame(width: itemSize, height: itemSize)
             } else {
                 let text = Text(item.name)
-                    .font(.system(.largeTitle))
+                    .font(.system(size: itemFontSize))
                     .bold()
                     .padding(.horizontal, itemBorderSize * 2)
                     .frame(height: itemSize)

--- a/Sources/AppBundle/util/AxUiElementMock.swift
+++ b/Sources/AppBundle/util/AxUiElementMock.swift
@@ -1,5 +1,4 @@
 import AppKit
-import Common
 
 /// Alternative name: AttrAddressibleStorage
 protocol AxUiElementMock {

--- a/Sources/AppBundleTests/MenuBarSizeTest.swift
+++ b/Sources/AppBundleTests/MenuBarSizeTest.swift
@@ -1,0 +1,41 @@
+@testable import AppBundle
+import XCTest
+
+final class MenuBarSizeTest: XCTestCase {
+    private let defaults = UserDefaults.standard
+    private let key = ExperimentalUISettingsItems.size.rawValue
+    private var previousValue: Any?
+
+    override func setUp() {
+        previousValue = defaults.object(forKey: key)
+        defaults.removeObject(forKey: key)
+    }
+
+    override func tearDown() {
+        if let previousValue {
+            defaults.set(previousValue, forKey: key)
+        } else {
+            defaults.removeObject(forKey: key)
+        }
+    }
+
+    func testPointSizes() {
+        assertEquals(MenuBarSize.small.pointSize, 24)
+        assertEquals(MenuBarSize.medium.pointSize, 32)
+        assertEquals(MenuBarSize.large.pointSize, 40)
+    }
+
+    func testDefaultsToLarge() {
+        assertEquals(ExperimentalUISettings().size, .large)
+        defaults.set("invalid", forKey: key)
+        assertEquals(ExperimentalUISettings().size, .large)
+    }
+
+    func testSelectionPersists() {
+        var settings = ExperimentalUISettings()
+        for size in MenuBarSize.allCases {
+            settings.size = size
+            assertEquals(ExperimentalUISettings().size, size)
+        }
+    }
+}


### PR DESCRIPTION
Add persistent Small, Medium, and Large choices for the image-based menu bar styles. Scale Square images, i3 grouped, and i3 ordered while preserving the existing text-style typography and Large dimensions.

## Screenshots

### Setting

<img width="797" height="643" alt="Image style size setting" src="https://github.com/user-attachments/assets/c483be5c-aaa8-4aa1-a3a1-ae5ec6a6aaa5" />

### Small
<img width="248" height="31" alt="Screenshot 2026-08-18 at 15 37 22" src="https://github.com/user-attachments/assets/928bfe7f-0370-4f80-993e-f2a6b6e53df1" />


### Medium
<img width="252" height="30" alt="Screenshot 2026-08-18 at 15 37 30" src="https://github.com/user-attachments/assets/33882496-eede-4423-9de5-00666e2ee4a7" />


### Large
<img width="266" height="30" alt="Screenshot 2026-08-18 at 15 37 38" src="https://github.com/user-attachments/assets/6b8726eb-a68e-4b01-9b4f-6e9c0973512a" />


## PR checklist

- [x] Explain your changes in the relevant commit messages rather than in the PR description. The PR description must not contain more information than the commit messages (except for images and other media).
- [x] Each commit must explain what/why/how and motivation in its description. https://cbea.ms/git-commit/
- [x] Don't forget to link the appropriate issues/discussions in commit messages (if applicable).
- [x] Each commit must be an atomic change (a PR may contain several commits). Don't introduce new functional changes together with refactorings in the same commit.
- [x] `./test.sh` exits with non-zero exit code.
- [x] Avoid merge commits, always rebase and force push.
