### PR TITLE
Fix crash: cache isUnitTest instead of calling NSClassFromString on hot path

### DIFF
--- a/Sources/Common/util/commonUtil.swift
+++ b/Sources/Common/util/commonUtil.swift
@@ -148,7 +148,13 @@ public func check(
     }
 }
 
-public var isUnitTest: Bool { NSClassFromString("XCTestCase") != nil }
+// Whether the process is a unit test bundle cannot change during the process
+// lifetime, so resolve it once. `isUnitTest` is read on hot paths (e.g. every
+// `mainMonitorInfo` / `monitorInfos` access via `rearrangeWorkspacesOnMonitors`),
+// and calling `NSClassFromString` there has been observed to crash with
+// EXC_BAD_ACCESS inside the dyld objc class lookup during display
+// reconfiguration. Caching the value removes that call from the hot path.
+public let isUnitTest: Bool = NSClassFromString("XCTestCase") != nil
 
 extension CaseIterable where Self: RawRepresentable, RawValue == String {
     public static var cliArgsCases: [String] { allCases.map(\.rawValue) }


### PR DESCRIPTION
## Problem

`isUnitTest` is a computed property that calls `NSClassFromString("XCTestCase")` on **every** access:

```swift
public var isUnitTest: Bool { NSClassFromString("XCTestCase") != nil }
```

It is read on hot paths — `mainMonitorInfo` and `monitorInfos` both start with `isUnitTest ? testMonitor : ...`, and those are walked by `rearrangeWorkspacesOnMonitors()` → `getStubWorkspace(forPoint:)` → `workspaceMonitor` → `monitorApproximation` on every workspace rearrangement.

On a multi-monitor setup this crashes with `EXC_BAD_ACCESS` inside the dyld objc class lookup during display reconfiguration. Observed crashing thread (release build, v0.21.3-Beta base):

```
objc::ObjectHashTable::forEachObject(...)
dyld4::APIs::_dyld_for_each_objc_class(...)
getPreoptimizedClass
look_up_class
NSClassFromString
isUnitTest.getter
mainMonitor.getter
monitors.getter
CGPoint.monitorApproximation.getter
Workspace.workspaceMonitor.getter
getStubWorkspace(forPoint:)
rearrangeWorkspacesOnMonitors()
Monitor.activeWorkspace.getter   (× several — see note below)
updateTrayText()
runLightSession(...)   ← spawned from the unix socket server on a workspace command
```

Because AeroSpace is restarted by its launch agent after the crash, and the crash happens *mid-rearrange* (after some `setActiveWorkspace` calls), the user-visible symptom is a monitor's visible workspace unexpectedly jumping to a neighbor when switching workspaces on another monitor.

## Fix

Whether the process is a unit-test bundle cannot change at runtime, so resolve it once into a global `let`. This removes `NSClassFromString` from the hot path while preserving identical behavior. Global `let`s in Swift are lazily initialized on first access, so test bundles still resolve it correctly.

## Note (not addressed here)

The same stack shows `Monitor.activeWorkspace.getter` recursing several times. Its own comment says recursion should happen "only once more … Unless monitor configuration data race happens" ([Workspace.swift](https://github.com/nikitabobko/AeroSpace/blob/main/Sources/AppBundle/tree/Workspace.swift)). The multiple frames suggest that data race does occur during display reconfiguration. That is a separate, larger issue and is left for a maintainer decision; this PR only removes the crashing `NSClassFromString` call from the hot path.

## Testing

I was not able to build locally as part of this change. The change is a mechanical `var`→`let` conversion of a value that is constant for the process lifetime and is never assigned anywhere in the tree (verified). Happy to iterate.
