### PR TITLE
feat: support moving floating windows

### DIFF
--- a/Sources/AppBundle/command/impl/MoveCommand.swift
+++ b/Sources/AppBundle/command/impl/MoveCommand.swift
@@ -35,8 +35,24 @@ struct MoveCommand: Command {
                 } else {
                     return moveOut(tilingWindow: currentWindow, direction: direction, io, args, env)
                 }
-            case .floatingWindowsContainer: // floating window
-                return .fail(io.err("moving floating windows isn't yet supported")) // todo
+            case .floatingWindowsContainer:
+                guard let rect = try? await currentWindow.getAxRect(.cancellable) else {
+                    return .fail(io.err("Can't get the floating window position"))
+                }
+                let pixels: CGFloat
+                if let floatingPixels = args.floatingPixels {
+                    pixels = CGFloat(floatingPixels)
+                } else if let monitor = currentWindow.nodeMonitor {
+                    pixels = monitor.rect.getDimension(direction.orientation) * 0.1
+                } else {
+                    return .fail(io.err("Can't find the monitor for the floating window"))
+                }
+                let signedPixels = direction.isPositive ? pixels : -pixels
+                let newTopLeft = direction.orientation == .h
+                    ? CGPoint(x: rect.topLeftX + signedPixels, y: rect.topLeftY)
+                    : CGPoint(x: rect.topLeftX, y: rect.topLeftY + signedPixels)
+                currentWindow.setAxFrame(newTopLeft, nil)
+                return .succ
             case .macosMinimizedWindowsContainer, .macosFullscreenWindowsContainer, .macosHiddenAppsWindowsContainer:
                 return .fail(io.err(moveOutMacosUnconventionalWindow))
             case .macosPopupWindowsContainer:

--- a/Sources/AppBundleTests/command/MoveCommandTest.swift
+++ b/Sources/AppBundleTests/command/MoveCommandTest.swift
@@ -9,6 +9,47 @@ final class MoveCommandTest: XCTestCase {
     func testParse() {
         assertNil(parseCommand("move --fail-if-fullscreen left").errorOrNil)
         assertNil(parseCommand("move --fail-if-macos-native-fullscreen --window-id 1 right").errorOrNil)
+        assertNil(parseCommand("move --floating-pixels 25 down").errorOrNil)
+        assertNotNil(parseCommand("move --floating-pixels -1 down").errorOrNil)
+        assertNotNil(parseCommand("move --floating-pixels nope down").errorOrNil)
+    }
+
+    func testMoveFloatingWindowByPixels() async throws {
+        let window = TestWindow.new(
+            id: 1,
+            parent: Workspace.get(byName: name).floatingWindowsContainer,
+            rect: Rect(topLeftX: 100, topLeftY: 200, width: 300, height: 400),
+        )
+        assertTrue(window.focusWindow())
+
+        for command in ["left", "up", "right", "down"] {
+            let result = await parseCommand("move --floating-pixels 25 \(command)").cmdOrDie.run(.defaultEnv, .emptyStdin)
+            assertEquals(result.exitCode.rawValue, 0)
+        }
+
+        let rect = try await window.getAxRect(.cancellable).orDie()
+        assertEquals(rect.topLeftX, 100)
+        assertEquals(rect.topLeftY, 200)
+        assertEquals(rect.width, 300)
+        assertEquals(rect.height, 400)
+    }
+
+    func testMoveFloatingWindowDefaultsToTenPercentOfMonitor() async throws {
+        let window = TestWindow.new(
+            id: 1,
+            parent: Workspace.get(byName: name).floatingWindowsContainer,
+            rect: Rect(topLeftX: 100, topLeftY: 200, width: 300, height: 400),
+        )
+        assertTrue(window.focusWindow())
+
+        let rightResult = await parseCommand("move right").cmdOrDie.run(.defaultEnv, .emptyStdin)
+        let downResult = await parseCommand("move down").cmdOrDie.run(.defaultEnv, .emptyStdin)
+
+        assertEquals(rightResult.exitCode.rawValue, 0)
+        assertEquals(downResult.exitCode.rawValue, 0)
+        let rect = try await window.getAxRect(.cancellable).orDie()
+        assertEquals(rect.topLeftX, 292)
+        assertEquals(rect.topLeftY, 308)
     }
 
     func testFailIfFullscreen() async {

--- a/Sources/AppBundleTests/tree/TestWindow.swift
+++ b/Sources/AppBundleTests/tree/TestWindow.swift
@@ -41,5 +41,18 @@ final class TestWindow: Window, CustomStringConvertible {
         _rect.map { CGSize(width: $0.width, height: $0.height) }
     }
 
+    override func setAxFrame(_ topLeft: CGPoint?, _ size: CGSize?) {
+        guard var rect = _rect else { return }
+        if let topLeft {
+            rect.topLeftX = topLeft.x
+            rect.topLeftY = topLeft.y
+        }
+        if let size {
+            rect.width = size.width
+            rect.height = size.height
+        }
+        _rect = rect
+    }
+
     override func isMacosFullscreen(_ cm: CancellationMode) async throws -> Bool { isMacosFullscreenForTest }
 }

--- a/Sources/Common/cmdArgs/impl/MoveCmdArgs.swift
+++ b/Sources/Common/cmdArgs/impl/MoveCmdArgs.swift
@@ -6,6 +6,7 @@ public struct MoveCmdArgs: CmdArgs {
         help: move_help_generated,
         flags: [
             "--window-id": windowIdSubArgParser(),
+            "--floating-pixels": singleValueSubArgParser(\.floatingPixels, "<pixels>", parseUInt32),
             "--boundaries": ArgParser(\.rawBoundaries, upcastArgParserFun(parseBoundaries)),
             "--boundaries-action": ArgParser(\.rawBoundariesAction, upcastArgParserFun(parseBoundariesAction)),
             "--fail-if-fullscreen": trueBoolFlag(\.failIfFullscreen),
@@ -15,6 +16,7 @@ public struct MoveCmdArgs: CmdArgs {
     )
 
     public var direction: Lateinit<CardinalDirection> = .uninitialized
+    public var floatingPixels: UInt32? = nil
     public var rawBoundaries: Boundaries? = nil
     public var rawBoundariesAction: WhenBoundariesCrossed? = nil
     public var failIfFullscreen: Bool = false

--- a/Sources/Common/cmdHelpGenerated.swift
+++ b/Sources/Common/cmdHelpGenerated.swift
@@ -131,7 +131,8 @@ let move_workspace_to_monitor_help_generated = """
 let move_help_generated = """
     USAGE: move [-h|--help] [--window-id <window-id>] [--boundaries <boundary>]
                 [--boundaries-action <boundary-action>] [--fail-if-fullscreen]
-                [--fail-if-macos-native-fullscreen] (left|down|up|right)
+                [--fail-if-macos-native-fullscreen] [--floating-pixels <pixels>]
+                (left|down|up|right)
     """
 let reload_config_help_generated = """
     USAGE: reload-config [-h|--help] [--no-gui] [--dry-run] [--warnings-as-errors]

--- a/docs/aerospace-move.adoc
+++ b/docs/aerospace-move.adoc
@@ -11,7 +11,8 @@ include::util/man-attributes.adoc[]
 // tag::synopsis[]
 aerospace move [-h|--help] [--window-id <window-id>] [--boundaries <boundary>]
                [--boundaries-action <boundary-action>] [--fail-if-fullscreen]
-               [--fail-if-macos-native-fullscreen] (left|down|up|right)
+               [--fail-if-macos-native-fullscreen] [--floating-pixels <pixels>]
+               (left|down|up|right)
 
 // end::synopsis[]
 
@@ -30,6 +31,10 @@ include::./util/conditional-options-header.adoc[]
 
 --window-id <window-id>::
 include::./util/window-id-flag-desc.adoc[]
+
+--floating-pixels <pixels>::
+If the window is floating, move it in the specified direction by `<pixels>`. +
+If omitted, the window moves by 10% of the monitor width or height, depending on the direction.
 
 --boundaries <boundary>::
 Defines move boundaries. +

--- a/grammar/commands-bnf-grammar.txt
+++ b/grammar/commands-bnf-grammar.txt
@@ -129,7 +129,7 @@ aerospace -h;
 <list_workspaces1_flag> ::= --visible [no] | --empty [no] | --format <output_format> | --format <output_format> | --count | --json;
 
 <move_command_flag> ::= --window-id <window_id> | --boundaries <boundary> | --boundaries-action <move_boundaries_action>
-    | --fail-if-fullscreen | --fail-if-macos-native-fullscreen;
+    | --fail-if-fullscreen | --fail-if-macos-native-fullscreen | --floating-pixels <number>;
 <move_boundaries_action> ::= stop|fail|create-implicit-container;
 
 <move_node_to_monitor1_flag> ::= --window-id <window_id>|--focus-follows-window|--fail-if-noop|--wrap-around;


### PR DESCRIPTION
Closes #1417

## Summary

- add `--floating-pixels <pixels>` to `move`
- move floating windows along the requested axis without resizing them
- default to 10% of the current monitor dimension when the flag is omitted
- update command help, manual docs, and shell-completion grammar
- add parser and floating-window behavior coverage

## Validation

- `swift build --target Common`
- Swift frontend parsing for the changed AppBundle and test files
- `git diff --check`

I also attempted `swift test --filter MoveCommandTest`. The selected Command Line Tools installation on this machine lacks the `SwiftUIMacros` plugin, so compilation stops in the existing `SecureInputView.swift` and `VolumeView.swift` before reaching the tests.