### PR TITLE
Make non-empty-workspaces-root-containers-layout-on-startup a functional tiles|accordion|smart selector

### DIFF
--- a/Sources/AppBundle/config/Config.swift
+++ b/Sources/AppBundle/config/Config.swift
@@ -38,7 +38,7 @@ struct Config: ConvenienceMutable {
     var afterStartupCommand: Shell<any Command> = .empty
     var _indentForNestedContainersWithTheSameOrientation: Void = ()
     var enableNormalizationFlattenContainers: Bool = true
-    var _nonEmptyWorkspacesRootContainersLayoutOnStartup: Void = ()
+    var nonEmptyWorkspacesRootContainersLayoutOnStartup: NonEmptyWorkspacesRootContainersLayoutOnStartup = .smart
     var defaultRootContainerLayout: Layout = .tiles
     var defaultRootContainerOrientation: DefaultContainerOrientation = .auto
     var startAtLogin: Bool = false
@@ -80,4 +80,13 @@ enum ConfigVersion: Int, Comparable, CaseIterable, Sendable, CustomStringConvert
 
 enum DefaultContainerOrientation: String {
     case horizontal, vertical, auto
+}
+
+enum NonEmptyWorkspacesRootContainersLayoutOnStartup: String {
+    /// Root of every non-empty workspace tiles at startup (i3/sway-like).
+    case tiles
+    /// Root of every non-empty workspace uses accordion at startup.
+    case accordion
+    /// AeroSpace's heuristic: tiles if the root has <= 3 children, else accordion.
+    case smart
 }

--- a/Sources/AppBundle/config/parseConfig.swift
+++ b/Sources/AppBundle/config/parseConfig.swift
@@ -159,7 +159,7 @@ private let configParser: [String: any ParserProtocol<Config>] = [
     "on-window-detected": Parser(\.onWindowDetected, parseOnWindowDetectedArray),
 
     // Deprecated
-    "non-empty-workspaces-root-containers-layout-on-startup": Parser(\._nonEmptyWorkspacesRootContainersLayoutOnStartup, parseStartupRootContainerLayout),
+    "non-empty-workspaces-root-containers-layout-on-startup": Parser(\.nonEmptyWorkspacesRootContainersLayoutOnStartup, parseStartupRootContainerLayout),
     "indent-for-nested-containers-with-the-same-orientation": Parser(\._indentForNestedContainersWithTheSameOrientation, parseIndentForNestedContainersWithTheSameOrientation),
 ]
 
@@ -379,10 +379,11 @@ func parseTable<T: ConvenienceMutable>(
     }
 }
 
-private func parseStartupRootContainerLayout(_ raw: OrderedJson, _ backtrace: ConfigBacktrace) -> ResOrConfigParseDiagnostic<Void> {
-    parseString(raw, backtrace)
-        .filter(.init(backtrace, "'non-empty-workspaces-root-containers-layout-on-startup' is deprecated. Please drop it from your config")) { raw in raw == "smart" }
-        .map { _ in () }
+private func parseStartupRootContainerLayout(_ raw: OrderedJson, _ backtrace: ConfigBacktrace) -> ResOrConfigParseDiagnostic<NonEmptyWorkspacesRootContainersLayoutOnStartup> {
+    parseString(raw, backtrace).flatMap {
+        NonEmptyWorkspacesRootContainersLayoutOnStartup(rawValue: $0)
+            .toResult(.init(backtrace, "Can't parse 'non-empty-workspaces-root-containers-layout-on-startup' value '\($0)'. Possible values: tiles|accordion|smart"))
+    }
 }
 
 private func parseLayout(_ raw: OrderedJson, _ backtrace: ConfigBacktrace) -> ResOrConfigParseDiagnostic<Layout> {

--- a/Sources/AppBundle/initAppBundle.swift
+++ b/Sources/AppBundle/initAppBundle.swift
@@ -50,9 +50,10 @@ import Foundation
 private func smartLayoutAtStartup() {
     let workspace = focus.workspace
     let root = workspace.rootTilingContainer
-    switch root.children.count <= 3 {
-        case true: root.layout = .tiles
-        case false: root.layout = .accordion
+    switch config.nonEmptyWorkspacesRootContainersLayoutOnStartup {
+        case .tiles: root.layout = .tiles
+        case .accordion: root.layout = .accordion
+        case .smart: root.layout = root.children.count <= 3 ? .tiles : .accordion
     }
 }
 

--- a/Sources/AppBundleTests/config/ConfigTest.swift
+++ b/Sources/AppBundleTests/config/ConfigTest.swift
@@ -29,6 +29,26 @@ final class ConfigTest: XCTestCase {
         assertEquals(result.warnings, [])
     }
 
+    func testParseNonEmptyWorkspacesRootContainersLayoutOnStartup() {
+        // default is 'smart' (historical hardcoded behavior)
+        assertEquals(defaultConfig.nonEmptyWorkspacesRootContainersLayoutOnStartup, .smart)
+
+        let tiles = parseConfig("non-empty-workspaces-root-containers-layout-on-startup = 'tiles'")
+        assertEquals(tiles.errors, [])
+        assertEquals(tiles.config.nonEmptyWorkspacesRootContainersLayoutOnStartup, .tiles)
+
+        let accordion = parseConfig("non-empty-workspaces-root-containers-layout-on-startup = 'accordion'")
+        assertEquals(accordion.errors, [])
+        assertEquals(accordion.config.nonEmptyWorkspacesRootContainersLayoutOnStartup, .accordion)
+
+        let smart = parseConfig("non-empty-workspaces-root-containers-layout-on-startup = 'smart'")
+        assertEquals(smart.errors, [])
+        assertEquals(smart.config.nonEmptyWorkspacesRootContainersLayoutOnStartup, .smart)
+
+        let invalid = parseConfig("non-empty-workspaces-root-containers-layout-on-startup = 'nonsense'")
+        assertTrue(!invalid.errors.isEmpty)
+    }
+
     func testConfigVersionOutOfBounds() {
         let result = parseConfig(
             """
@@ -637,25 +657,6 @@ final class ConfigTest: XCTestCase {
         )
     }
 
-    func testDeprecatedNonEmptyWorkspacesRootContainersLayoutOnStartup() {
-        // The 'smart' value used to be accepted and is silently dropped now
-        let smart = parseConfig(
-            """
-            non-empty-workspaces-root-containers-layout-on-startup = 'smart'
-            """,
-        )
-        assertEquals(smart.errors, [])
-
-        let bad = parseConfig(
-            """
-            non-empty-workspaces-root-containers-layout-on-startup = 'tiles'
-            """,
-        ).strErrors
-        assertEquals(
-            bad,
-            ["[ERROR] non-empty-workspaces-root-containers-layout-on-startup: \'non-empty-workspaces-root-containers-layout-on-startup\' is deprecated. Please drop it from your config"],
-        )
-    }
 
     func testOutdatedConfigVersionWarning() {
         let result = parseConfig(

--- a/docs/config-examples/default-config.toml
+++ b/docs/config-examples/default-config.toml
@@ -34,6 +34,13 @@ default-root-container-layout = 'tiles'
 #               tall monitor (anything higher than wide) gets vertical orientation
 default-root-container-orientation = 'auto'
 
+# Layout that non-empty workspaces' root containers get on AeroSpace startup.
+# Possible values: tiles|accordion|smart
+#   'smart'     tiles if the root has <= 3 windows, otherwise accordion (default)
+#   'tiles'     always tile at startup (i3/sway-like)
+#   'accordion' always accordion at startup
+non-empty-workspaces-root-containers-layout-on-startup = 'smart'
+
 # Mouse follows focus when focused monitor changes
 # Drop it from your config, if you don't like this behavior
 # See https://nikitabobko.github.io/AeroSpace/guide#on-focus-changed-callbacks


### PR DESCRIPTION
### Problem

`non-empty-workspaces-root-containers-layout-on-startup` currently exists only as a deprecated no-op — the parser accepts `'smart'` (and warns to drop the key otherwise), the value is stored as `Void` and discarded, and `smartLayoutAtStartup()` always applies the hardcoded heuristic:

```swift
switch root.children.count <= 3 {
    case true: root.layout = .tiles
    case false: root.layout = .accordion
}
```

That heuristic silently overrides `default-root-container-layout = 'tiles'` at startup for any workspace with more than 3 windows — it comes up as accordion instead. For users coming from i3/sway who expect workspaces to always tile unless they explicitly stack, this is surprising and there's currently no way to turn it off.

### Change

Restore the key as a real selector (default `smart` → **no behavior change** for existing configs):

| value | behavior |
|-------|----------|
| `smart` | tiles if the root has ≤ 3 windows, else accordion (the current heuristic; default) |
| `tiles` | always tile at startup (i3/sway-like) |
| `accordion` | always accordion at startup |

- `Config`: `Void` placeholder → typed `NonEmptyWorkspacesRootContainersLayoutOnStartup` enum, default `.smart`
- `parseConfig`: parser returns the enum (`tiles|accordion|smart`) instead of the deprecation no-op
- `smartLayoutAtStartup()`: honors the config value
- Updated `default-config.toml`; replaced the now-obsolete deprecation test with parse tests for all three values + default + invalid

`swift build`, `swift test --filter ConfigTest` (40 pass), and `./lint.sh` are green.