### PR TITLE
Add menu-bar-item config option to hide the menu bar item

### DIFF
--- a/Sources/AppBundle/config/Config.swift
+++ b/Sources/AppBundle/config/Config.swift
@@ -41,6 +41,7 @@ struct Config: ConvenienceMutable {
     var _nonEmptyWorkspacesRootContainersLayoutOnStartup: Void = ()
     var defaultRootContainerLayout: Layout = .tiles
     var defaultRootContainerOrientation: DefaultContainerOrientation = .auto
+    var menuBarItem: Bool = true
     var startAtLogin: Bool = false
     var autoReloadConfig: Bool = false
     var automaticallyUnhideMacosHiddenApps: Bool = false

--- a/Sources/AppBundle/config/parseConfig.swift
+++ b/Sources/AppBundle/config/parseConfig.swift
@@ -141,6 +141,7 @@ private let configParser: [String: any ParserProtocol<Config>] = [
 
     "default-root-container-layout": Parser(\.defaultRootContainerLayout, parseLayout),
     "default-root-container-orientation": Parser(\.defaultRootContainerOrientation, parseDefaultContainerOrientation),
+    "menu-bar-item": Parser(\.menuBarItem, parseBool),
 
     "start-at-login": Parser(\.startAtLogin, parseBool),
     "auto-reload-config": Parser(\.autoReloadConfig, parseBool),

--- a/Sources/AppBundle/ui/MenuBar.swift
+++ b/Sources/AppBundle/ui/MenuBar.swift
@@ -72,17 +72,27 @@ public func menuBar(viewModel: TrayMenuModel) -> some Scene { // todo should it 
             }
         }.keyboardShortcut("Q", modifiers: .command)
     } label: {
-        switch (viewModel.axPermissionStatus, viewModel.isEnabled) {
-            case (.granted, true):
-                MenuBarLabel().environmentObject(viewModel)
-            case (.granted, false):
-                Image(systemName: "pause.circle.fill")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-            case (_, _):
-                Image(systemName: "exclamationmark.triangle.fill")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
+        // `menu-bar-item = false` collapses AeroSpace's menu bar item to a single compact
+        // icon (instead of the workspace readout). The MenuBarExtra scene must stay
+        // present — it's the app's only scene, and removing it terminates the app — so
+        // a full removal isn't possible; the compact icon is the minimal footprint.
+        if !viewModel.menuBarItemIsShown {
+            Image(systemName: "square.split.2x2")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+        } else {
+            switch (viewModel.axPermissionStatus, viewModel.isEnabled) {
+                case (.granted, true):
+                    MenuBarLabel().environmentObject(viewModel)
+                case (.granted, false):
+                    Image(systemName: "pause.circle.fill")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                case (_, _):
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+            }
         }
     }
 }

--- a/Sources/AppBundle/ui/TrayMenuModel.swift
+++ b/Sources/AppBundle/ui/TrayMenuModel.swift
@@ -8,6 +8,11 @@ public final class TrayMenuModel: ObservableObject {
 
     @Published var trayText: String = ""
     @Published var trayItems: [TrayItem] = []
+    /// Whether AeroSpace shows its workspace readout in the menu bar. Driven by the
+    /// `menu-bar-item` config key (see updateTrayText). When false, the menu bar item
+    /// collapses to a single compact icon (it can't be removed outright — it's the
+    /// app's only scene). For people who already run their own indicator (SketchyBar).
+    @Published var menuBarItemIsShown: Bool = true
     /// Is "layouting" enabled
     @Published var isEnabled: Bool = true
     @Published var workspaces: [WorkspaceViewModel] = []
@@ -24,6 +29,9 @@ enum AxPermissionStatus: Equatable {
 }
 
 @MainActor func updateTrayText() {
+    if TrayMenuModel.shared.menuBarItemIsShown != config.menuBarItem {
+        TrayMenuModel.shared.menuBarItemIsShown = config.menuBarItem
+    }
     let sortedMonitors = sortedMonitorInfos
     let focus = focus
     TrayMenuModel.shared.trayText = (activeMode?.takeIf { $0 != mainModeId }?.first.map { "(\($0.uppercased())) " } ?? "") +

--- a/Sources/AppBundleTests/config/ConfigTest.swift
+++ b/Sources/AppBundleTests/config/ConfigTest.swift
@@ -29,6 +29,22 @@ final class ConfigTest: XCTestCase {
         assertEquals(result.warnings, [])
     }
 
+    func testParseMenuBarItem() {
+        // default is true (menu bar item shown)
+        assertEquals(defaultConfig.menuBarItem, true)
+
+        let hidden = parseConfig("menu-bar-item = false")
+        assertEquals(hidden.errors, [])
+        assertEquals(hidden.config.menuBarItem, false)
+
+        let shown = parseConfig("menu-bar-item = true")
+        assertEquals(shown.errors, [])
+        assertEquals(shown.config.menuBarItem, true)
+
+        let invalid = parseConfig("menu-bar-item = 'nonsense'")
+        assertTrue(!invalid.errors.isEmpty)
+    }
+
     func testConfigVersionOutOfBounds() {
         let result = parseConfig(
             """

--- a/docs/config-examples/default-config.toml
+++ b/docs/config-examples/default-config.toml
@@ -34,6 +34,13 @@ default-root-container-layout = 'tiles'
 #               tall monitor (anything higher than wide) gets vertical orientation
 default-root-container-orientation = 'auto'
 
+# Whether AeroSpace shows its workspace readout in the macOS menu bar.
+# Set to false if you use a separate workspace indicator (e.g. SketchyBar) and
+# don't want the duplicate. AeroSpace's menu bar item can't be removed entirely
+# (it's the app's only scene, and removing it would terminate AeroSpace), so
+# false collapses it to a single compact icon instead of the workspace readout.
+menu-bar-item = true
+
 # Mouse follows focus when focused monitor changes
 # Drop it from your config, if you don't like this behavior
 # See https://nikitabobko.github.io/AeroSpace/guide#on-focus-changed-callbacks


### PR DESCRIPTION
## Summary

AeroSpace always shows its own item in the macOS menu bar (the per-monitor workspace readout, e.g. `1 │ 2 │ *3`). Users who already run a separate workspace indicator — [SketchyBar](https://github.com/FelixKratz/SketchyBar), a waybar-style bar, etc. — end up with a duplicate they can't turn off from config.

This adds an opt-in config option to hide it:

```toml
menu-bar-item = true   # default, unchanged
menu-bar-item = false  # remove AeroSpace's menu bar item entirely
```

## How it works

- New top-level `menu-bar-item` bool on `Config` (default `true`), parsed with the existing `parseBool`.
- `TrayMenuModel` gets a `@Published var menuBarItemIsShown`, which `updateTrayText()` keeps in sync with `config.menuBarItem`.
- The `MenuBarExtra` scene is created with the `isInserted:` initializer bound to `menuBarItemIsShown`. Setting it `false` removes the item from the menu bar entirely.

Because `updateTrayText()` runs on every session refresh, the item appears/disappears **live on `reload-config`** — no relaunch needed.

Default is `true`, so behavior is unchanged unless the option is opted into.

## Test plan

- `swift build` — clean.
- `swift test` — all pass, incl. a new `testParseMenuBarItem` (default `true`, parses `true`/`false`, rejects a non-bool).
- `./lint.sh` — SwiftFormat clean, no unused code.
- Manually: with `menu-bar-item = false`, AeroSpace's menu bar item is gone; toggling back to `true` + `reload-config` brings it back without relaunch.

## Files

- `Sources/AppBundle/config/Config.swift` — the config field
- `Sources/AppBundle/config/parseConfig.swift` — registry entry
- `Sources/AppBundle/ui/TrayMenuModel.swift` — published flag + sync in `updateTrayText`
- `Sources/AppBundle/ui/MenuBar.swift` — `MenuBarExtra(isInserted:)`
- `Sources/AppBundleTests/config/ConfigTest.swift` — `testParseMenuBarItem`
- `docs/config-examples/default-config.toml` — documented default