### PR TITLE
default-config: Bind swap to h/j/k/l in service mode

### DIFF
--- a/docs/config-examples/default-config.toml
+++ b/docs/config-examples/default-config.toml
@@ -218,3 +218,12 @@ gaps.outer.right =      0
     alt-shift-j = ['join-with down', 'mode main']
     alt-shift-k = ['join-with up', 'mode main']
     alt-shift-l = ['join-with right', 'mode main']
+
+    # Swap with the nearest window in the given direction.
+    # Unlike 'move', 'swap' exchanges the two windows without restructuring
+    # the tree. No 'mode main' tail, so swaps can be chained in service mode.
+    # See: https://nikitabobko.github.io/AeroSpace/commands#swap
+    h = 'swap left'
+    j = 'swap down'
+    k = 'swap up'
+    l = 'swap right'


### PR DESCRIPTION
## Changes

Adds four bindings to the default config's `service` mode:

```toml
h = 'swap left'
j = 'swap down'
k = 'swap up'
l = 'swap right'
```

Rationale is in the commit message: `swap` is under-discoverable (users only learn `move` and its tree-restructuring surprises); service mode already hosts `join-with`, so it becomes the complete restructure hub; bare `h/j/k/l` collide with no existing default binding; no `mode main` tail so swaps chain, `esc` exits as always.

## Testing

- `./test.sh` — ✅ All tests have passed successfully (requires bash 5, installed via Homebrew to run it; the repo's own `script/setup.sh` gate)
- Includes `testParseDefaultConfig` (default config parses with 0 errors / 0 warnings), `lint.sh`, `generate.sh` + `check-uncommitted-files.sh` (TOML-only change; no generated-file drift)

## PR checklist

- [x] Explain your changes in the relevant commit messages rather than in the PR description. The PR description must not contain more information than the commit messages (except for images and other media).
- [x] Each commit must explain what/why/how and motivation in its description. https://cbea.ms/git-commit/
- [x] Don't forget to link the appropriate issues/discussions in commit messages (if applicable). (searched issues/PRs/discussions; no prior discussion found)
- [x] Each commit must be an atomic change (a PR may contain several commits). Don't introduce new functional changes together with refactorings in the same commit.
- [x] `./test.sh` exits with zero exit code (suite passes).
- [x] Avoid merge commits, always rebase and force push.
