### PR TITLE
fix bug: focus-follows-mouse steals focus from macOS Control Center and SystemUIServer dropdowns

### DIFF
--- a/Sources/AppBundle/mouse/focusFollowsMouse.swift
+++ b/Sources/AppBundle/mouse/focusFollowsMouse.swift
@@ -23,6 +23,14 @@ import AppKit
         focusFollowsTask?.cancel()
         focusFollowsTask = Task.startUnstructured { @MainActor in
             guard let token: RunSessionGuard = .isServerEnabled else { return }
+
+            if let frontmostApp = NSWorkspace.shared.frontmostApplication {
+                let bundleId = frontmostApp.bundleIdentifier
+                if bundleId == "com.apple.controlcenter" || bundleId == "com.apple.systemuiserver" {
+                    return
+                }
+            }
+
             try checkCancellation()
             // Ignores macOS menubar dropdown, but, unfortunately, it doesn't ignore non-native menu-like fake windows.
             // todo: It would be cool to somehow reuse isWindowHeuristic logic here


### PR DESCRIPTION
## Problem

When `focus-follows-mouse.enabled = true`, attempting to click items in the macOS Control Center (like the Wi-Fi or Bluetooth dropdown) or the system menu bar often fails. Because the mouse cursor passes over or rests on top of AeroSpace-managed windows underneath the dropdown, AeroSpace instantly refocuses those windows. macOS is designed to auto-dismiss the Control Center the moment it loses focus, causing the dropdown to vanish before the user can interact with it.

## Fix

Inject a guard check inside `focusFollowsMouseMonitor` before evaluating the `AXUIElement`. We check `NSWorkspace.shared.frontmostApplication?.bundleIdentifier`. If the active foreground application is `com.apple.controlcenter` or `com.apple.systemuiserver`, we return early and skip the focus check. 

This prevents AeroSpace from stealing focus while the user is actively interacting with macOS system overlays, natively solving one of the most frustrating quirks of `focus-follows-mouse` without relying on visual gap workarounds.

## Testing

- [x] Tested locally by compiling the `AeroSpaceApp` release binary. Hovering over a terminal window while clicking the Wi-Fi dropdown now allows the menu to stay open indefinitely without focus stealing.
- [x] Verified `./test.sh` runs and exits with a successful `0` exit code.

<hr>

## PR checklist

- [x] Explain your changes in the relevant commit messages rather than in the PR description. The PR description must not contain more information than the commit messages (except for images and other media).
- [x] Each commit must explain what/why/how and motivation in its description. https://cbea.ms/git-commit/
- [x] Don't forget to link the appropriate issues/discussions in commit messages (if applicable).
- [x] Each commit must be an atomic change (a PR may contain several commits). Don't introduce new functional changes together with refactorings in the same commit.
- [x] `./test.sh` exits with non-zero exit code.
- [x] Avoid merge commits, always rebase and force push.
